### PR TITLE
Use custom object input stream to deserialize

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/CustomClassLoaderObjectInputStream.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/CustomClassLoaderObjectInputStream.java
@@ -1,0 +1,50 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2013 Regents of the University of Minnesota and contributors
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+/**
+ * Object input stream that uses a custom class loader.
+ *
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+class CustomClassLoaderObjectInputStream extends ObjectInputStream {
+    private final ClassLoader classLoader;
+
+    CustomClassLoaderObjectInputStream(InputStream in, ClassLoader loader) throws IOException {
+        super(in);
+        classLoader = loader;
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        if (classLoader == null) {
+            return super.resolveClass(desc);
+        } else {
+            String name = desc.getName();
+            return classLoader.loadClass(name);
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommenderEngine.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommenderEngine.java
@@ -129,7 +129,7 @@ public final class LenskitRecommenderEngine implements RecommenderEngine {
     public static LenskitRecommenderEngine load(InputStream input, ClassLoader loader) throws IOException, RecommenderConfigurationException {
         logger.debug("using classloader {}", loader);
         InjectSPI spi = new ReflectionInjectSPI();
-        ObjectInputStream in = new ObjectInputStream(input);
+        ObjectInputStream in = new CustomClassLoaderObjectInputStream(input, loader);
         try {
             Thread current = Thread.currentThread();
             // save the old class loader


### PR DESCRIPTION
Use a custom object input stream to use the user-specified class loader for recommender engine deserialization. Attempts to fix more bugs using LensKit in Play.
