### PR TITLE
Fix aggregation with no predictions

### DIFF
--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/AbstractTestUserMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/AbstractTestUserMetric.java
@@ -20,7 +20,10 @@
  */
 package org.grouplens.lenskit.eval.metrics;
 
+import com.google.common.base.Preconditions;
 import org.grouplens.lenskit.eval.traintest.TrainTestEvalTask;
+
+import java.util.Arrays;
 
 /**
  * Abstract base implementation of {@link TestUserMetric}.
@@ -31,4 +34,25 @@ import org.grouplens.lenskit.eval.traintest.TrainTestEvalTask;
 public abstract class AbstractTestUserMetric
         extends AbstractMetric<TrainTestEvalTask>
         implements TestUserMetric {
+    /**
+     * Make a user result row. This expands it to the length of the user columns, inserting
+     * {@code null}s as needed.
+     * @return The result row, the same length as {@link #getUserColumnLabels()}.
+     */
+    protected Object[] userRow(Object... results) {
+        int len = getUserColumnLabels().size();
+        Preconditions.checkArgument(results.length <= len, "too many results");;
+        return Arrays.copyOf(results, len);
+    }
+
+    /**
+     * Make a final aggregate result row. This expands it to the length of the columns, inserting
+     * {@code null}s as needed.
+     * @return The result row, the same length as {@link #getColumnLabels()}.
+     */
+    protected Object[] finalRow(Object... results) {
+        int len = getColumnLabels().size();
+        Preconditions.checkArgument(results.length <= len, "too many results");;
+        return Arrays.copyOf(results, len);
+    }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/CoveragePredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/CoveragePredictMetric.java
@@ -86,9 +86,8 @@ public class CoveragePredictMetric extends AbstractTestUserMetric {
             npreds += n;
             ngood += good;
             nusers += 1;
-            return new Object[]{n, good,
-                                n > 0 ? (((double) good) / n) : null
-            };
+            return userRow(n, good,
+                           n > 0 ? (((double) good) / n) : null);
         }
 
         @Nonnull
@@ -100,7 +99,7 @@ public class CoveragePredictMetric extends AbstractTestUserMetric {
             }
             logger.info("Coverage: {}", coverage);
 
-            return new Object[]{nusers, npreds, ngood, coverage};
+            return finalRow(nusers, npreds, ngood, coverage);
         }
 
     }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/EntropyPredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/EntropyPredictMetric.java
