### PR TITLE
Allow file parameters to be bound to strings

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitConfiguration.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitConfiguration.java
@@ -93,6 +93,14 @@ public class LenskitConfiguration extends AbstractConfigContext {
         roots.add(componentType);
     }
 
+    /**
+     * Clear the set of roots, removing all configured <em>and default</em> roots.  This is almost
+     * never desired in production, but is useful for testing.
+     */
+    public void clearRoots() {
+        roots.clear();
+    }
+
     @Override
     public <T> LenskitBinding<T> bind(Class<T> type) {
         return wrapContext(bindings.getRootContext()).bind(type);

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/inject/LenskitBindingImpl.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/inject/LenskitBindingImpl.java
@@ -20,6 +20,8 @@
  */
 package org.grouplens.lenskit.inject;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import org.grouplens.grapht.Binding;
 import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.lenskit.core.LenskitBinding;
@@ -36,58 +38,88 @@ import java.lang.annotation.Annotation;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 class LenskitBindingImpl<T> implements LenskitBinding<T> {
+    @Nonnull
     private final Binding<T> binding;
+    @Nullable
+    private final Function<Object,Optional<T>> coercion;
 
-    private LenskitBindingImpl(Binding<T> b) {
+    private LenskitBindingImpl(@Nonnull Binding<T> b, @Nullable Function<Object,Optional<T>> coerce) {
         binding = b;
+        coercion = coerce;
     }
 
+    /**
+     * Wrap a binding in a LensKit binding.
+     * @param binding The binding to wrap.
+     * @param <T> The bound type.
+     * @return The LensKit binding wrapper.
+     */
     static <T> LenskitBinding<T> wrap(Binding<T> binding) {
-        if (binding instanceof LenskitBinding) {
+        return wrap(binding, null);
+    }
+
+    /**
+     * Wrap a binding in a LensKit binding, with a coercion function to allow type conversions.
+     * This will allow instances of other types to be bound, if the coercion function provides
+     * a transformation.  Ordinarily, the generic types prevent this feature from being used, but
+     * a raw type (returned from {@link org.grouplens.lenskit.core.LenskitConfigContext#set(Class)}
+     * or commonly arising in Groovy) will allow arbitrary objects, and the coercion function will
+     * convert them.  It should return an absent optional if the type
+     * is unconvertable, and an optional wrapping the converted value if it is present.  If the
+     * coercion fails, the original value will be used as-is (which will usually result in an error
+     * from the underlying binding).
+     *
+     * @param binding The binding to wrap.
+     * @param coercion The coercion function.
+     * @param <T> The bound type.
+     * @return The
+     */
+    static <T> LenskitBinding<T> wrap(Binding<T> binding, Function<Object,Optional<T>> coercion) {
+        if (coercion == null && binding instanceof LenskitBinding) {
             return (LenskitBinding<T>) binding;
         } else {
-            return new LenskitBindingImpl<T>(binding);
+            return new LenskitBindingImpl<T>(binding, coercion);
         }
     }
 
     @Override
     public LenskitBinding<T> withQualifier(@Nonnull Class<? extends Annotation> qualifier) {
-        return wrap(binding.withQualifier(qualifier));
+        return wrap(binding.withQualifier(qualifier), coercion);
     }
 
     @Override
     public LenskitBinding<T> withQualifier(@Nonnull Annotation annot) {
-        return wrap(binding.withQualifier(annot));
+        return wrap(binding.withQualifier(annot), coercion);
     }
 
     @Override
     public LenskitBinding<T> withAnyQualifier() {
-        return wrap(binding.withAnyQualifier());
+        return wrap(binding.withAnyQualifier(), coercion);
     }
 
     @Override
     public LenskitBinding<T> unqualified() {
-        return wrap(binding.unqualified());
+        return wrap(binding.unqualified(), coercion);
     }
 
     @Override
     public LenskitBinding<T> exclude(@Nonnull Class<?> exclude) {
-        return wrap(binding.exclude(exclude));
+        return wrap(binding.exclude(exclude), coercion);
     }
 
     @Override
     public LenskitBinding<T> shared() {
-        return wrap(binding.shared());
+        return wrap(binding.shared(), coercion);
     }
 
     @Override
     public LenskitBinding<T> unshared() {
-        return wrap(binding.unshared());
+        return wrap(binding.unshared(), coercion);
     }
 
     @Override
     public Binding<T> fixed() {
-        return wrap(binding.fixed());
+        return wrap(binding.fixed(), coercion);
     }
 
     @Override
@@ -102,12 +134,21 @@ class LenskitBindingImpl<T> implements LenskitBinding<T> {
 
     @Override
     public void to(@Nullable T instance) {
-        binding.to(instance);
+        T obj = instance;
+        if (coercion != null && obj != null) {
+            Optional<T> result = coercion.apply(instance);
+            assert result != null;
+            if (result.isPresent()) {
+                obj = result.get();
+            }
+            // otherwise, just try to use the object as-is, let Binding fail
+        }
+        binding.to(obj);
     }
 
     @Override
     public void toInstance(@Nullable T instance) {
-        binding.to(instance);
+        to(instance);
     }
 
     @Override

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/core/LenskitConfigurationTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/core/LenskitConfigurationTest.java
@@ -1,0 +1,38 @@
+package org.grouplens.lenskit.core;
+
+import org.grouplens.grapht.InjectionException;
+import org.grouplens.grapht.Injector;
+import org.grouplens.grapht.annotation.AnnotationBuilder;
+import org.grouplens.lenskit.data.text.EventFile;
+import org.grouplens.lenskit.data.text.EventFormat;
+import org.grouplens.lenskit.data.text.Formats;
+import org.grouplens.lenskit.data.text.TextEventDAO;
+import org.grouplens.lenskit.inject.RecommenderGraphBuilder;
+import org.grouplens.lenskit.inject.StaticInjector;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class LenskitConfigurationTest {
+    /**
+     * Test that we can bind a file parameter to a string and have it work.
+     *
+     * @throws InjectionException if there is an (unexpected) injection failure.
+     */
+    @Test
+    public void testSetFile() throws InjectionException {
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.clearRoots();
+        config.addRoot(TextEventDAO.class);
+        config.set(EventFile.class).to("ratings.foodat");
+        config.bind(EventFormat.class).to(Formats.ml100kFormat());
+        RecommenderGraphBuilder rgb = new RecommenderGraphBuilder();
+        rgb.addConfiguration(config);
+        Injector inj = new StaticInjector(rgb.buildGraph());
+        File f = inj.getInstance(AnnotationBuilder.of(EventFile.class).build(), File.class);
+        assertThat(f.getName(), equalTo("ratings.foodat"));
+    }
+}

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/core/LenskitConfigurationTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/core/LenskitConfigurationTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.lenskit.core;
 
 import org.grouplens.grapht.InjectionException;


### PR DESCRIPTION
This bolts on some machinery to allow File parameters to be bound to String values, making it easier to write configuration files.

Implemented by augmenting the LensKit binding implementation with a type coercion function, applied to instance bindings.  `set` on a File parameter applies a string-to-file coercion, allowing the string parameters.