### PR TITLE
Add ItemNameDAO

### DIFF
--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Recommend.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Recommend.java
@@ -27,6 +27,7 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.grouplens.lenskit.ItemRecommender;
 import org.grouplens.lenskit.RecommenderBuildException;
 import org.grouplens.lenskit.core.*;
+import org.grouplens.lenskit.data.dao.ItemNameDAO;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.grouplens.lenskit.symbols.Symbol;
 import org.grouplens.lenskit.util.io.CompressionMode;
@@ -67,6 +68,7 @@ public class Recommend implements Command {
 
         LenskitRecommender rec = engine.createRecommender();
         ItemRecommender irec = rec.getItemRecommender();
+        ItemNameDAO indao = rec.get(ItemNameDAO.class);
         if (irec == null) {
             logger.error("recommender has no item recommender");
             throw new UnsupportedOperationException("no item recommender");
@@ -79,7 +81,11 @@ public class Recommend implements Command {
             List<ScoredId> recs = irec.recommend(user, n);
             System.out.format("recommendations for user %d:\n", user);
             for (ScoredId item: recs) {
-                System.out.format("  %d: %.3f", item.getId(), item.getScore());
+                System.out.format("  %d", item.getId());
+                if (indao != null) {
+                    System.out.format(" (%s)", indao.getItemName(item.getId()));
+                }
+                System.out.format(": %.3f", item.getScore());
                 if (pchan != null && item.hasUnboxedChannel(pchan)) {
                     System.out.format(" (%f)", item.getUnboxedChannelValue(pchan));
                 }

--- a/lenskit-cli/src/man/lenskit-predict.1.md
+++ b/lenskit-cli/src/man/lenskit-predict.1.md
@@ -57,6 +57,10 @@ data to work with, one of the following mutually-exclusive options must be prese
 :   Read ratings from the packed rating file *FILE*.  Packed files can be created with the
     [**pack-ratings**](lenskit-pack-ratings.1.html) command.
 
+--item-names *FILE*
+:   Load an item ID to name mapping from the CSV file *FILE*.  This will be used to provide an
+    `ItemNameDAO` and `ItemDAO`.
+
 Additionally, the following options provide additional control over the data input:
 
 -d *DELIM*, --delimiter *DELIM*

--- a/lenskit-cli/src/man/lenskit-recommend.1.md
+++ b/lenskit-cli/src/man/lenskit-recommend.1.md
@@ -57,6 +57,10 @@ data to work with, one of the following mutually-exclusive options must be prese
 :   Read ratings from the packed rating file *FILE*.  Packed files can be created with the
     [**pack-ratings**](lenskit-pack-ratings.1.html) command.
 
+--item-names *FILE*
+:   Load an item ID to name mapping from the CSV file *FILE*.  This will be used to provide an
+    `ItemNameDAO` and `ItemDAO`.
+
 Additionally, the following options provide additional control over the data input:
 
 -d *DELIM*, --delimiter *DELIM*

--- a/lenskit-cli/src/man/lenskit-train-model.1.md
+++ b/lenskit-cli/src/man/lenskit-train-model.1.md
@@ -51,6 +51,10 @@ data to work with, one of the following mutually-exclusive options must be prese
 :   Read ratings from the packed rating file *FILE*.  Packed files can be created with the
     [**pack-ratings**](lenskit-pack-ratings.1.html) command.
 
+--item-names *FILE*
+:   Load an item ID to name mapping from the CSV file *FILE*.  This will be used to provide an
+    `ItemNameDAO` and `ItemDAO`.
+
 Additionally, the following options provide additional control over the data input:
 
 -d *DELIM*, --delimiter *DELIM*

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/ItemNameDAO.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/ItemNameDAO.java
@@ -25,6 +25,20 @@ import javax.annotation.Nullable;
 
 /**
  * A DAO interface that provides access to item names.
+ * <p>
+ * The normal way to get item names, without writing your own DAOs, is to use a {@link org.grouplens.lenskit.data.dao.MapItemNameDAO}, often
+ * loaded from a CSV file:
+ * </p>
+ * <pre>{@code
+ * bind MapItemNameDAO to CSVFileItemNameDAOProvider
+ * set ItemFile to "item-names.csv"
+ * }</pre>
+ * <p>
+ * Note that, while {@link org.grouplens.lenskit.data.dao.MapItemNameDAO} implements both this
+ * interface and {@link org.grouplens.lenskit.data.dao.ItemDAO}, binding this interface to the
+ * provider instead of the class means that the item name DAO will only be used to satisfy item name
+ * DAO requests and not item list requests.
+ * </p>
  */
 public interface ItemNameDAO {
     /**

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/ItemNameDAO.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/ItemNameDAO.java
@@ -1,0 +1,37 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package org.grouplens.lenskit.data.dao;
+
+import javax.annotation.Nullable;
+
+/**
+ * A DAO interface that provides access to item names.
+ */
+public interface ItemNameDAO {
+    /**
+     * Get the name for an item.
+     * @param item The item ID.
+     * @return A display name for the item, or {@code null} if the item is unknown or has no name.
+     */
+    @Nullable
+    String getItemName(long item);
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/MapItemNameDAO.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/MapItemNameDAO.java
@@ -1,0 +1,103 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.data.dao;
+
+import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongSortedSet;
+import org.apache.commons.lang3.text.StrTokenizer;
+import org.grouplens.lenskit.collections.LongUtils;
+import org.grouplens.lenskit.core.Shareable;
+import org.grouplens.lenskit.util.LineCursor;
+import org.grouplens.lenskit.util.io.CompressionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * An item name DAO backed by a map of item IDs to names.
+ *
+ * @since 2.1
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+@Shareable
+public class MapItemNameDAO implements ItemNameDAO, ItemDAO, Serializable {
+    private static final Logger logger = LoggerFactory.getLogger(MapItemNameDAO.class);
+    private static final long serialVersionUID = 1L;
+    private final Map<Long,String> itemNameMap;
+    private final LongSortedSet itemIds;
+
+    public MapItemNameDAO(Map<Long,String> items) {
+        itemNameMap = ImmutableMap.copyOf(items);
+        itemIds = LongUtils.packedSet(itemNameMap.keySet());
+    }
+
+    @Nullable
+    @Override
+    public LongSet getItemIds() {
+        return itemIds;
+    }
+
+    @Nullable
+    @Override
+    public String getItemName(long item) {
+        return itemNameMap.get(item);
+    }
+
+    /**
+     * Read an item list DAO from a file.
+     * @param file A file of item IDs, one per line.
+     * @return The item list DAO.
+     * @throws java.io.IOException if there is an error reading the list of items.
+     */
+    public static MapItemNameDAO fromCSVFile(File file) throws IOException {
+        LineCursor cursor = LineCursor.openFile(file, CompressionMode.AUTO);
+        try {
+            ImmutableMap.Builder<Long, String> names = ImmutableMap.builder();
+            StrTokenizer tok = StrTokenizer.getCSVInstance();
+            for (String line : cursor) {
+                tok.reset(line);
+                long item = Long.parseLong(tok.next());
+                String title = tok.nextToken();
+                if (title != null) {
+                    names.put(item, title);
+                }
+            }
+            return new MapItemNameDAO(names.build());
+        } catch (NoSuchElementException ex) {
+            throw new IOException(String.format("%s:%s: not enough columns",
+                                                file, cursor.getLineNumber()),
+                                  ex);
+        } catch (NumberFormatException ex) {
+            throw new IOException(String.format("%s:%s: id not an integer",
+                                                file, cursor.getLineNumber()),
+                                  ex);
+        } finally {
+            cursor.close();
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/MapItemNameDAO.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/dao/MapItemNameDAO.java
@@ -41,8 +41,8 @@ import java.util.NoSuchElementException;
 /**
  * An item name DAO backed by a map of item IDs to names.
  *
- * @since 2.1
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * @since 2.2
+ * @see org.grouplens.lenskit.data.dao.ItemNameDAO
  */
 @Shareable
 public class MapItemNameDAO implements ItemNameDAO, ItemDAO, Serializable {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/text/CSVFileItemNameDAOProvider.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/text/CSVFileItemNameDAOProvider.java
@@ -1,0 +1,53 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.data.text;
+
+import org.grouplens.lenskit.data.dao.DataAccessException;
+import org.grouplens.lenskit.data.dao.ItemFile;
+import org.grouplens.lenskit.data.dao.MapItemNameDAO;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Provider for {@link org.grouplens.lenskit.data.dao.ItemListItemDAO} that reads a list of item IDs from a file, one per line.
+ *
+ * @since 2.1
+ */
+public class CSVFileItemNameDAOProvider implements Provider<MapItemNameDAO> {
+    private final File itemFile;
+
+    @Inject
+    public CSVFileItemNameDAOProvider(@ItemFile File file) {
+        itemFile = file;
+    }
+
+    @Override
+    public MapItemNameDAO get() {
+        try {
+            return MapItemNameDAO.fromCSVFile(itemFile);
+        } catch (IOException e) {
+            throw new DataAccessException("error reading " + itemFile, e);
+        }
+    }
+}

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/data/dao/MapItemNameDAOTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/data/dao/MapItemNameDAOTest.java
@@ -1,0 +1,67 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.data.dao;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class MapItemNameDAOTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    MapItemNameDAO dao;
+
+    @Before
+    public void createFile() throws IOException {
+        File f = folder.newFile("titles.csv");
+        PrintStream str = new PrintStream(f);
+        try {
+            str.println("42,Iron Man");
+            str.println("67,Star Wars");
+        } finally {
+            str.close();
+        }
+        dao = MapItemNameDAO.fromCSVFile(f);
+    }
+
+    @Test
+    public void testMissingItem() {
+        assertThat(dao.getItemName(5), nullValue());
+    }
+
+    @Test
+    public void testPresentItem() {
+        assertThat(dao.getItemName(42), equalTo("Iron Man"));
+    }
+
+    @Test
+    public void testItemIds() {
+        assertThat(dao.getItemIds(), containsInAnyOrder(42L, 67L));
+    }
+}


### PR DESCRIPTION
This adds an `ItemNameDAO` for generic support for giving items names (e.g. movie titles), along with support in the `recommend` CLI to print recommended item names.

Questionable decisions I made:

- [x] `ItemNameDAO` does not extend `ItemDAO`
- [x] `MapItemNameDAO` implements both `ItemNameDAO` and `ItemDAO`
- [x] `@ItemFile` is reused for the `CSVFileItemNameDAOProvider`, on the premise that using both an item name file and an item ID list file is an unlikely scenario

The first two are affected by the fact that LensKit sort-of implicitly assumes that getItemIds() will return all items that might ever be seen in an event.  This can be false for two reasons:

- in our case, the title file might not have all the movies
- in a database, a new item might be added and rated between the two calls

Guaranteeing that `getItemIds()` will return all item IDs requires heavy database snapshotting. I am very hesitant to require this.

The better fix, IMO, is to make sure LensKit algorithms work fine when `getItemIds()` is missing items. We can test for this with a modification of ML-100K. An algorithm should either ignore unknown items, or augment its storage to accomodate them (either is acceptable behavior).

If we go with this better fix (should create a separate issue for it), then having `MapItemNameDAO` implement `ItemDAO` seems appropriate, and the only question is whether `ItemNameDAO` should extend `ItemDAO`.