### PR TITLE
#N 376 SimpleEvaluator should set the project for externally

### DIFF
--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/SimpleEvaluator.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/SimpleEvaluator.java
@@ -99,6 +99,7 @@ public class SimpleEvaluator implements Callable<Table> {
      * @return Itself to allow for  method chaining.
      */
     public SimpleEvaluator addDataset(CrossfoldTask cross){
+        cross.setProject(project);
         try {
             for (TTDataSet data: cross.perform()) {
                 result.addDataset(data);
@@ -125,7 +126,6 @@ public class SimpleEvaluator implements Callable<Table> {
                 .setSource(source)
                 .setPartitions(partitions)
                 .setHoldoutFraction(holdout);
-        cross.setProject(project);
         addDataset(cross);
         return this;
     }


### PR DESCRIPTION
#376 SimpleEvaluator should set the project for externally - constructed crossfold tasks.

As mentioned in the ticket the project is set in addDataset(CrossfoldTask cross) now. 
