### PR TITLE
Add tests with subsetted item DAOs

### DIFF
--- a/lenskit-integration-tests/src/main/java/org/grouplens/lenskit/test/ML100KTestSuite.java
+++ b/lenskit-integration-tests/src/main/java/org/grouplens/lenskit/test/ML100KTestSuite.java
@@ -45,6 +45,7 @@ import static org.junit.Assume.assumeTrue;
 public class ML100KTestSuite {
     protected final String ML100K_PROPERTY = "lenskit.movielens.100k";
     protected final String INPUT_FILE_NAME = "u.data";
+    protected final int SUBSET_DROP_SIZE = 20;
 
     protected File inputFile;
     protected EventDAO ratingDAO;
@@ -62,7 +63,7 @@ public class ML100KTestSuite {
         ItemDAO idao = new PrefetchingItemDAO(ratingDAO);
         LongList items = new LongArrayList(idao.getItemIds());
         LongLists.shuffle(items, rng);
-        items = items.subList(0, items.size() - 20);
+        items = items.subList(0, items.size() - SUBSET_DROP_SIZE);
         config.bind(ItemDAO.class).to(new ItemListItemDAO(items));
         return config;
     }

--- a/lenskit-integration-tests/src/main/java/org/grouplens/lenskit/test/ML100KTestSuite.java
+++ b/lenskit-integration-tests/src/main/java/org/grouplens/lenskit/test/ML100KTestSuite.java
@@ -20,9 +20,11 @@
  */
 package org.grouplens.lenskit.test;
 
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.longs.LongLists;
 import org.grouplens.lenskit.core.LenskitConfiguration;
-import org.grouplens.lenskit.data.dao.EventDAO;
-import org.grouplens.lenskit.data.dao.SimpleFileRatingDAO;
+import org.grouplens.lenskit.data.dao.*;
 import org.grouplens.lenskit.data.text.DelimitedColumnEventFormat;
 import org.grouplens.lenskit.data.text.Fields;
 import org.grouplens.lenskit.data.text.TextEventDAO;
@@ -32,6 +34,7 @@ import org.junit.internal.AssumptionViolatedException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.Random;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -50,6 +53,17 @@ public class ML100KTestSuite {
     protected LenskitConfiguration getDaoConfig() {
         LenskitConfiguration config = new LenskitConfiguration();
         config.bind(EventDAO.class).to(ratingDAO);
+        return config;
+    }
+
+    protected LenskitConfiguration getItemSubsetConfig() {
+        Random rng = new Random();
+        LenskitConfiguration config = getDaoConfig();
+        ItemDAO idao = new PrefetchingItemDAO(ratingDAO);
+        LongList items = new LongArrayList(idao.getItemIds());
+        LongLists.shuffle(items, rng);
+        items = items.subList(0, items.size() - 20);
+        config.bind(ItemDAO.class).to(new ItemListItemDAO(items));
         return config;
     }
 

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/baseline/LeastSquaresBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/baseline/LeastSquaresBuildSerializeTest.groovy
@@ -41,6 +41,20 @@ import static org.junit.Assert.assertThat
  */
 public class LeastSquaresBuildSerializeTest extends ML100KTestSuite {
     @Test
+    public void testBuildWithItemSubset() {
+        LenskitConfiguration config = ConfigHelpers.load {
+            bind ItemScorer to LeastSquaresItemScorer
+        }
+
+        LenskitRecommenderEngine engine =
+                LenskitRecommenderEngine.newBuilder()
+                                        .addConfiguration(config)
+                                        .addConfiguration(itemSubsetConfig, ModelDisposition.EXCLUDED)
+                                        .build()
+        assertThat(engine, notNullValue())
+    }
+
+    @Test
     public void testBuildAndSerializeModel() throws RecommenderBuildException, IOException {
         LenskitConfiguration config = ConfigHelpers.load {
             bind ItemScorer to LeastSquaresItemScorer

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
@@ -46,15 +46,25 @@ import static org.junit.Assert.assertThat
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class ItemItemBuildSerializeTest extends ML100KTestSuite {
+    def config = ConfigHelpers.load {
+        bind ItemScorer to ItemItemScorer
+        bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
+        bind(BaselineScorer, ItemScorer) to UserMeanItemScorer
+        bind(UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
+    }
+
+    @Test
+    public void testBuildWithItemSubset() throws RecommenderBuildException, IOException {
+        LenskitRecommenderEngine engine =
+                LenskitRecommenderEngine.newBuilder()
+                                        .addConfiguration(config)
+                                        .addConfiguration(itemSubsetConfig)
+                                        .build()
+        assertThat(engine, notNullValue())
+    }
+
     @Test
     public void testBuildAndSerializeModel() throws RecommenderBuildException, IOException {
-        def config = ConfigHelpers.load {
-            bind ItemScorer to ItemItemScorer
-            bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
-            bind (BaselineScorer, ItemScorer) to UserMeanItemScorer
-            bind (UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
-        }
-
         LenskitRecommenderEngine engine =
             LenskitRecommenderEngine.newBuilder()
                                     .addConfiguration(config)

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
@@ -31,6 +31,7 @@ import org.grouplens.lenskit.config.ConfigHelpers
 import org.grouplens.lenskit.core.LenskitRecommender
 import org.grouplens.lenskit.core.LenskitRecommenderEngine
 import org.grouplens.lenskit.core.ModelDisposition
+import org.grouplens.lenskit.data.dao.ItemDAO
 import org.grouplens.lenskit.knn.item.model.ItemItemModel
 import org.grouplens.lenskit.knn.item.model.ItemItemModelBuilder
 import org.grouplens.lenskit.knn.item.model.NormalizingItemItemModelBuilder
@@ -55,6 +56,7 @@ public class ItemItemBuildSerializeTest extends ML100KTestSuite {
         bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
         bind(BaselineScorer, ItemScorer) to UserMeanItemScorer
         bind(UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
+        root ItemDAO
     }
 
     @Test
@@ -65,6 +67,12 @@ public class ItemItemBuildSerializeTest extends ML100KTestSuite {
                                         .addConfiguration(itemSubsetConfig)
                                         .build()
         assertThat(engine, notNullValue())
+        def rec = engine.createRecommender();
+        def dao = rec.get(ItemDAO)
+        def model = rec.get(ItemItemModel)
+        assertThat(model.itemUniverse,
+                   anyOf(hasSize(dao.itemIds.size()),
+                         hasSize(dao.itemIds.size() + SUBSET_DROP_SIZE)))
     }
 
     @Test
@@ -78,6 +86,12 @@ public class ItemItemBuildSerializeTest extends ML100KTestSuite {
                                         .addConfiguration(itemSubsetConfig)
                                         .build()
         assertThat(engine, notNullValue())
+        def rec = engine.createRecommender();
+        def dao = rec.get(ItemDAO)
+        def model = rec.get(ItemItemModel)
+        assertThat(model.itemUniverse,
+                   anyOf(hasSize(dao.itemIds.size()),
+                         hasSize(dao.itemIds.size() + SUBSET_DROP_SIZE)))
     }
 
     @Test

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
@@ -32,9 +32,13 @@ import org.grouplens.lenskit.core.LenskitRecommender
 import org.grouplens.lenskit.core.LenskitRecommenderEngine
 import org.grouplens.lenskit.core.ModelDisposition
 import org.grouplens.lenskit.knn.item.model.ItemItemModel
+import org.grouplens.lenskit.knn.item.model.ItemItemModelBuilder
+import org.grouplens.lenskit.knn.item.model.NormalizingItemItemModelBuilder
+import org.grouplens.lenskit.knn.item.model.StandardVectorTruncatorProvider
 import org.grouplens.lenskit.test.ML100KTestSuite
 import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
 import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
+import org.grouplens.lenskit.transform.truncate.VectorTruncator
 import org.junit.Test
 
 import static org.hamcrest.Matchers.*
@@ -58,6 +62,19 @@ public class ItemItemBuildSerializeTest extends ML100KTestSuite {
         LenskitRecommenderEngine engine =
                 LenskitRecommenderEngine.newBuilder()
                                         .addConfiguration(config)
+                                        .addConfiguration(itemSubsetConfig)
+                                        .build()
+        assertThat(engine, notNullValue())
+    }
+
+    @Test
+    public void testNormalizingBuildWithItemSubset() throws RecommenderBuildException, IOException {
+        def cfg = config.copy()
+        cfg.bind(ItemItemModel).toProvider(NormalizingItemItemModelBuilder)
+        cfg.at(ItemItemModel).bind(VectorTruncator).toProvider(StandardVectorTruncatorProvider)
+        LenskitRecommenderEngine engine =
+                LenskitRecommenderEngine.newBuilder()
+                                        .addConfiguration(cfg)
                                         .addConfiguration(itemSubsetConfig)
                                         .build()
         assertThat(engine, notNullValue())

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemSubsetAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemSubsetAccuracyTest.groovy
@@ -1,0 +1,13 @@
+package org.grouplens.lenskit.knn.item
+
+import org.grouplens.lenskit.core.LenskitConfiguration
+import org.grouplens.lenskit.data.dao.ItemDAO
+import org.grouplens.lenskit.test.ML100KTestSuite
+
+class ItemItemSubsetAccuracyTest extends ItemItemAccuracyTest {
+    @Override
+    protected void configureAlgorithm(LenskitConfiguration config) {
+        super.configureAlgorithm(config)
+        config.bind(ItemDAO).toProvider(ML100KTestSuite.SubsetProvider)
+    }
+}

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemSubsetAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/item/ItemItemSubsetAccuracyTest.groovy
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.lenskit.knn.item
 
 import org.grouplens.lenskit.core.LenskitConfiguration

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/user/UserUserAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/user/UserUserAccuracyTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.knn.user
+
+import org.grouplens.lenskit.ItemScorer
+import org.grouplens.lenskit.baseline.BaselineScorer
+import org.grouplens.lenskit.baseline.UserMeanItemScorer
+import org.grouplens.lenskit.config.ConfigHelpers
+import org.grouplens.lenskit.core.LenskitConfiguration
+import org.grouplens.lenskit.knn.NeighborhoodSize
+import org.grouplens.lenskit.test.CrossfoldTestSuite
+import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
+import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
+import org.grouplens.lenskit.util.table.Table
+
+import static org.hamcrest.Matchers.closeTo
+import static org.junit.Assert.assertThat
+
+/**
+ * Do major tests on the item-item recommender.
+ *
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+public class UserUserAccuracyTest extends CrossfoldTestSuite {
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void configureAlgorithm(LenskitConfiguration config) {
+        ConfigHelpers.configure(config) {
+            bind ItemScorer to UserUserItemScorer
+            bind (BaselineScorer, ItemScorer) to UserMeanItemScorer
+            bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
+            set NeighborhoodSize to 30
+        }
+    }
+
+    @Override
+    protected void checkResults(Table table) {
+        assertThat(table.column("MAE.ByRating").average(),
+                   closeTo(0.70d, 0.025d))
+        assertThat(table.column("RMSE.ByUser").average(),
+                   closeTo(0.90d, 0.05d))
+    }
+}

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/user/UserUserBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/knn/user/UserUserBuildSerializeTest.groovy
@@ -53,6 +53,26 @@ import static org.junit.Assert.assertThat
  */
 public class UserUserBuildSerializeTest extends ML100KTestSuite {
     @Test
+    public void testBuildWithoutItems() throws RecommenderBuildException, IOException {
+        def config = ConfigHelpers.load {
+            bind ItemScorer to UserUserItemScorer
+            within(UserVectorSimilarity) {
+                bind VectorSimilarity to CosineVectorSimilarity
+            }
+            bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
+            bind(BaselineScorer, ItemScorer) to UserMeanItemScorer
+            bind(UserMeanBaseline, ItemMeanRatingItemScorer) to ItemMeanRatingItemScorer
+        }
+
+        LenskitRecommenderEngine engine =
+                LenskitRecommenderEngine.newBuilder()
+                                        .addConfiguration(config)
+                                        .addConfiguration(itemSubsetConfig, ModelDisposition.EXCLUDED)
+                                        .build()
+        assertThat(engine, notNullValue())
+    }
+
+    @Test
     public void testBuildAndSerializeModel() throws RecommenderBuildException, IOException {
         def config = ConfigHelpers.load {
             bind ItemScorer to UserUserItemScorer

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDBuildSerializeTest.groovy
@@ -27,13 +27,12 @@ import org.grouplens.lenskit.config.ConfigHelpers
 import org.grouplens.lenskit.core.LenskitRecommender
 import org.grouplens.lenskit.core.LenskitRecommenderEngine
 import org.grouplens.lenskit.core.ModelDisposition
-import org.grouplens.lenskit.data.dao.EventDAO
+import org.grouplens.lenskit.data.dao.ItemDAO
 import org.grouplens.lenskit.iterative.IterationCount
 import org.grouplens.lenskit.test.ML100KTestSuite
 import org.junit.Test
 
-import static org.hamcrest.Matchers.instanceOf
-import static org.hamcrest.Matchers.notNullValue
+import static org.hamcrest.Matchers.*
 import static org.junit.Assert.assertThat
 
 /**
@@ -51,6 +50,7 @@ public class FunkSVDBuildSerializeTest extends ML100KTestSuite {
         within (BaselineScorer, ItemScorer) {
             set MeanDamping to 25
         }
+        root ItemDAO
     }
 
     @Test
@@ -58,9 +58,15 @@ public class FunkSVDBuildSerializeTest extends ML100KTestSuite {
         LenskitRecommenderEngine engine =
                 LenskitRecommenderEngine.newBuilder()
                                         .addConfiguration(config)
-                                        .addConfiguration(itemSubsetConfig, ModelDisposition.EXCLUDED)
+                                        .addConfiguration(itemSubsetConfig)
                                         .build()
         assertThat(engine, notNullValue())
+        def rec = engine.createRecommender();
+        def dao = rec.get(ItemDAO)
+        def model = rec.get(FunkSVDModel)
+        assertThat(model.itemIndex.idList,
+                   anyOf(hasSize(dao.itemIds.size()),
+                         hasSize(dao.itemIds.size() + SUBSET_DROP_SIZE)));
     }
 
     @Test

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDBuildSerializeTest.groovy
@@ -42,19 +42,29 @@ import static org.junit.Assert.assertThat
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class FunkSVDBuildSerializeTest extends ML100KTestSuite {
+    def config = ConfigHelpers.load {
+        bind ItemScorer to FunkSVDItemScorer
+        bind (BaselineScorer, ItemScorer) to UserMeanItemScorer
+        bind (UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
+        set FeatureCount to 10
+        set IterationCount to 10
+        within (BaselineScorer, ItemScorer) {
+            set MeanDamping to 25
+        }
+    }
+
+    @Test
+    void testBuildWithMissingItems() {
+        LenskitRecommenderEngine engine =
+                LenskitRecommenderEngine.newBuilder()
+                                        .addConfiguration(config)
+                                        .addConfiguration(itemSubsetConfig, ModelDisposition.EXCLUDED)
+                                        .build()
+        assertThat(engine, notNullValue())
+    }
+
     @Test
     void testBuildAndSerializeModel() throws RecommenderBuildException, IOException {
-        def config = ConfigHelpers.load {
-            bind ItemScorer to FunkSVDItemScorer
-            bind (BaselineScorer, ItemScorer) to UserMeanItemScorer
-            bind (UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
-            set FeatureCount to 10
-            set IterationCount to 10
-            within (BaselineScorer, ItemScorer) {
-                set MeanDamping to 25
-            }
-        }
-
         LenskitRecommenderEngine engine =
             LenskitRecommenderEngine.newBuilder()
                                     .addConfiguration(config)

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDSubsetAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDSubsetAccuracyTest.groovy
@@ -1,0 +1,13 @@
+package org.grouplens.lenskit.mf.funksvd
+
+import org.grouplens.lenskit.core.LenskitConfiguration
+import org.grouplens.lenskit.data.dao.ItemDAO
+import org.grouplens.lenskit.test.ML100KTestSuite
+
+class FunkSVDSubsetAccuracyTest extends FunkSVDAccuracyTest {
+    @Override
+    protected void configureAlgorithm(LenskitConfiguration config) {
+        super.configureAlgorithm(config)
+        config.bind(ItemDAO).toProvider(ML100KTestSuite.SubsetProvider)
+    }
+}

--- a/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDSubsetAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/grouplens/lenskit/mf/funksvd/FunkSVDSubsetAccuracyTest.groovy
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.lenskit.mf.funksvd
 
 import org.grouplens.lenskit.core.LenskitConfiguration

--- a/lenskit-integration-tests/src/test/java/org/grouplens/lenskit/test/ML100KTestSuiteTest.java
+++ b/lenskit-integration-tests/src/test/java/org/grouplens/lenskit/test/ML100KTestSuiteTest.java
@@ -1,0 +1,65 @@
+package org.grouplens.lenskit.test;
+
+import org.grouplens.lenskit.RecommenderBuildException;
+import org.grouplens.lenskit.core.LenskitConfiguration;
+import org.grouplens.lenskit.core.LenskitRecommender;
+import org.grouplens.lenskit.core.LenskitRecommenderEngine;
+import org.grouplens.lenskit.core.LenskitRecommenderEngineBuilder;
+import org.grouplens.lenskit.data.dao.ItemDAO;
+import org.grouplens.lenskit.data.dao.PrefetchingItemDAO;
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test the ML-100K test suite setup.
+ */
+public class ML100KTestSuiteTest extends ML100KTestSuite {
+    @Test
+    public void testFullItemDAO() throws RecommenderBuildException {
+        LenskitConfiguration cfg = new LenskitConfiguration();
+        cfg.addRoot(DAOFetcher.class);
+        LenskitRecommenderEngineBuilder bld = LenskitRecommenderEngine.newBuilder();
+        LenskitRecommender rec = bld.addConfiguration(getDaoConfig())
+                                    .addConfiguration(cfg)
+                                    .build()
+                                    .createRecommender();
+        DAOFetcher df = rec.get(DAOFetcher.class);
+        assertThat(df.activeItemDAO, notNullValue());
+        assertThat(df.fullItemDAO, notNullValue());
+        assertThat(df.activeItemDAO, sameInstance(df.fullItemDAO));
+        assertThat(df.activeItemDAO.getItemIds(),
+                   hasSize(df.fullItemDAO.getItemIds().size()));
+    }
+
+    @Test
+    public void testSubsetItemDAO() throws RecommenderBuildException {
+        LenskitConfiguration cfg = new LenskitConfiguration();
+        cfg.addRoot(DAOFetcher.class);
+        LenskitRecommenderEngineBuilder bld = LenskitRecommenderEngine.newBuilder();
+        LenskitRecommender rec = bld.addConfiguration(getItemSubsetConfig())
+                                    .addConfiguration(cfg)
+                                    .build()
+                                    .createRecommender();
+        DAOFetcher df = rec.get(DAOFetcher.class);
+        assertThat(df.activeItemDAO, notNullValue());
+        assertThat(df.fullItemDAO, notNullValue());
+        assertThat(df.activeItemDAO, not(sameInstance(df.fullItemDAO)));
+        assertThat(df.activeItemDAO.getItemIds(),
+                   hasSize(df.fullItemDAO.getItemIds().size() - SUBSET_DROP_SIZE));
+    }
+
+    private static class DAOFetcher {
+        private final ItemDAO activeItemDAO;
+        private final ItemDAO fullItemDAO;
+
+        @Inject
+        public DAOFetcher(ItemDAO items, PrefetchingItemDAO allItems) {
+            activeItemDAO = items;
+            fullItemDAO = allItems;
+        }
+    }
+}

--- a/lenskit-integration-tests/src/test/java/org/grouplens/lenskit/test/ML100KTestSuiteTest.java
+++ b/lenskit-integration-tests/src/test/java/org/grouplens/lenskit/test/ML100KTestSuiteTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.grouplens.lenskit.test;
 
 import org.grouplens.lenskit.RecommenderBuildException;


### PR DESCRIPTION
This adds integration tests with subsetted item DAOs, doing the testing for #671. Right now, it just tests that nothing fails w/ an exception (e.g. invalid key or index out of bounds) if we build a recommender with a subset of the items in its `ItemDAO`.

I'm somewhat surprised that these tests didn't shake out any fresh errors.