### PR TITLE
Add helper for staged file writes

### DIFF
--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/io/StagedWriteTest.groovy
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/io/StagedWriteTest.groovy
@@ -42,7 +42,7 @@ class StagedWriteTest {
             stage.stagingFile.text = "hello, world"
             stage.commit()
         } finally {
-            stage.cleanup()
+            stage.close()
         }
         assertThat file.exists(), equalTo(true)
         assertThat file.text, equalTo("hello, world")
@@ -57,7 +57,7 @@ class StagedWriteTest {
         try {
             stage.stagingFile.text = "hello, world"
         } finally {
-            stage.cleanup()
+            stage.close()
         }
         assertThat file.exists(), equalTo(false)
         assertThat folder.root.listFiles().toList(), hasSize(0)
@@ -73,7 +73,7 @@ class StagedWriteTest {
             stage.stagingFile.text = "goodnight, moon"
             stage.commit()
         } finally {
-            stage.cleanup()
+            stage.close()
         }
         assertThat file.exists(), equalTo(true)
         assertThat file.text, equalTo("goodnight, moon")

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/pack/PackTask.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/pack/PackTask.java
@@ -157,7 +157,7 @@ public class PackTask extends AbstractTask<List<Object>> {
             logger.error("error packing {}: {}", outFile, ex);
             throw new TaskExecutionException("error packing " + outFile, ex);
         } finally {
-            stage.cleanup();
+            stage.close();
         }
 
         return source;

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/ComponentCache.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/ComponentCache.java
@@ -218,7 +218,7 @@ class ComponentCache {
                 }
                 stage.commit();
             } finally {
-                stage.cleanup();
+                stage.close();
             }
         }
 


### PR DESCRIPTION
This creates a helper for staged file writes (where we write to a temporary file and then rename), uses it in the place where we had that logic, and then uses it (along with logging and error handling improvements) to improve the error behavior of the evaluator's component cache.
