### PR TITLE
Make Pearson correlation use mean of common items

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/vectors/similarity/PearsonCorrelation.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/vectors/similarity/PearsonCorrelation.java
@@ -74,8 +74,23 @@ public class PearsonCorrelation implements VectorSimilarity, Serializable {
          * correlation only considers items shared by both vectors; other items
          * are discarded for the purpose of similarity computation.
          */
-        final double mu1 = vec1.mean();
-        final double mu2 = vec2.mean();
+
+        // first compute means of common items
+        double sum1 = 0;
+        double sum2 = 0;
+        int n = 0;
+        for (Pair<VectorEntry,VectorEntry> pair: Vectors.fastIntersect(vec1, vec2)) {
+            sum1 += pair.getLeft().getValue();
+            sum2 += pair.getRight().getValue();
+            n += 1;
+        }
+
+        if (n == 0) {
+            return 0;
+        }
+
+        final double mu1 = sum1 / n;
+        final double mu2 = sum2 / n;
 
         double var1 = 0;
         double var2 = 0;

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/vectors/similarity/TestPearsonCorrelation.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/vectors/similarity/TestPearsonCorrelation.java
@@ -76,6 +76,17 @@ public class TestPearsonCorrelation {
         double val2[] = {2, 2.5, 1.7};
         SparseVector v1 = MutableSparseVector.wrap(k1, val1).freeze();
         SparseVector v2 = MutableSparseVector.wrap(k2, val2).freeze();
-        assertThat(sim.similarity(v1, v2), closeTo(0.806404996, EPSILON));
+        assertThat(sim.similarity(v1, v2), closeTo(1, EPSILON));
+    }
+
+    @Test
+    public void testSimilarity2() {
+        long k1[] = {1, 5, 7, 8};
+        double val1[] = {1.5, 2.5, 2, 3.5};
+        long k2[] = {1, 5, 7, 9};
+        double val2[] = {2, 2.5, 1.7, 0.8};
+        SparseVector v1 = MutableSparseVector.wrap(k1, val1).freeze();
+        SparseVector v2 = MutableSparseVector.wrap(k2, val2).freeze();
+        assertThat(sim.similarity(v1, v2), closeTo(0.6185896, EPSILON));
     }
 }


### PR DESCRIPTION
Pearson correlation used to offset from the mean of all items, not just common items (#404). This fixes that.
