### PR TITLE
Used linked hash map in TTDataSet attributes

### DIFF
--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataSet.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataSet.java
@@ -21,6 +21,7 @@
 package org.grouplens.lenskit.eval.data.traintest;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.grouplens.lenskit.core.LenskitConfiguration;
 import org.grouplens.lenskit.data.dao.EventDAO;
@@ -69,7 +70,7 @@ public class GenericTTDataSet implements TTDataSet {
         if (attrs == null) {
             attributes = Collections.emptyMap();
         } else {
-            attributes = Maps.newHashMap(attrs);
+            attributes = ImmutableMap.copyOf(attrs);
         }
     }
 

--- a/lenskit-eval/src/test/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataBuilderTest.java
+++ b/lenskit-eval/src/test/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataBuilderTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.lenskit.eval.data.traintest;
 
 import org.grouplens.lenskit.data.dao.EventCollectionDAO;

--- a/lenskit-eval/src/test/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataBuilderTest.java
+++ b/lenskit-eval/src/test/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataBuilderTest.java
@@ -1,0 +1,33 @@
+package org.grouplens.lenskit.eval.data.traintest;
+
+import org.grouplens.lenskit.data.dao.EventCollectionDAO;
+import org.grouplens.lenskit.data.event.Rating;
+import org.grouplens.lenskit.eval.data.GenericDataSource;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static net.java.quickcheck.generator.CombinedGenerators.uniqueValues;
+import static net.java.quickcheck.generator.CombinedGeneratorsIterables.someNonEmptyLists;
+import static net.java.quickcheck.generator.PrimitiveGenerators.nonEmptyStrings;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class GenericTTDataBuilderTest {
+    @Test
+    public void testAttributeOrder() {
+        for (List<String> strings: someNonEmptyLists(uniqueValues(nonEmptyStrings(), 10))) {
+            GenericTTDataBuilder bld = new GenericTTDataBuilder(nonEmptyStrings().next());
+            bld.setTrain(new GenericDataSource("train", EventCollectionDAO.create(Collections.<Rating>emptyList())));
+            bld.setTest(new GenericDataSource("test", EventCollectionDAO.create(Collections.<Rating>emptyList())));
+            for (String str: strings) {
+                bld.setAttribute(str, nonEmptyStrings().next());
+            }
+            TTDataSet ds = bld.build();
+            assertThat(ds.getAttributes().size(), equalTo(strings.size()));
+            assertThat(ds.getAttributes().keySet(), contains(strings.toArray()));
+        }
+    }
+}

--- a/lenskit-test/build.gradle
+++ b/lenskit-test/build.gradle
@@ -38,6 +38,7 @@ apply from: "$rootDir/gradle/maven.gradle"
 dependencies {
     compile group: 'junit', name: 'junit', version: '4.11'
     compile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
+    compile group: 'net.java.quickcheck', name: 'quickcheck', version: '0.6'
 }
 
 meta {


### PR DESCRIPTION
Use a linked hash map to maintain the order of data set attributes in `GenericTTDataSet`. Addresses #630.