### PR TITLE
Add a 'crossfold' command

### DIFF
--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
@@ -1,0 +1,190 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.cli;
+
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.grouplens.lenskit.data.event.Rating;
+import org.grouplens.lenskit.eval.EvalProject;
+import org.grouplens.lenskit.eval.TaskExecutionException;
+import org.grouplens.lenskit.eval.data.crossfold.CrossfoldMethod;
+import org.grouplens.lenskit.eval.data.crossfold.CrossfoldTask;
+import org.grouplens.lenskit.eval.data.crossfold.TimestampOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Pack ratings data into a rating file.
+ *
+ * @since 2.1
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+@CommandSpec(name = "crossfold", help = "crossfold a data set")
+public class Crossfold implements Command {
+    private final Logger logger = LoggerFactory.getLogger(Crossfold.class);
+    private final Namespace options;
+    private final InputData input;
+
+    public Crossfold(Namespace opts) {
+        options = opts;
+        input = new InputData(null, opts);
+    }
+
+    public String getDelimiter() {
+        return options.get("delimiter");
+    }
+
+    @Override
+    public void execute() throws IOException, TaskExecutionException {
+        logger.info("packing ratings from {}", input);
+        logger.debug("using delimiter {}", getDelimiter());
+        CrossfoldTask task = new CrossfoldTask();
+        task.setProject(new EvalProject(System.getProperties()));
+        task.setSource(input.getSource());
+        task.setForce(true);
+
+        Integer k = options.get("partitions");
+        if (k != null) {
+            task.setPartitions(k);
+        }
+
+        String dir = options.getString("output_dir");
+        boolean pack = options.getBoolean("pack_output");
+        String suffix = pack ? "pack" : "csv";
+        task.setTrain(dir + "/" + "train.%d." + suffix);
+        task.setTest(dir + "/" + "test.%d." + suffix);
+        if (pack) {
+            task.setWriteTimestamps(options.getBoolean("use_timestamps"));
+        }
+
+        CrossfoldMethod method = options.get("crossfold_mode");
+        if (method == null) {
+            method = CrossfoldMethod.PARTITION_USERS;
+        }
+        task.setMethod(method);
+        Integer n;
+        Double v;
+        switch (method) {
+        case PARTITION_RATINGS:
+        case PARTITION_USERS: {
+            if ((n = options.get("holdout_count")) != null) {
+                task.setHoldout(n);
+            } else if ((n = options.get("retain_count")) != null) {
+                task.setRetain(n);
+            } else if ((v = options.get("holdout_fraction")) != null) {
+                task.setHoldoutFraction(v);
+            }
+            if ("timestamp".equals(options.getString("order"))) {
+                task.setOrder(new TimestampOrder<Rating>());
+            }
+            break;
+        }
+        case SAMPLE_USERS:
+            n = options.get("sample_size");
+            if (n != null) {
+                task.setSampleSize(n);
+            }
+            break;
+        }
+
+        task.execute();
+    }
+
+    public static void configureArguments(Subparser parser) {
+        parser.addArgument("-o", "--output-dir")
+              .dest("output_dir")
+              .type(String.class)
+              .metavar("DIR")
+              .setDefault("crossfold")
+              .help("write splits to DIR");
+        parser.addArgument("--pack-output")
+              .action(Arguments.storeTrue())
+              .dest("pack_output")
+              .help("store output in binary-packed files");
+        parser.addArgument("--no-timestamps")
+              .action(Arguments.storeFalse())
+              .setDefault(true)
+              .dest("use_timestamps")
+              .help("don't include timestamps in output");
+
+        parser.addArgument("-k", "--partition-count")
+              .metavar("K")
+              .dest("partitions")
+              .type(Integer.class)
+              .help("Fold into K partitions.");
+
+        MutuallyExclusiveGroup mode =
+                parser.addMutuallyExclusiveGroup("crossfold mode")
+                      .description("Partitioning mode for the crossfolder.");
+        mode.addArgument("--partition-users")
+            .dest("crossfold_mode")
+            .action(Arguments.storeConst())
+            .setConst(CrossfoldMethod.PARTITION_USERS)
+            .help("Partition users into K partitions (the default)");
+        mode.addArgument("--partition-ratings")
+            .dest("crossfold_mode")
+            .action(Arguments.storeConst())
+            .setConst(CrossfoldMethod.PARTITION_RATINGS)
+            .help("Partition ratings into K partitions");
+        mode.addArgument("--sample-users")
+            .dest("crossfold_mode")
+            .action(Arguments.storeConst())
+            .setConst(CrossfoldMethod.SAMPLE_USERS)
+            .help("Generate K samples of users");
+
+        parser.addArgument("--sample-size")
+              .dest("sample_size")
+              .metavar("N")
+              .type(Integer.class)
+              .help("Sample N users per partition (for --sample-users)");
+
+        MutuallyExclusiveGroup userOpts =
+                parser.addMutuallyExclusiveGroup("user crossfolding options")
+                      .description("Options controlling user-based crossfolding (--sample-users, --partition-users)");
+        userOpts.addArgument("--holdout-fraction")
+                .metavar("F")
+                .type(Double.class)
+                .dest("holdout_fraction")
+                .help("Hold out a fraction of each user's ratings (for user-based folding)");
+        userOpts.addArgument("--holdout-count")
+                .metavar("N")
+                .type(Integer.class)
+                .dest("holdout_count")
+                .help("Hold out N ratings per user for testing.");
+        userOpts.addArgument("--retain-count")
+                .metavar("N")
+                .type(Integer.class)
+                .dest("retain_count")
+                .help("Retain N training ratings per user.");
+
+        parser.addArgument("--timestamp-order")
+                .dest("order")
+                .setConst("timestamp")
+                .action(Arguments.storeConst())
+                .help("Test on latest ratings from each user, not random.");
+
+        InputData.configureArguments(parser);
+    }
+}

