### PR TITLE
Fix the crossfold by changing write files logic.

### DIFF
--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldTask.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldTask.java
@@ -467,13 +467,16 @@ public class CrossfoldTask extends AbstractTask<List<TTDataSet>> {
         Holdout mode = this.getHoldout();
         try {
             for (UserHistory<Event> history : historyCursor) {
+                // get the corresponding fold number given a user's Id, fold number is the partition group given to a user
                 int foldNum = splits.get(history.getUserId());
                 // FIXME Use filtered streaming
+                // get a list of user's rating history
                 List<Rating> ratings = new ArrayList<Rating>(history.filter(Rating.class));
                 final int n = ratings.size();
 
                 for (int f = 0; f < partitionCount; f++) {
                     if (f == foldNum) {
+                        // get the cut off number that separates the user's ratings into train or test data. It uses the specified partition method to get cut off number
                         final int p = mode.partition(ratings, getProject().getRandom());
                         for (int j = 0; j < p; j++) {
                             trainWriters[f].writeRating(ratings.get(j));
@@ -481,13 +484,8 @@ public class CrossfoldTask extends AbstractTask<List<TTDataSet>> {
                         for (int j = p; j < n; j++) {
                             testWriters[f].writeRating(ratings.get(j));
                         }
-                    } else {
-                        for (Rating rating : CollectionUtils.fast(ratings)) {
-                            trainWriters[f].writeRating(rating);
-                        }
                     }
                 }
-
             }
         } catch (IOException e) {
             throw new TaskExecutionException("Error writing to the train test files", e);


### PR DESCRIPTION
When crossing fold the data, it first divides users into different groups. The number of groups is given by configuration in eval.grovy. When we try to put a user's rating history into test set or train set,  we first get the fold number of which group this user belongs to and then get the cut off number that separates the user's ratings into train or test data.
But the original version of lenskit-crossfold iterates all the groups when writing a user's rating history, and if a user's group does not correspond to the file number which going to be written, it just writes all this user's rating history into the training set of that file, which is done in the else part we took off from the commitment.
The else part does not make sense to us.

If we did not understand wrong, is that the supposed behavior of cross-fold? Thanks!
