### PR TITLE
minor fix to evaluators, make perform blocks behave like other tasks with respect to return values.

### DIFF
--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/script/GroovyActionTask.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/script/GroovyActionTask.java
@@ -23,23 +23,25 @@ package org.grouplens.lenskit.eval.script;
 import groovy.lang.Closure;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
+import org.grouplens.lenskit.eval.AbstractTask;
+import org.grouplens.lenskit.eval.TaskExecutionException;
 
 /**
- * A basic Ant task that executes a Groovy action. These tasks are added by {@link
+ * A basic Eval task that executes a Groovy action. These tasks are added by {@link
  * org.grouplens.lenskit.eval.script.TargetDelegate#perform(Closure)}.
  *
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @since 1.2
  */
-public class GroovyActionTask extends Task {
-    private Closure<?> closure;
+public class GroovyActionTask<K> extends AbstractTask<K> {
+    private Closure<K> closure;
 
-    public GroovyActionTask(Closure<?> cl) {
+    public GroovyActionTask(Closure<K> cl) {
         closure = cl;
     }
 
     @Override
-    public void execute() throws BuildException {
-        closure.call();
+    protected K perform() throws TaskExecutionException, InterruptedException {
+        return closure.call();
     }
 }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/script/TargetDelegate.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/script/TargetDelegate.java
@@ -25,6 +25,7 @@ import groovy.lang.DelegatesTo;
 import groovy.util.AntBuilder;
 import org.apache.tools.ant.Target;
 import org.apache.tools.ant.Task;
+import org.grouplens.lenskit.eval.EvalAntTask;
 
 /**
  * Delegate to build a target.
@@ -53,8 +54,9 @@ public class TargetDelegate {
 
     }
 
-    public void perform(Closure<?> cl) {
-        GroovyActionTask task = new GroovyActionTask(cl);
+    public <K> void perform(Closure<K> cl) {
+        GroovyActionTask<K> evalTask = new GroovyActionTask(cl);
+        EvalAntTask task = new EvalAntTask(evalTask);
         task.setProject(target.getProject());
         target.addTask(task);
     }


### PR DESCRIPTION
changed GroovyActionTask and TargetDelegate.perform so that a perform block in a target in a lenskit evaluation will behave like other tasks, returning a value that can be the value of the target if the perfom block is the last task in the target
