### PR TITLE
Don't fail the build if Pandoc is missing

### DIFF
--- a/lenskit-cli/src/package/bin-package.ant
+++ b/lenskit-cli/src/package/bin-package.ant
@@ -23,7 +23,9 @@
   <target name="render-manpages">
     <mkdir dir="${packageDir}/man"/>
     <apply executable="pandoc"
-           dest="${packageDir}/man">
+           dest="${packageDir}/man"
+           failonerror="false"
+           failifexecutionfails="false">
       <arg value="-Mheader=LensKit"/>
       <arg value="-Mfooter=${project.version}"/>
       <arg value="-Msection=1"/>


### PR DESCRIPTION
This addresses #553, ignoring Pandoc failures.
