### PR TITLE
Fix a bug in `RemovableLongSortedArraySet#retainAll()`

### DIFF
--- a/lenskit-data-structures/src/main/java/org/grouplens/lenskit/collections/RemovableLongSortedArraySet.java
+++ b/lenskit-data-structures/src/main/java/org/grouplens/lenskit/collections/RemovableLongSortedArraySet.java
@@ -105,8 +105,8 @@ class RemovableLongSortedArraySet extends LongSortedArraySet {
         boolean removed = false;
         IntIterator posIter = keys.activeIndexIterator(true);
         int pos = posIter.hasNext() ? posIter.nextInt() : -1;
-        while (iter.hasNext() && pos >= 0) {
-            long rmk = iter.nextLong();
+        while (pos >= 0) {
+            long rmk = iter.hasNext() ? iter.nextLong() : Long.MAX_VALUE;
             // advance position pointer looking for this item
             while (pos >= 0 && keys.getKey(pos) < rmk) {
                 // this item is < than rmk, delete it

--- a/lenskit-data-structures/src/test/java/org/grouplens/lenskit/collections/RemovableLongSortedArraySetTest.java
+++ b/lenskit-data-structures/src/test/java/org/grouplens/lenskit/collections/RemovableLongSortedArraySetTest.java
@@ -74,12 +74,14 @@ public class RemovableLongSortedArraySetTest {
 
     @Test
     public void testRetainAll() {
-        LongKeyDomain lks = LongKeyDomain.create(20, 25, 30, 42, 62);
+        LongKeyDomain lks = LongKeyDomain.create(20, 25, 30, 42, 62, 99);
         LongSet ls = lks.modifiableActiveSetView();
         List<Long> rm = Longs.asList(20, 25, 62, 30, 98, 1);
         assertThat(ls.retainAll(rm), equalTo(true));
         assertThat(ls, contains(20L, 25L, 30L, 62L));
         assertThat(Lists.newArrayList(lks.activeIndexIterator(false)),
                    contains(0, 1, 2, 4));
+        assertThat(ls.retainAll(Lists.newArrayList()), equalTo(true));
+        assertThat(ls.isEmpty(), equalTo(true));
     }
 }


### PR DESCRIPTION
Please see the modified test for cases that fail under the original code.
