### PR TITLE
Small CLI tweaks

### DIFF
--- a/lenskit-cli/build.gradle
+++ b/lenskit-cli/build.gradle
@@ -41,7 +41,7 @@ apply plugin: 'groovy'
 
 dependencies {
     compile project(':lenskit-all')
-    compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.4.3'
+    compile group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.4.4'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
 
     runtime group: 'org.fusesource.jansi', name: 'jansi', version: '1.8'

--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Eval.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Eval.java
@@ -52,6 +52,8 @@ public class Eval implements Command {
     private final Logger logger = LoggerFactory.getLogger(Eval.class);
 
     public static void configureArguments(Subparser parser) {
+        parser.description("Run a LensKit evaluation script.  By default, the script is " +
+                           "taken from 'eval.groovy'; use -f to override");
         ScriptEnvironment.configureArguments(parser);
         parser.addArgument("-F", "--force")
               .action(Arguments.storeTrue())


### PR DESCRIPTION
A couple of little things for the CLI:

- add descriptive text to `lenskit eval --help` to suggest using `-f` (#650).
- Bump `argparse4j` to 0.4.4.