### PR TITLE
Remove @Singleton annotations (#374)

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/baseline/ConstantItemScorer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/baseline/ConstantItemScorer.java
@@ -44,7 +44,6 @@ import java.util.Collection;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class ConstantItemScorer implements ItemScorer, Serializable {
     /**
      * Parameter: the value used by the constant scorer.

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/EventCountUserHistorySummarizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/EventCountUserHistorySummarizer.java
@@ -40,7 +40,6 @@ import javax.inject.Singleton;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public final class EventCountUserHistorySummarizer implements UserHistorySummarizer {
     protected final Class<? extends Event> wantedType;
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/RatingVectorUserHistorySummarizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/RatingVectorUserHistorySummarizer.java
@@ -40,7 +40,6 @@ import java.io.Serializable;
  */
 @Shareable
 @ThreadSafe
-@Singleton
 public final class RatingVectorUserHistorySummarizer implements UserHistorySummarizer, Serializable {
     private static final RatingVectorUserHistorySummarizer INSTANCE = new RatingVectorUserHistorySummarizer();
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/clamp/IdentityClampingFunction.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/clamp/IdentityClampingFunction.java
@@ -32,7 +32,6 @@ import java.io.Serializable;
  * @since 0.11
  */
 @Shareable
-@Singleton
 public final class IdentityClampingFunction implements ClampingFunction, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/IdentityVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/IdentityVectorNormalizer.java
@@ -33,7 +33,6 @@ import java.io.Serializable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class IdentityVectorNormalizer extends AbstractVectorNormalizer implements Serializable {
     private static final long serialVersionUID = -6708410675383598691L;
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/UnitVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/UnitVectorNormalizer.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class UnitVectorNormalizer extends AbstractVectorNormalizer implements Serializable {
     private final static long serialVersionUID = 1L;
     private final double tolerance;

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/threshold/NoThreshold.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/threshold/NoThreshold.java
@@ -30,7 +30,6 @@ import java.io.Serializable;
  * to retain all similarity values passed to it.
  */
 @Shareable
-@Singleton
 public class NoThreshold implements Threshold, Serializable {
     private static final long serialVersionUID = 1;
 

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
@@ -34,7 +34,6 @@ import java.io.Serializable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class SimilaritySumNeighborhoodScorer implements NeighborhoodScorer, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/WeightedAverageNeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/WeightedAverageNeighborhoodScorer.java
@@ -36,7 +36,6 @@ import static java.lang.Math.abs;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class WeightedAverageNeighborhoodScorer implements NeighborhoodScorer, Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
This drops the @Singleton annotations from all LensKit classes to keep CDI2.0 containers from instantiating them.