@@ -81,11 +81,11 @@ public class EntropyPredictMetric extends AbstractTestUserMetric {
 
         @Nonnull
         @Override
-        public String[] evaluate(TestUser user) {
+        public Object[] evaluate(TestUser user) {
             SparseVector ratings = user.getTestRatings();
             SparseVector predictions = user.getPredictions();
             if (predictions == null) {
-                return new String[3];
+                return userRow();
             }
 
             // TODO Re-use accumulators
@@ -104,27 +104,28 @@ public class EntropyPredictMetric extends AbstractTestUserMetric {
                 ratingEntropySum += ratingEntropy;
                 predictionEntropySum += predEntropy;
                 nusers += 1;
-                return new String[] {
-                        Double.toString(ratingEntropy),
-                        Double.toString(predEntropy),
-                        Double.toString(info)
-                };
+                return userRow(ratingEntropy,
+                               predEntropy,
+                               info);
             } else {
-                return new String[3];
+                return userRow();
             }
         }
 
         @Nonnull
         @Override
-        public String[] finalResults() {
+        public Object[] finalResults() {
+            if (nusers <= 0) {
+                return finalRow();
+            }
+
             logger.info("H(rating|user): {}", ratingEntropySum / nusers);
             logger.info("H(prediction|user): {}", predictionEntropySum / nusers);
             logger.info("I(rating;prediction): {}", informationSum / nusers);
-            return new String[]{
-                    Double.toString(ratingEntropySum / nusers),
-                    Double.toString(predictionEntropySum / nusers),
-                    Double.toString(informationSum / nusers)
-            };
+
+            return finalRow(ratingEntropySum / nusers,
+                            predictionEntropySum / nusers,
+                            informationSum / nusers);
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/HLUtilityPredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/HLUtilityPredictMetric.java
@@ -86,7 +86,7 @@ public class HLUtilityPredictMetric extends AbstractTestUserMetric {
         public Object[] evaluate(TestUser user) {
             SparseVector predictions = user.getPredictions();
             if (predictions == null) {
-                return new Object[1];
+                return userRow();
             }
             return evaluatePredictions(user.getTestRatings(), predictions);
         }
@@ -100,15 +100,19 @@ public class HLUtilityPredictMetric extends AbstractTestUserMetric {
             double u = actualUtility / idealUtility;
             total += u;
             nusers++;
-            return new Object[]{u};
+            return userRow(u);
         }
 
         @Nonnull
         @Override
         public Object[] finalResults() {
-            double v = total / nusers;
-            logger.info("HLU: {}", v);
-            return new Object[]{v};
+            if (nusers > 0) {
+                double v = total / nusers;
+                logger.info("HLU: {}", v);
+                return finalRow(v);
+            } else {
+                return finalRow();
+            }
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/MAEPredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/MAEPredictMetric.java
@@ -79,7 +79,7 @@ public class MAEPredictMetric extends AbstractTestUserMetric {
             SparseVector ratings = user.getTestRatings();
             SparseVector predictions = user.getPredictions();
             if (predictions == null) {
-                return new Object[USER_COLUMNS.size()];
+                return userRow();
             }
             double err = 0;
             int n = 0;
@@ -98,19 +98,23 @@ public class MAEPredictMetric extends AbstractTestUserMetric {
                 double errRate = err / n;
                 totalUserError += errRate;
                 nusers += 1;
-                return new Object[]{errRate};
+                return userRow(errRate);
             } else {
-                return new Object[1];
+                return userRow();
             }
         }
 
         @Nonnull
         @Override
         public Object[] finalResults() {
-            double v = totalError / nratings;
-            double uv = totalUserError / nusers;
-            logger.info("MAE: {}", v);
-            return new Object[]{v, uv};
+            if (nratings > 0) {
+                double v = totalError / nratings;
+                double uv = totalUserError / nusers;
+                logger.info("MAE: {}", v);
+                return finalRow(v, uv);
+            } else {
+                return finalRow();
+            }
         }
 
     }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/NDCGPredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/NDCGPredictMetric.java
@@ -104,7 +104,7 @@ public class NDCGPredictMetric extends AbstractTestUserMetric {
         public Object[] evaluate(TestUser user) {
             SparseVector predictions = user.getPredictions();
             if (predictions == null) {
-                return new Object[COLUMNS.size()];
+                return userRow();
             }
             return evaluatePredictions(user.getTestRatings(), predictions);
         }
@@ -117,15 +117,19 @@ public class NDCGPredictMetric extends AbstractTestUserMetric {
             double score = gain / idealGain;
             total += score;
             nusers += 1;
-            return new Object[]{score};
+            return userRow(score);
         }
 
         @Nonnull
         @Override
         public Object[] finalResults() {
-            double v = total / nusers;
-            logger.info("nDCG: {}", v);
-            return new Object[]{v};
+            if (nusers > 0) {
+                double v = total / nusers;
+                logger.info("nDCG: {}", v);
+                return finalRow(v);
+            } else {
+                return finalRow();
+            }
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/RMSEPredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/predict/RMSEPredictMetric.java
@@ -73,7 +73,7 @@ public class RMSEPredictMetric extends AbstractTestUserMetric {
             SparseVector ratings = user.getTestRatings();
             SparseVector predictions = user.getPredictions();
             if (predictions == null) {
-                return new Object[USER_COLUMNS.size()];
+                return userRow();
             }
             double usse = 0;
             int n = 0;
@@ -92,18 +92,22 @@ public class RMSEPredictMetric extends AbstractTestUserMetric {
                 double rmse = sqrt(usse / n);
                 totalRMSE += rmse;
                 nusers++;
-                return new Object[]{rmse};
+                return userRow(rmse);
             } else {
-                return new Object[1];
+                return userRow();
             }
         }
 
         @Nonnull
         @Override
         public Object[] finalResults() {
-            double v = sqrt(sse / nratings);
-            logger.info("RMSE: {}", v);
-            return new Object[]{v, totalRMSE / nusers};
+            if (nratings > 0) {
+                double v = sqrt(sse / nratings);
+                logger.info("RMSE: {}", v);
+                return finalRow(v, totalRMSE / nusers);
+            } else {
+                return finalRow();
+            }
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/topn/NDCGTopNMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/topn/NDCGTopNMetric.java
@@ -113,7 +113,7 @@ public class NDCGTopNMetric extends AbstractTestUserMetric {
             List<ScoredId> recommendations;
             recommendations = user.getRecommendations(listSize, candidates, exclude);
             if (recommendations == null) {
-                return new Object[1];
+                return userRow();
             }
             return evaluateRecommendations(user.getTestRatings(), recommendations);
         }
@@ -134,15 +134,19 @@ public class NDCGTopNMetric extends AbstractTestUserMetric {
             double score = gain / idealGain;
             total += score;
             nusers += 1;
-            return new Object[]{score};
+            return userRow(score);
         }
 
         @Nonnull
         @Override
         public Object[] finalResults() {
-            double v = total / nusers;
-            logger.info("Top-N nDCG: {}", v);
-            return new Object[]{v};
+            if (nusers > 0) {
+                double v = total / nusers;
+                logger.info("Top-N nDCG: {}", v);
+                return finalRow(v);
+            } else {
+                return finalRow();
+            }
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/topn/TopNLengthMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/topn/TopNLengthMetric.java
@@ -78,14 +78,17 @@ public class TopNLengthMetric extends AbstractTestUserMetric {
             int n = recs.size();
             total += n;
             nusers += 1;
-            return new Object[]{n};
+            return userRow(n);
         }
 
         @Nonnull
         @Override
         public Object[] finalResults() {
-            double v = total / nusers;
-            return new Object[]{v};
+            if (nusers > 0) {
+                return finalRow(total / nusers);
+            } else {
+                return finalRow();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix aggregation with no predictions (#401).
- Add userRow() and finalRow() convenience methods to help build user/final result rows more easily (including empty rows)
- Return null/NA when no users are scored in a metric
