### PR TITLE
fixed SnapshotNeighborFinder

### DIFF
--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/user/SnapshotNeighborFinder.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/user/SnapshotNeighborFinder.java
@@ -124,7 +124,7 @@ public class SnapshotNeighborFinder implements NeighborFinder {
             while (neighborIter.hasNext()) {
                 final long neighbor = neighborIter.nextLong();
                 SparseVector vector = snapshot.getNormalizedUserVector(neighbor);
-                double sim = similarity.similarity(user, vector, neighbor, vector);
+                double sim = similarity.similarity(user, userVector, neighbor, vector);
                 if (acceptSimilarity(sim)) {
                     return new Neighbor(neighbor, snapshot.getUserVector(neighbor), sim);
                 }


### PR DESCRIPTION
SnapshotNeighborFinder was behaving differently from the LiveNeighborFinder, Turns out its similarities were all 1! (interestingly, this didn't substantially impact accuracy)

Anyways this pull requests fixes the bug.
