### PR TITLE
Add missing return in TopN recommender

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNItemRecommender.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNItemRecommender.java
@@ -100,7 +100,7 @@ public class TopNItemRecommender extends AbstractItemRecommender {
      */
     protected List<ScoredId> recommend(int n, SparseVector scores) {
         if (scores.isEmpty()) {
-            Collections.emptyList();
+            return Collections.emptyList();
         }
 
         if (n < 0) {

--- a/src/site/apt/releases/lenskit-2.0.3.apt.vm
+++ b/src/site/apt/releases/lenskit-2.0.3.apt.vm
@@ -4,3 +4,5 @@
   This is the third bugfix release in the 2.0 series.
 
   #pmIntro("2.0.3", 21)
+
+  * Fix <<<TopNItemRecommender>>> bug when no scores are available (#issue(373)).


### PR DESCRIPTION
This addresses #373 by adding the missing `return` to the `TopNItemRecommender`.
