### PR TITLE
Exclude all interacted-with items, not just rated, by default.

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNItemRecommender.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNItemRecommender.java
@@ -23,7 +23,6 @@ package org.grouplens.lenskit.basic;
 
 import com.google.common.collect.Lists;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import org.apache.commons.lang3.tuple.Pair;
@@ -34,7 +33,6 @@ import org.grouplens.lenskit.collections.LongUtils;
 import org.grouplens.lenskit.data.dao.ItemDAO;
 import org.grouplens.lenskit.data.dao.UserEventDAO;
 import org.grouplens.lenskit.data.event.Event;
-import org.grouplens.lenskit.data.event.Rating;
 import org.grouplens.lenskit.data.history.UserHistory;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.grouplens.lenskit.scored.ScoredIdBuilder;
@@ -158,7 +156,7 @@ public class TopNItemRecommender extends AbstractItemRecommender {
 
     /**
      * Get the default exclude set for a user.  The base implementation gets
-     * all their rated items.
+     * all the items they have interacted with.
      *
      * @param user The user ID.
      * @return The set of items to exclude.
@@ -169,7 +167,7 @@ public class TopNItemRecommender extends AbstractItemRecommender {
 
     /**
      * Get the default exclude set for a user.  The base implementation returns
-     * all their rated items.
+     * all the items they have interacted with (from {@link UserHistory#itemSet()}).
      *
      * @param user The user history.
      * @return The set of items to exclude.
@@ -177,12 +175,9 @@ public class TopNItemRecommender extends AbstractItemRecommender {
     protected LongSet getDefaultExcludes(@Nullable UserHistory<? extends Event> user) {
         if (user == null) {
             return LongSets.EMPTY_SET;
+        } else {
+            return user.itemSet();
         }
-        LongSet excludes = new LongOpenHashSet();
-        for (Rating r: CollectionUtils.fast(user.filter(Rating.class))) {
-            excludes.add(r.getItemId());
-        }
-        return excludes;
     }
 
     /**

--- a/src/site/markdown/releases/lenskit-2.1.md.vm
+++ b/src/site/markdown/releases/lenskit-2.1.md.vm
@@ -87,6 +87,10 @@ This release includes several improvements and additions to LensKit's selection 
 -   Add `RatingPredictorItemScorer`, a wrapper that uses the output of a rating predictor to produce
     item scores.  Useful primarily for using things like OrdRec for item-scorer-based components.
 
+-   **Behavior change:** the default exclude set used by `TopNItemRecommender` now contains all
+    items the user has interacted with, not just the ones they have rated.  Baking the knowledge of
+    ratings into the top-N recommender was arguably a mistake.
+
 ### User-user CF
 
 -   Updated user-user CF to be simpler & make better use of new DAOs (#issue(356)).


### PR DESCRIPTION
This excludes all items the user has interacted with, not just the ones they have rated, in the default item scorer implementation.
