### PR TITLE
Build fixes for Java 6

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -62,6 +62,9 @@ allprojects {
     tasks.withType(Javadoc) { task ->
         task.configure {
             dependsOn ':build-support:jar'
+            onlyIf {
+                JavaVersion.current() >= JavaVersion.VERSION_1_7
+            }
             options {
                 tags 'todo:a:To Do:', 'review:a:Review:'
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/inject/GraphtUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/inject/GraphtUtils.java
@@ -118,8 +118,9 @@ public final class GraphtUtils {
                 return input != null && input.getSatisfaction() instanceof PlaceholderSatisfaction;
             }
         };
+        Predicate<DAGNode<Component, ?>> nodePredicate = DAGNode.labelMatches(isPlaceholder);
         return FluentIterable.from(graph.getReachableNodes())
-                             .filter(DAGNode.labelMatches(isPlaceholder))
+                             .filter(nodePredicate)
                              .toSet();
     }
 


### PR DESCRIPTION
This includes some build fixes for Java 6:

- fix a build problem on Apple's Java 6.
- disable JavaDoc builds on Java 6, they don't work for some reason.