--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
@@ -75,6 +75,7 @@ public class Crossfold implements Command {
         String suffix = pack ? "pack" : "csv";
         task.setTrain(dir + "/" + "train.%d." + suffix);
         task.setTest(dir + "/" + "test.%d." + suffix);
+        task.setSpec(dir + "/" + "split.%d.json");
         if (pack) {
             task.setWriteTimestamps(options.getBoolean("use_timestamps"));
         }

--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
@@ -84,7 +84,7 @@ public class Crossfold implements Command {
 
         DataSource src = input.getSource();
         if (src != null) {
-            overrides.put("source", src.toSpecification());
+            overrides.put("source", src.toSpecification(SpecificationContext.create()));
         }
         Integer k = options.get("partitions");
         if (k != null) {

--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Crossfold.java
@@ -219,6 +219,7 @@ public class Crossfold implements Command {
         parser.addArgument("spec")
               .type(File.class)
               .metavar("SPEC")
+              .nargs("?")
               .help("Read crossfold configuration from SPEC (command line opts will override)");
 
         InputData.configureArguments(parser);

--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Main.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/Main.java
@@ -55,6 +55,7 @@ public class Main {
         registerClass(subparsers, Predict.class);
         registerClass(subparsers, Graph.class);
         registerClass(subparsers, GlobalRecommend.class);
+        registerClass(subparsers, Crossfold.class);
 
         try {
             Namespace options = parser.parseArgs(args);

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/pref/PreferenceDomain.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/pref/PreferenceDomain.java
@@ -28,6 +28,7 @@ import org.grouplens.grapht.annotation.DefaultNull;
 import org.grouplens.lenskit.core.Shareable;
 import org.grouplens.lenskit.specs.SpecHandlerInterface;
 import org.grouplens.lenskit.specs.Specifiable;
+import org.grouplens.lenskit.specs.SpecificationContext;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.VectorEntry;
 
@@ -186,7 +187,7 @@ public final class PreferenceDomain implements Serializable, Specifiable {
 
     @Nonnull
     @Override
-    public Map<String, Object> toSpecification() {
+    public Map<String, Object> toSpecification(SpecificationContext context) {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("minimum", minimum);
         bld.put("maximum", maximum);

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/pref/PreferenceDomain.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/pref/PreferenceDomain.java
@@ -21,16 +21,19 @@
 package org.grouplens.lenskit.data.pref;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.grouplens.grapht.annotation.DefaultNull;
 import org.grouplens.lenskit.core.Shareable;
 import org.grouplens.lenskit.specs.SpecHandlerInterface;
+import org.grouplens.lenskit.specs.Specifiable;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.VectorEntry;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,7 +45,7 @@ import java.util.regex.Pattern;
 @Shareable
 @DefaultNull
 @SpecHandlerInterface(PreferenceDomainBuilder.class)
-public final class PreferenceDomain implements Serializable {
+public final class PreferenceDomain implements Serializable, Specifiable {
     public static final long serialVersionUID = 1L;
 
     private final double minimum;
@@ -146,7 +149,7 @@ public final class PreferenceDomain implements Serializable {
     @Override
     public String toString() {
         String str = String.format("[%f,%f]", minimum, maximum);
-        if (!Double.isNaN(precision)) {
+        if (precision > 0) {
             str += String.format("/%f", precision);
         }
         return str;
@@ -179,6 +182,18 @@ public final class PreferenceDomain implements Serializable {
         } else {
             return false;
         }
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> toSpecification() {
+        ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
+        bld.put("minimum", minimum);
+        bld.put("maximum", maximum);
+        if (precision > 0) {
+            bld.put("precision", precision);
+        }
+        return bld.build();
     }
 
     private static Pattern specRE =

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/pref/PreferenceDomainBuilder.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/pref/PreferenceDomainBuilder.java
@@ -127,7 +127,7 @@ public class PreferenceDomainBuilder implements Builder<PreferenceDomain>, SpecH
         if (cfg.hasPath("precision")) {
             setPrecision(cfg.getDouble("precision"));
         } else {
-            setPrecision(Double.NaN);
+            setPrecision(0);
         }
         return build();
     }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/DataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/DataSource.java
@@ -24,6 +24,7 @@ import org.grouplens.lenskit.core.LenskitConfiguration;
 import org.grouplens.lenskit.data.dao.*;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
 import org.grouplens.lenskit.specs.SpecHandlerInterface;
+import org.grouplens.lenskit.specs.Specifiable;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +35,7 @@ import javax.annotation.Nullable;
  * @since 2.2
  */
 @SpecHandlerInterface(DataSourceSpecHandler.class)
-public interface DataSource {
+public interface DataSource extends Specifiable {
     /**
      * Get the data source name.
      *

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/GenericDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/GenericDataSource.java
@@ -22,6 +22,7 @@ package org.grouplens.lenskit.data.source;
 
 import org.grouplens.lenskit.data.dao.EventDAO;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
+import org.grouplens.lenskit.specs.SpecificationContext;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
@@ -70,7 +71,7 @@ public class GenericDataSource extends AbstractDataSource {
 
     @Nonnull
     @Override
-    public Map<String, Object> toSpecification() {
+    public Map<String, Object> toSpecification(SpecificationContext context) {
         throw new UnsupportedOperationException("generic data sources cannot be specified");
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/GenericDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/GenericDataSource.java
@@ -23,6 +23,9 @@ package org.grouplens.lenskit.data.source;
 import org.grouplens.lenskit.data.dao.EventDAO;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
 
+import javax.annotation.Nonnull;
+import java.util.Map;
+
 /**
  * Generic data source backed by a single DAO object, implementing at least {@link EventDAO}.  If
  * the object implements other DAO interfaces, it is used to provide those; otherwise, they are
@@ -65,4 +68,9 @@ public class GenericDataSource extends AbstractDataSource {
         return 0;
     }
 
+    @Nonnull
+    @Override
+    public Map<String, Object> toSpecification() {
+        throw new UnsupportedOperationException("generic data sources cannot be specified");
+    }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
@@ -26,6 +26,7 @@ import org.grouplens.lenskit.core.LenskitConfiguration;
 import org.grouplens.lenskit.data.dao.*;
 import org.grouplens.lenskit.data.dao.packed.BinaryRatingDAO;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
+import org.grouplens.lenskit.specs.SpecificationContext;
 import org.grouplens.lenskit.util.MoreSuppliers;
 import org.grouplens.lenskit.util.io.Describable;
 import org.grouplens.lenskit.util.io.DescriptionWriter;
@@ -116,13 +117,13 @@ public class PackedDataSource implements DataSource {
 
     @Nonnull
     @Override
-    public Map<String, Object> toSpecification() {
+    public Map<String, Object> toSpecification(SpecificationContext context) {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "pack")
            .put("name", getName())
-           .put("file", file.toURI().toString());
+           .put("file", context.relativize(file));
         if (domain != null) {
-            bld.put("domain", domain.toSpecification());
+            bld.put("domain", domain.toSpecification(context));
         }
         return bld.build();
     }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
@@ -119,6 +119,7 @@ public class PackedDataSource implements DataSource {
     public Map<String, Object> toSpecification() {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "pack")
+           .put("name", getName())
            .put("file", file.getPath());
         if (domain != null) {
             bld.put("domain", domain.toSpecification());

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
@@ -21,6 +21,7 @@
 package org.grouplens.lenskit.data.source;
 
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
 import org.grouplens.lenskit.core.LenskitConfiguration;
 import org.grouplens.lenskit.data.dao.*;
 import org.grouplens.lenskit.data.dao.packed.BinaryRatingDAO;
@@ -29,9 +30,11 @@ import org.grouplens.lenskit.util.MoreSuppliers;
 import org.grouplens.lenskit.util.io.Describable;
 import org.grouplens.lenskit.util.io.DescriptionWriter;
 
+import javax.annotation.Nonnull;
 import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Data source backed by a packed rating file.
@@ -109,6 +112,18 @@ public class PackedDataSource implements DataSource {
         if (dom != null) {
             config.addComponent(dom);
         }
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> toSpecification() {
+        ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
+        bld.put("type", "pack")
+           .put("file", file.getPath());
+        if (domain != null) {
+            bld.put("domain", domain.toSpecification());
+        }
+        return bld.build();
     }
 
     private class DAOProvider implements Provider<BinaryRatingDAO>, Describable {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
@@ -120,7 +120,7 @@ public class PackedDataSource implements DataSource {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "pack")
            .put("name", getName())
-           .put("file", file.getPath());
+           .put("file", file.toURI().toString());
         if (domain != null) {
             bld.put("domain", domain.toSpecification());
         }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandler.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandler.java
@@ -26,9 +26,6 @@ import org.grouplens.lenskit.data.pref.PreferenceDomain;
 import org.grouplens.lenskit.specs.SpecificationContext;
 import org.grouplens.lenskit.specs.SpecificationException;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-
 /**
  * Configurator for packed sources.  Example configuration:
  *
@@ -62,17 +59,7 @@ public class PackedDataSourceSpecHandler implements DataSourceSpecHandler {
         }
 
         String file = cfg.getString("file");
-        URI uri = ctx.getBaseURI().resolve(file);
-        if (uri.isAbsolute()) {
-            try {
-                // FIXME This doesn't really work
-                bld.setFile(uri.toURL().getFile());
-            } catch (MalformedURLException e) {
-                throw new SpecificationException(e);
-            }
-        } else {
-            bld.setFile(uri.toString());
-        }
+        bld.setFile(ctx.resolveFile(file));
 
         return bld.build();
     }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandler.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandler.java
@@ -53,6 +53,9 @@ public class PackedDataSourceSpecHandler implements DataSourceSpecHandler {
     @Override
     public DataSource buildFromSpec(SpecificationContext ctx, Config cfg) throws SpecificationException {
         PackedDataSourceBuilder bld = new PackedDataSourceBuilder();
+        if (cfg.hasPath("name")) {
+            bld.setName(cfg.getString("name"));
+        }
 
         if (cfg.hasPath("domain")) {
             bld.setDomain(ctx.build(PreferenceDomain.class, cfg.getConfig("domain")));

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
@@ -20,17 +20,18 @@
  */
 package org.grouplens.lenskit.data.source;
 
+import com.google.common.collect.ImmutableMap;
 import org.grouplens.grapht.util.Providers;
 import org.grouplens.lenskit.data.dao.*;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
-import org.grouplens.lenskit.data.text.CSVFileItemNameDAOProvider;
-import org.grouplens.lenskit.data.text.EventFormat;
+import org.grouplens.lenskit.data.text.*;
 import org.grouplens.lenskit.data.text.SimpleFileItemDAOProvider;
-import org.grouplens.lenskit.data.text.TextEventDAO;
 import org.grouplens.lenskit.util.io.CompressionMode;
 
+import javax.annotation.Nonnull;
 import javax.inject.Provider;
 import java.io.File;
+import java.util.Map;
 
 /**
  * Data source backed by a CSV file.  Use {@link CSVDataSourceBuilder} to configure and build one
@@ -129,5 +130,23 @@ public class TextDataSource extends AbstractDataSource {
            .append(getName())
            .append(")");
         return str.toString();
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> toSpecification() {
+        ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
+        bld.put("type", "text")
+           .put("file", sourceFile.getPath());
+        if (format instanceof DelimitedColumnEventFormat) {
+            DelimitedColumnEventFormat cf = (DelimitedColumnEventFormat) format;
+            bld.put("delimiter", cf.getDelimiter());
+            // FIXME Serialize columns
+            logger.warn("cannot serialize columns, assuming default");
+        }
+        if (domain != null) {
+            bld.put("domain", domain.toSpecification());
+        }
+        return bld.build();
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
@@ -138,7 +138,7 @@ public class TextDataSource extends AbstractDataSource {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "text")
            .put("name", getName())
-           .put("file", sourceFile.getPath());
+           .put("file", sourceFile.toURI().toString());
         // FIXME Handle item name DAO
         if (format instanceof DelimitedColumnEventFormat) {
             DelimitedColumnEventFormat cf = (DelimitedColumnEventFormat) format;

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
@@ -137,7 +137,7 @@ public class TextDataSource extends AbstractDataSource {
     public Map<String, Object> toSpecification() {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "text")
-           .put("name", name)
+           .put("name", getName())
            .put("file", sourceFile.getPath());
         // FIXME Handle item name DAO
         if (format instanceof DelimitedColumnEventFormat) {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
@@ -137,7 +137,9 @@ public class TextDataSource extends AbstractDataSource {
     public Map<String, Object> toSpecification() {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "text")
+           .put("name", name)
            .put("file", sourceFile.getPath());
+        // FIXME Handle item name DAO
         if (format instanceof DelimitedColumnEventFormat) {
             DelimitedColumnEventFormat cf = (DelimitedColumnEventFormat) format;
             bld.put("delimiter", cf.getDelimiter());

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSource.java
@@ -26,6 +26,7 @@ import org.grouplens.lenskit.data.dao.*;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
 import org.grouplens.lenskit.data.text.*;
 import org.grouplens.lenskit.data.text.SimpleFileItemDAOProvider;
+import org.grouplens.lenskit.specs.SpecificationContext;
 import org.grouplens.lenskit.util.io.CompressionMode;
 
 import javax.annotation.Nonnull;
@@ -134,11 +135,11 @@ public class TextDataSource extends AbstractDataSource {
 
     @Nonnull
     @Override
-    public Map<String, Object> toSpecification() {
+    public Map<String, Object> toSpecification(SpecificationContext context) {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         bld.put("type", "text")
            .put("name", getName())
-           .put("file", sourceFile.toURI().toString());
+           .put("file", context.relativize(sourceFile));
         // FIXME Handle item name DAO
         if (format instanceof DelimitedColumnEventFormat) {
             DelimitedColumnEventFormat cf = (DelimitedColumnEventFormat) format;
@@ -147,7 +148,7 @@ public class TextDataSource extends AbstractDataSource {
             logger.warn("cannot serialize columns, assuming default");
         }
         if (domain != null) {
-            bld.put("domain", domain.toSpecification());
+            bld.put("domain", domain.toSpecification(context));
         }
         return bld.build();
     }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSourceSpecHandler.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSourceSpecHandler.java
@@ -72,8 +72,8 @@ public class TextDataSourceSpecHandler implements DataSourceSpecHandler {
             bld.setDomain(ctx.build(PreferenceDomain.class, cfg.getConfig("domain")));
         }
 
-        String file = cfg.getString("file");
-        URI uri = ctx.getBaseURI().resolve(file);
+        String path = cfg.getString("file");
+        URI uri = ctx.getBaseURI().resolve(path);
         if (uri.isAbsolute()) {
             try {
                 // FIXME This doesn't really work

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSourceSpecHandler.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSourceSpecHandler.java
@@ -59,6 +59,9 @@ public class TextDataSourceSpecHandler implements DataSourceSpecHandler {
         CSVDataSourceBuilder bld = new CSVDataSourceBuilder();
 
         bld.setDelimiter(",");
+        if (cfg.hasPath("name")) {
+            bld.setName(cfg.getString("name"));
+        }
         if (cfg.hasPath("delimiter")) {
             bld.setDelimiter(cfg.getString("delimiter"));
         } else if (cfg.getString("type").equalsIgnoreCase("tsv")) {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSourceSpecHandler.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/TextDataSourceSpecHandler.java
@@ -27,8 +27,6 @@ import org.grouplens.lenskit.data.pref.PreferenceDomain;
 import org.grouplens.lenskit.specs.SpecificationContext;
 import org.grouplens.lenskit.specs.SpecificationException;
 
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.util.Set;
 
 /**
@@ -73,17 +71,7 @@ public class TextDataSourceSpecHandler implements DataSourceSpecHandler {
         }
 
         String path = cfg.getString("file");
-        URI uri = ctx.getBaseURI().resolve(path);
-        if (uri.isAbsolute()) {
-            try {
-                // FIXME This doesn't really work
-                bld.setFile(uri.toURL().getFile());
-            } catch (MalformedURLException e) {
-                throw new SpecificationException(e);
-            }
-        } else {
-            bld.setFile(uri.toString());
-        }
+        bld.setFile(ctx.resolveFile(path));
 
         return bld.build();
     }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/specs/Specifiable.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/specs/Specifiable.java
@@ -1,0 +1,40 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.specs;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * Interface allowing an object to produce a specification to recreate itself.
+ */
+public interface Specifiable {
+    /**
+     * Create a specification for this object.  The return value should be a JSON-like structure,
+     * such that wrapping it in {@link com.typesafe.config.ConfigFactory#parseMap(java.util.Map)}
+     * and passing it to {@link SpecificationContext#build(Class, com.typesafe.config.Config)} will
+     * result in an equivalent object.
+     *
+     * @return A specification for this object.
+     */
+    @Nonnull
+    Map<String,Object> toSpecification();
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/specs/Specifiable.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/specs/Specifiable.java
@@ -34,7 +34,8 @@ public interface Specifiable {
      * result in an equivalent object.
      *
      * @return A specification for this object.
+     * @param context The context for generating the specification.
      */
     @Nonnull
-    Map<String,Object> toSpecification();
+    Map<String,Object> toSpecification(SpecificationContext context);
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/specs/SpecificationContext.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/specs/SpecificationContext.java
@@ -152,6 +152,21 @@ public class SpecificationContext {
     }
 
     /**
+     * Relativize a file against the base URI, if present; if no base URI is provided, then the
+     * file's absolute path is used.
+     * @param file The file to relativize.
+     * @return The relative path string.
+     */
+    public String relativize(File file) {
+        URI fileURI = file.toURI();
+        if (baseURI == null) {
+            return fileURI.toString();
+        } else {
+            return baseURI.relativize(fileURI).toString();
+        }
+    }
+
+    /**
      * Configure an object using a specification and a particular spec handler.
      * @param specClass The specification handler interface, defining the kind of object to
      *                  configure.  If it is a concrete instantiable class, then the class is used

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandlerTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandlerTest.groovy
@@ -35,12 +35,14 @@ class PackedDataSourceSpecHandlerTest extends GroovyTestCase {
     @Test
     public void testConfigurePack() {
         def cfg = MiscBuilders.configObj {
+            name "hackem-muche"
             type "pack"
             file "ratings.pack"
         }
         def src = context.build(DataSource, cfg)
         assertThat src, instanceOf(PackedDataSource)
         src = src as PackedDataSource
+        assertThat src.name, equalTo("hackem-muche")
         assertThat src.file.name, equalTo("ratings.pack")
     }
 

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandlerTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandlerTest.groovy
@@ -53,7 +53,7 @@ class PackedDataSourceSpecHandlerTest extends GroovyTestCase {
             file "ratings.pack"
         }
         def orig = context.build(DataSource, cfg)
-        def spec = ConfigFactory.parseMap(orig.toSpecification())
+        def spec = ConfigFactory.parseMap(orig.toSpecification(SpecificationContext.create()))
         def src = context.build(DataSource, spec)
         assertThat src, instanceOf(PackedDataSource)
         src = src as PackedDataSource

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandlerTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/PackedDataSourceSpecHandlerTest.groovy
@@ -20,9 +20,14 @@
  */
 package org.grouplens.lenskit.data.source
 
+import com.typesafe.config.ConfigFactory
 import org.grouplens.lenskit.specs.SpecificationContext
 import org.grouplens.lenskit.util.test.MiscBuilders
 import org.junit.Test
+
+import static org.hamcrest.Matchers.equalTo
+import static org.hamcrest.Matchers.instanceOf
+import static org.junit.Assert.assertThat
 
 class PackedDataSourceSpecHandlerTest extends GroovyTestCase {
     private final def context = SpecificationContext.create()
@@ -34,8 +39,22 @@ class PackedDataSourceSpecHandlerTest extends GroovyTestCase {
             file "ratings.pack"
         }
         def src = context.build(DataSource, cfg)
-        org.junit.Assert.assertThat src, org.hamcrest.Matchers.instanceOf(PackedDataSource)
+        assertThat src, instanceOf(PackedDataSource)
         src = src as PackedDataSource
-        org.junit.Assert.assertThat src.file.name, org.hamcrest.Matchers.equalTo("ratings.pack")
+        assertThat src.file.name, equalTo("ratings.pack")
+    }
+
+    @Test
+    public void testRoundTrip() {
+        def cfg = MiscBuilders.configObj {
+            type "pack"
+            file "ratings.pack"
+        }
+        def orig = context.build(DataSource, cfg)
+        def spec = ConfigFactory.parseMap(orig.toSpecification())
+        def src = context.build(DataSource, spec)
+        assertThat src, instanceOf(PackedDataSource)
+        src = src as PackedDataSource
+        assertThat src.file.name, equalTo("ratings.pack")
     }
 }

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/TextDataSourceSpecHandlerTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/TextDataSourceSpecHandlerTest.groovy
@@ -92,7 +92,7 @@ class TextDataSourceSpecHandlerTest {
     public void testRoundTrip() {
         def src = SpecificationContext.buildWithHandler(DataSourceSpecHandler,
                                                         getClass().getResource("csvsource.conf").toURI())
-        def spec = ConfigFactory.parseMap(src.toSpecification())
+        def spec = ConfigFactory.parseMap(src.toSpecification(SpecificationContext.create()))
         def s2 = SpecificationContext.create().build(DataSource, spec);
         assertThat(s2, instanceOf(TextDataSource))
         s2 = s2 as TextDataSource

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/TextDataSourceSpecHandlerTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/TextDataSourceSpecHandlerTest.groovy
@@ -35,12 +35,14 @@ class TextDataSourceSpecHandlerTest {
     @Test
     public void testCSVFile() {
         def cfg = MiscBuilders.configObj {
+            name "wombats"
             type "csv"
             file "ratings.csv"
         }
         def src = context.build(DataSource, cfg)
         assertThat src, instanceOf(TextDataSource)
         src = src as TextDataSource
+        assertThat src.name, equalTo("wombats")
         assertThat src.format.delimiter, equalTo(",")
         assertThat src.file.name, equalTo("ratings.csv")
         assertThat src.domain, nullValue()

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/TextDataSourceSpecHandlerTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/data/source/TextDataSourceSpecHandlerTest.groovy
@@ -20,6 +20,7 @@
  */
 package org.grouplens.lenskit.data.source
 
+import com.typesafe.config.ConfigFactory
 import org.grouplens.lenskit.data.pref.PreferenceDomain
 import org.grouplens.lenskit.specs.SpecificationContext
 import org.grouplens.lenskit.util.test.MiscBuilders
@@ -83,5 +84,18 @@ class TextDataSourceSpecHandlerTest {
         assertThat src.format.delimiter, equalTo("::")
         assertThat src.file.name, equalTo("ratings.dat")
         assertThat src.domain, equalTo(PreferenceDomain.fromString("[1.0,5.0]/1.0"))
+    }
+
+    @Test
+    public void testRoundTrip() {
+        def src = SpecificationContext.buildWithHandler(DataSourceSpecHandler,
+                                                        getClass().getResource("csvsource.conf").toURI())
+        def spec = ConfigFactory.parseMap(src.toSpecification())
+        def s2 = SpecificationContext.create().build(DataSource, spec);
+        assertThat(s2, instanceOf(TextDataSource))
+        s2 = s2 as TextDataSource
+        assertThat s2.format.delimiter, equalTo("::")
+        assertThat s2.file.name, equalTo("ratings.dat")
+        assertThat s2.domain, equalTo(PreferenceDomain.fromString("[1.0,5.0]/1.0"))
     }
 }

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/specs/SpecificationContextTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/specs/SpecificationContextTest.groovy
@@ -54,6 +54,21 @@ class SpecificationContextTest {
     }
 
     @Test
+    public void testRelativize() {
+        def base = new File(".").absoluteFile.toURI()
+        def context = SpecificationContext.create(base)
+        def path = context.relativize(new File("wombat"))
+        assertThat path, equalTo("wombat")
+    }
+
+    @Test
+    public void testRelativizeDefault() {
+        def context = SpecificationContext.create()
+        def path = context.relativize(new File("wombat").absoluteFile)
+        assertThat path, equalTo(new File("wombat").absoluteFile.toURI().toString())
+    }
+
+    @Test
     public void testEmpty() {
         def context = SpecificationContext.create()
         def spec = MiscBuilders.configObj {

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/specs/SpecificationContextTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/specs/SpecificationContextTest.groovy
@@ -34,7 +34,10 @@ class SpecificationContextTest {
         def context = SpecificationContext.create(base)
         def uri = context.resolve("wombat")
         assertThat uri, equalTo(new File("foo/wombat").absoluteFile.toURI())
-        assertThat context.resolve("/foo"), equalTo(new File("/foo").absoluteFile.toURI())
+        // let's also test that an absolute path resolves absolutely
+        File foo = new File("/foo");
+        assertThat(context.resolve(foo.absoluteFile.toURI().getPath()),
+                equalTo(foo.absoluteFile.toURI()))
     }
 
     @Test
@@ -42,7 +45,9 @@ class SpecificationContextTest {
         def context = SpecificationContext.create()
         def uri = context.resolve("wombat")
         assertThat uri, equalTo(new File("wombat").absoluteFile.toURI())
-        assertThat context.resolve("/foo"), equalTo(new File("/foo").absoluteFile.toURI())
+        File foo = new File("/foo");
+        assertThat(context.resolve(foo.absoluteFile.toURI().getPath()),
+                equalTo(foo.absoluteFile.toURI()))
     }
 
     @Test

--- a/lenskit-core/src/test/groovy/org/grouplens/lenskit/specs/SpecificationContextTest.groovy
+++ b/lenskit-core/src/test/groovy/org/grouplens/lenskit/specs/SpecificationContextTest.groovy
@@ -29,6 +29,31 @@ import static org.junit.Assert.assertThat
 
 class SpecificationContextTest {
     @Test
+    public void testResolveToBase() {
+        def base = new File("foo/bar").absoluteFile.toURI()
+        def context = SpecificationContext.create(base)
+        def uri = context.resolve("wombat")
+        assertThat uri, equalTo(new File("foo/wombat").absoluteFile.toURI())
+        assertThat context.resolve("/foo"), equalTo(new File("/foo").absoluteFile.toURI())
+    }
+
+    @Test
+    public void testResolveToDefault() {
+        def context = SpecificationContext.create()
+        def uri = context.resolve("wombat")
+        assertThat uri, equalTo(new File("wombat").absoluteFile.toURI())
+        assertThat context.resolve("/foo"), equalTo(new File("/foo").absoluteFile.toURI())
+    }
+
+    @Test
+    public void testResolveFile() {
+        def base = new File("foo/bar").absoluteFile.toURI()
+        def context = SpecificationContext.create(base)
+        def file = context.resolveFile("wombat")
+        assertThat file, equalTo(new File("foo/wombat").absoluteFile)
+    }
+
+    @Test
     public void testEmpty() {
         def context = SpecificationContext.create()
         def spec = MiscBuilders.configObj {

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/data/pref/PreferenceDomainBuilderTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/data/pref/PreferenceDomainBuilderTest.java
@@ -20,7 +20,13 @@
  */
 package org.grouplens.lenskit.data.pref;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.grouplens.lenskit.specs.SpecificationContext;
+import org.grouplens.lenskit.specs.SpecificationException;
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -71,5 +77,19 @@ public class PreferenceDomainBuilderTest {
         assertThat(dom.getMinimum(), equalTo(1.0));
         assertThat(dom.getMaximum(), equalTo(5.0));
         assertThat(dom.getPrecision(), equalTo(0.5));
+    }
+
+    @Test
+    public void testSpecRoundTrip() throws SpecificationException {
+        PreferenceDomainBuilder bld = new PreferenceDomainBuilder();
+        bld.setMinimum(1.0)
+           .setMaximum(5)
+           .setPrecision(0.5);
+        PreferenceDomain dom = bld.build();
+        Map<String,Object> spec = dom.toSpecification();
+        Config config = ConfigFactory.parseMap(spec);
+        PreferenceDomain dom2 = SpecificationContext.create()
+                                                    .build(PreferenceDomain.class, config);
+        assertThat(dom2, equalTo(dom));
     }
 }

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/data/pref/PreferenceDomainBuilderTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/data/pref/PreferenceDomainBuilderTest.java
@@ -86,7 +86,7 @@ public class PreferenceDomainBuilderTest {
            .setMaximum(5)
            .setPrecision(0.5);
         PreferenceDomain dom = bld.build();
-        Map<String,Object> spec = dom.toSpecification();
+        Map<String,Object> spec = dom.toSpecification(SpecificationContext.create());
         Config config = ConfigFactory.parseMap(spec);
         PreferenceDomain dom2 = SpecificationContext.create()
                                                     .build(PreferenceDomain.class, config);

--- a/lenskit-eval/build.gradle
+++ b/lenskit-eval/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
     compile group: 'org.apache.ant', name: 'ant', version: '1.8.4'
     compile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
+    compile(group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1') {
+        exclude module: 'junit'
+    }
     compileOnly group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc2'
 
     application group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldSpecHandler.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldSpecHandler.java
@@ -1,0 +1,104 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.eval.data.crossfold;
+
+import com.typesafe.config.Config;
+import org.grouplens.lenskit.data.event.Rating;
+import org.grouplens.lenskit.data.source.DataSource;
+import org.grouplens.lenskit.specs.SpecHandler;
+import org.grouplens.lenskit.specs.SpecificationContext;
+import org.grouplens.lenskit.specs.SpecificationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Specification handler to configure a crossfold task from a specification.
+ */
+public class CrossfoldSpecHandler implements SpecHandler<CrossfoldTask> {
+    private static final Logger logger = LoggerFactory.getLogger(CrossfoldSpecHandler.class);
+
+    public boolean handlesType(String type) {
+        return "crossfold".equals(type);
+    }
+
+    @Override
+    public CrossfoldTask buildFromSpec(SpecificationContext context, Config cfg) throws SpecificationException {
+        CrossfoldTask task = new CrossfoldTask();
+        if (cfg.hasPath("name")) {
+            task.setName(cfg.getString("name"));
+        }
+        task.setSource(context.build(DataSource.class, cfg.getConfig("source")));
+        if (cfg.hasPath("partitions")) {
+            task.setPartitions(cfg.getInt("partitions"));
+        }
+
+        if (cfg.hasPath("holdout")) {
+            // TODO Make CrossfoldTask take holdout objects
+            task.setHoldout(cfg.getInt("holdout"));
+            if (cfg.hasPath("holdoutFraction")) {
+                logger.warn("holdout and holdoutFraction specified, using holdout");
+            }
+            if (cfg.hasPath("retain")) {
+                logger.warn("holdout and retain specified, using holdout");
+            }
+        } else if (cfg.hasPath("holdoutFraction")) {
+            task.setHoldoutFraction(cfg.getDouble("holdoutFraction"));
+            if (cfg.hasPath("retain")) {
+                logger.warn("holdoutFraction and retain specified, using holdout");
+            }
+        } else if (cfg.hasPath("retain")) {
+            task.setRetain(cfg.getInt("retain"));
+        }
+
+        if (cfg.hasPath("order")) {
+            String order = cfg.getString("order");
+            if (order.equalsIgnoreCase("random")) {
+                task.setOrder(new RandomOrder<Rating>());
+            } else if (order.equalsIgnoreCase("timestamp")) {
+                task.setOrder(new TimestampOrder<Rating>());
+            } else {
+                throw new SpecificationException("invalid order " + order + " for crossfold");
+            }
+        }
+
+        if (cfg.hasPath("useTimestamps")) {
+            task.setWriteTimestamps(cfg.getBoolean("useTimestamps"));
+        }
+
+        if (cfg.hasPath("outputDir")) {
+            // TODO Make CrossfoldTask use an output directory
+            String dir = cfg.getString("outputDir");
+            boolean pack = cfg.hasPath("packOutput") && cfg.getBoolean("packOutput");
+            String suffix = pack ? "pack" : "csv";
+            task.setTrain(dir + "/train.%d." + suffix);
+            task.setTest(dir + "/test.%d." + suffix);
+            task.setSpec(dir + "/split.%d.json");
+        } else {
+            logger.warn("no output directory specified for crossfold {}", task.getName());
+        }
+
+        if (cfg.hasPath("isolate")) {
+            task.setIsolate(cfg.getBoolean("isolate"));
+        }
+
+        return task;
+    }
+}

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldTask.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldTask.java
@@ -44,6 +44,7 @@ import org.grouplens.lenskit.eval.data.RatingWriters;
 import org.grouplens.lenskit.eval.data.traintest.GenericTTDataBuilder;
 import org.grouplens.lenskit.eval.data.traintest.TTDataSet;
 import org.grouplens.lenskit.specs.SpecHandlerInterface;
+import org.grouplens.lenskit.specs.SpecificationContext;
 import org.grouplens.lenskit.util.io.UpToDateChecker;
 import org.grouplens.lenskit.util.table.writer.TableWriter;
 import org.json.simple.JSONValue;
@@ -470,7 +471,8 @@ public class CrossfoldTask extends AbstractTask<List<TTDataSet>> {
             assert dataSets.size() == partitionCount;
             for (int i = 0; i < partitionCount; i++) {
                 File file = new File(String.format(specFilePattern, i));
-                String json = JSONValue.toJSONString(dataSets.get(i).toSpecification());
+                SpecificationContext ctx = SpecificationContext.create(file.toURI());
+                String json = JSONValue.toJSONString(dataSets.get(i).toSpecification(ctx));
                 Files.write(json, file, Charset.forName("UTF-8"));
             }
         }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldTask.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/crossfold/CrossfoldTask.java
@@ -43,6 +43,7 @@ import org.grouplens.lenskit.eval.data.RatingWriter;
 import org.grouplens.lenskit.eval.data.RatingWriters;
 import org.grouplens.lenskit.eval.data.traintest.GenericTTDataBuilder;
 import org.grouplens.lenskit.eval.data.traintest.TTDataSet;
+import org.grouplens.lenskit.specs.SpecHandlerInterface;
 import org.grouplens.lenskit.util.io.UpToDateChecker;
 import org.grouplens.lenskit.util.table.writer.TableWriter;
 import org.json.simple.JSONValue;
@@ -59,6 +60,7 @@ import java.util.*;
  *
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
+@SpecHandlerInterface(CrossfoldSpecHandler.class)
 public class CrossfoldTask extends AbstractTask<List<TTDataSet>> {
     private static final Logger logger = LoggerFactory.getLogger(CrossfoldTask.class);
 

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataSet.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataSet.java
@@ -27,6 +27,7 @@ import org.grouplens.lenskit.data.dao.EventDAO;
 import org.grouplens.lenskit.data.dao.UserDAO;
 import org.grouplens.lenskit.data.dao.UserListUserDAO;
 import org.grouplens.lenskit.data.source.DataSource;
+import org.grouplens.lenskit.specs.SpecificationContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -141,13 +142,13 @@ public class GenericTTDataSet implements TTDataSet {
 
     @Nonnull
     @Override
-    public Map<String, Object> toSpecification() {
+    public Map<String, Object> toSpecification(SpecificationContext context) {
         ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
         if (name != null) {
             bld.put("name", name);
         }
-        bld.put("train", trainData.toSpecification());
-        bld.put("test", testData.toSpecification());
+        bld.put("train", trainData.toSpecification(context));
+        bld.put("test", testData.toSpecification(context));
         if (queryData != null) {
             bld.put("query", queryData);
         }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataSet.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/GenericTTDataSet.java
@@ -139,6 +139,21 @@ public class GenericTTDataSet implements TTDataSet {
         return String.format("{TTDataSet %s}", name);
     }
 
+    @Nonnull
+    @Override
+    public Map<String, Object> toSpecification() {
+        ImmutableMap.Builder<String,Object> bld = ImmutableMap.builder();
+        if (name != null) {
+            bld.put("name", name);
+        }
+        bld.put("train", trainData.toSpecification());
+        bld.put("test", testData.toSpecification());
+        if (queryData != null) {
+            bld.put("query", queryData);
+        }
+        return bld.build();
+    }
+
     /**
      * Create a new generic train-test data set builder.
      * @return The new builder.

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/TTDataSet.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/data/traintest/TTDataSet.java
@@ -25,6 +25,7 @@ import org.grouplens.lenskit.data.dao.EventDAO;
 import org.grouplens.lenskit.data.source.DataSource;
 import org.grouplens.lenskit.eval.script.BuiltBy;
 import org.grouplens.lenskit.specs.SpecHandlerInterface;
+import org.grouplens.lenskit.specs.Specifiable;
 
 import java.util.Map;
 import java.util.UUID;
@@ -37,7 +38,7 @@ import java.util.UUID;
  */
 @BuiltBy(GenericTTDataBuilder.class)
 @SpecHandlerInterface(GenericTTSpecHandler.class)
-public interface TTDataSet {
+public interface TTDataSet extends Specifiable {
     /**
      * Get the data set name.
      *

--- a/lenskit-eval/src/test/groovy/org/grouplens/lenskit/eval/data/crossfold/CrossfoldConfigTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/grouplens/lenskit/eval/data/crossfold/CrossfoldConfigTest.groovy
@@ -132,7 +132,7 @@ class CrossfoldConfigTest extends ConfigTestBase {
             name "tempRatings"
             source {
                 type "text"
-                file file.toURI()
+                file file.toURI().toString()
                 delimiter ","
             }
             partitions 10

--- a/lenskit-eval/src/test/groovy/org/grouplens/lenskit/eval/data/crossfold/CrossfoldConfigTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/grouplens/lenskit/eval/data/crossfold/CrossfoldConfigTest.groovy
@@ -132,7 +132,7 @@ class CrossfoldConfigTest extends ConfigTestBase {
             name "tempRatings"
             source {
                 type "text"
-                file file.absolutePath
+                file file.toURI()
                 delimiter ","
             }
             partitions 10

--- a/lenskit-integration-tests/gradle-tests.gradle
+++ b/lenskit-integration-tests/gradle-tests.gradle
@@ -48,20 +48,17 @@ def ift = task makeTestRepo {
 task gradleTests
 check.dependsOn gradleTests
 
-file('src/it/gradle').eachDir { dir ->
-    def fname = dir.name
+file('src/it/gradle').eachDir { testDir ->
+    def fname = testDir.name
     def tname = fname.replaceAll(/(?:^|-)(.)/) { m -> m[1].toUpperCase() }
     def workDir = file("build/gradle-tests/$fname")
-    task("prep$tname", type: Copy) {
-        onlyIf {
-            !file("$dir/ignore").exists()
-        }
-        from dir
-        into workDir
-    }
 
     task("test$tname", type: GradleBuild) {
-        dependsOn "prep$tname", makeTestRepo, fetchData
+        dependsOn makeTestRepo, fetchData
+        inputs.dir testDir
+        inputs.dir "$buildDir/test-repo"
+        outputs.dir workDir
+
         startParameter.projectProperties = [
                 testRepoURI: uri("$buildDir/test-repo"),
                 lenskitVersion: project.version,
@@ -72,10 +69,14 @@ file('src/it/gradle').eachDir { dir ->
         tasks = ['check']
 
         onlyIf {
-            workDir.exists()
+            !file("$testDir/ignore").exists()
         }
         doFirst {
-            println "running gradle build for $dir"
+            copy {
+                from testDir
+                into workDir
+            }
+            println "running gradle build for $testDir"
         }
     }
 

--- a/lenskit-integration-tests/src/it/gradle/cli-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/cli-crossfold/build.gradle
@@ -1,0 +1,54 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.hamcrest:hamcrest-library:1.3"
+    }
+}
+apply plugin: 'java'
+
+
+import static org.hamcrest.MatcherAssert.*
+import static org.hamcrest.Matchers.*
+
+repositories {
+    maven {
+        url testRepoURI
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
+    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
+}
+
+task crossfold(type: JavaExec) {
+    dependsOn classes
+    classpath configurations.runtime
+    inputs.file 'predictor.groovy'
+    inputs.file ratingsFile
+    outputs.dir 'split'
+
+    main 'org.grouplens.lenskit.cli.Main'
+    args 'crossfold'
+    args "--tsv-file", ratingsFile
+    args '--no-timestamps'
+    args '-k', 10
+    args '--pack-output'
+    args '-o', file('split')
+}
+
+check {
+    dependsOn crossfold
+    doLast {
+        def dir = file('split')
+        assertThat dir.exists(), equalTo(true)
+        for (int i = 0; i < 10; i++) {
+            assertThat file("split/split.${i}.json").exists(), equalTo(true)
+            assertThat file("split/train.${i}.pack").exists(), equalTo(true)
+            assertThat file("split/test.${i}.pack").exists(), equalTo(true)
+        }
+    }
+}

--- a/lenskit-integration-tests/src/it/gradle/crossfold-from-spec/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/crossfold-from-spec/build.gradle
@@ -1,0 +1,51 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.hamcrest:hamcrest-library:1.3"
+    }
+}
+apply plugin: 'java'
+
+
+import static org.hamcrest.MatcherAssert.*
+import static org.hamcrest.Matchers.*
+
+repositories {
+    maven {
+        url testRepoURI
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
+    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
+}
+
+task crossfold(type: JavaExec) {
+    dependsOn classes
+    classpath configurations.runtime
+    inputs.file 'predictor.groovy'
+    inputs.file ratingsFile
+    outputs.dir 'split'
+
+    main 'org.grouplens.lenskit.cli.Main'
+    args 'crossfold'
+    args '--tsv-file', ratingsFile
+    args 'crossfold.conf'
+}
+
+check {
+    dependsOn crossfold
+    doLast {
+        def dir = file('split')
+        assertThat dir.exists(), equalTo(true)
+        for (int i = 0; i < 10; i++) {
+            assertThat file("split/split.${i}.json").exists(), equalTo(true)
+            assertThat file("split/train.${i}.pack").exists(), equalTo(true)
+            assertThat file("split/test.${i}.pack").exists(), equalTo(true)
+        }
+    }
+}

--- a/lenskit-integration-tests/src/it/gradle/crossfold-from-spec/crossfold.conf
+++ b/lenskit-integration-tests/src/it/gradle/crossfold-from-spec/crossfold.conf
@@ -1,0 +1,4 @@
+partitions: 10
+useTimestamps: false
+outputDir: split
+packOutput: true


### PR DESCRIPTION
This adds a `crossfold` command, that crossfolds a data set. It can read the crossfold configuration from a spec, or from command-line arguments. It writes out the data, along with spec files for the train-test data sets.

Unlike the `CrossfoldTask`, this command takes an output directory instead of arbitrary train/test patterns. This is easier to understand, I think.

In order for this to work, I added the `Specifiable` interface for the spec system, that produces a spec from an object.