### PR TITLE
Remove @Singleton annotations (#374)

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/baseline/ConstantItemScorer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/baseline/ConstantItemScorer.java
@@ -33,7 +33,6 @@ import org.grouplens.lenskit.vectors.SparseVector;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Qualifier;
-import javax.inject.Singleton;
 import java.io.Serializable;
 import java.lang.annotation.*;
 import java.util.Collection;
@@ -44,7 +43,6 @@ import java.util.Collection;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class ConstantItemScorer implements ItemScorer, Serializable {
     /**
      * Parameter: the value used by the constant scorer.

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/EventCountUserHistorySummarizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/EventCountUserHistorySummarizer.java
@@ -32,7 +32,6 @@ import org.grouplens.lenskit.vectors.SparseVector;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 /**
  * Summarize a history by counting all events referencing an item.  The history
@@ -41,7 +40,6 @@ import javax.inject.Singleton;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public final class EventCountUserHistorySummarizer implements UserHistorySummarizer {
     protected final Class<? extends Event> wantedType;
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/RatingVectorUserHistorySummarizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/history/RatingVectorUserHistorySummarizer.java
@@ -30,7 +30,6 @@ import org.grouplens.lenskit.vectors.SparseVector;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Singleton;
 import java.io.Serializable;
 
 /**
@@ -40,7 +39,6 @@ import java.io.Serializable;
  */
 @Shareable
 @ThreadSafe
-@Singleton
 public final class RatingVectorUserHistorySummarizer implements UserHistorySummarizer, Serializable {
     private static final RatingVectorUserHistorySummarizer INSTANCE = new RatingVectorUserHistorySummarizer();
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/clamp/IdentityClampingFunction.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/clamp/IdentityClampingFunction.java
@@ -22,7 +22,6 @@ package org.grouplens.lenskit.transform.clamp;
 
 import org.grouplens.lenskit.core.Shareable;
 
-import javax.inject.Singleton;
 import java.io.Serializable;
 
 /**
@@ -32,7 +31,6 @@ import java.io.Serializable;
  * @since 0.11
  */
 @Shareable
-@Singleton
 public final class IdentityClampingFunction implements ClampingFunction, Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/IdentityVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/IdentityVectorNormalizer.java
@@ -24,7 +24,6 @@ import org.grouplens.lenskit.core.Shareable;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
 
-import javax.inject.Singleton;
 import java.io.Serializable;
 
 /**
@@ -33,7 +32,6 @@ import java.io.Serializable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class IdentityVectorNormalizer extends AbstractVectorNormalizer implements Serializable {
     private static final long serialVersionUID = -6708410675383598691L;
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/UnitVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/UnitVectorNormalizer.java
@@ -25,7 +25,6 @@ import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
 
 import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.Serializable;
 
 /**
@@ -36,7 +35,6 @@ import java.io.Serializable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class UnitVectorNormalizer extends AbstractVectorNormalizer implements Serializable {
     private final static long serialVersionUID = 1L;
     private final double tolerance;

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/threshold/NoThreshold.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/threshold/NoThreshold.java
@@ -22,7 +22,6 @@ package org.grouplens.lenskit.transform.threshold;
 
 import org.grouplens.lenskit.core.Shareable;
 
-import javax.inject.Singleton;
 import java.io.Serializable;
 
 /**
@@ -30,7 +29,6 @@ import java.io.Serializable;
  * to retain all similarity values passed to it.
  */
 @Shareable
-@Singleton
 public class NoThreshold implements Threshold, Serializable {
     private static final long serialVersionUID = 1;
 

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
@@ -26,7 +26,6 @@ import org.grouplens.lenskit.scored.ScoredId;
 import org.grouplens.lenskit.scored.ScoredIds;
 import org.grouplens.lenskit.vectors.SparseVector;
 
-import javax.inject.Singleton;
 import java.io.Serializable;
 
 /**
@@ -35,7 +34,6 @@ import java.io.Serializable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 @Shareable
-@Singleton
 public class SimilaritySumNeighborhoodScorer implements NeighborhoodScorer, Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
This drops the @Singleton annotations from all LensKit classes to keep CDI2.0 containers from instantiating them, working around the CDI bugs causing #374.
