### PR TITLE
Replace closers with try-with-resources

### DIFF
--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/PackRatings.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/PackRatings.java
@@ -20,7 +20,6 @@
  */
 package org.grouplens.lenskit.cli;
 
-import com.google.common.io.Closer;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -78,16 +77,10 @@ public class PackRatings implements Command {
             flags.add(BinaryFormatFlag.TIMESTAMPS);
         }
         logger.info("packing to {} with flags {}", getOutputFile(), flags);
-        Closer closer = Closer.create();
-        try {
-            BinaryRatingPacker packer = closer.register(BinaryRatingPacker.open(getOutputFile(), flags));
-            Cursor<Rating> ratings = closer.register(dao.streamEvents(Rating.class));
+        try (BinaryRatingPacker packer = BinaryRatingPacker.open(getOutputFile(), flags);
+        Cursor<Rating> ratings = dao.streamEvents(Rating.class)) {
             packer.writeRatings(ratings);
             logger.info("packed {} ratings", packer.getRatingCount());
-        } catch (Throwable th) { // NOSONAR using a closer
-            throw closer.rethrow(th);
-        } finally {
-            closer.close();
         }
     }
 

--- a/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/TrainModel.java
+++ b/lenskit-cli/src/main/java/org/grouplens/lenskit/cli/TrainModel.java
@@ -21,7 +21,6 @@
 package org.grouplens.lenskit.cli;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.io.Closer;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.grouplens.lenskit.RecommenderBuildException;
@@ -78,16 +77,11 @@ public class TrainModel implements Command {
         logger.info("built model in {}", timer);
         File output = getOutputFile();
         CompressionMode comp = CompressionMode.autodetect(output);
+
         logger.info("writing model to {}", output);
-        Closer closer = Closer.create();
-        try {
-            OutputStream stream = closer.register(new FileOutputStream(output));
-            stream = closer.register(comp.wrapOutput(stream));
+        try (OutputStream raw = new FileOutputStream(output);
+             OutputStream stream = comp.wrapOutput(raw)) {
             engine.write(stream);
-        } catch (Throwable th) { // NOSONAR using a closer
-            throw closer.rethrow(th);
-        } finally {
-            closer.close();
         }
     }
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/ClassDirectory.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/ClassDirectory.java
@@ -22,7 +22,6 @@ package org.grouplens.lenskit.util;
 
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
-import com.google.common.io.Closer;
 
 import java.io.*;
 import java.net.URL;
@@ -55,11 +54,9 @@ public class ClassDirectory {
             Enumeration<URL> urls = loader.getResources("META-INF/classes.lst");
             while (urls.hasMoreElements()) {
                 URL url = urls.nextElement();
-                Closer closer = Closer.create();
-                try {
-                    InputStream stream = closer.register(url.openStream());
-                    Reader rdr = closer.register(new InputStreamReader(stream, "UTF-8"));
-                    BufferedReader buf = closer.register(new BufferedReader(rdr));
+                try (InputStream stream = url.openStream();
+                     Reader rdr = new InputStreamReader(stream);
+                     BufferedReader buf = new BufferedReader(rdr)) {
                     String line = buf.readLine();
                     while (line != null) {
                         int idx = line.lastIndexOf('.');
@@ -70,10 +67,6 @@ public class ClassDirectory {
                         }
                         line = buf.readLine();
                     }
-                } catch (Throwable th) { // NOSONAR using a closer
-                    throw closer.rethrow(th);
-                } finally {
-                    closer.close();
                 }
             }
         } catch (IOException e) {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/LineCursor.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/LineCursor.java
@@ -21,7 +21,6 @@
 package org.grouplens.lenskit.util;
 
 import com.google.common.base.Throwables;
-import com.google.common.io.Closer;
 import com.google.common.io.Files;
 import org.grouplens.lenskit.cursors.AbstractPollingCursor;
 import org.grouplens.lenskit.util.io.CompressionMode;

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/io/LKFileUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/io/LKFileUtils.java
@@ -22,7 +22,6 @@ package org.grouplens.lenskit.util.io;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
-import com.google.common.io.Closer;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.slf4j.Logger;
@@ -209,10 +208,8 @@ public final class LKFileUtils {
      */
     public static LongList readIdList(File file) throws IOException {
         LongList items = new LongArrayList();
-        Closer closer = Closer.create();
-        try {
-            FileReader fread = closer.register(new FileReader(file));
-            BufferedReader buf = closer.register(new BufferedReader(fread));
+        try (FileReader fread = new FileReader(file);
+             BufferedReader buf = new BufferedReader(fread)) {
             String line;
             int lno = 0;
             while ((line = buf.readLine()) != null) {
@@ -228,10 +225,6 @@ public final class LKFileUtils {
                 }
                 items.add(item);
             }
-        } catch (Throwable th) { // NOSONAR using a closer
-            throw closer.rethrow(th);
-        } finally {
-            closer.close();
         }
         return items;
     }

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/data/dao/packed/BinaryRatingDAOTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/data/dao/packed/BinaryRatingDAOTest.java
@@ -22,7 +22,6 @@ package org.grouplens.lenskit.data.dao.packed;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.io.Closer;
 import org.apache.commons.lang3.SerializationUtils;
 import org.grouplens.lenskit.cursors.Cursors;
 import org.grouplens.lenskit.data.dao.SortOrder;
@@ -182,15 +181,9 @@ public class BinaryRatingDAOTest {
         }
 
         ByteBuffer buffer;
-        Closer closer = Closer.create();
-        try {
-            FileInputStream istr = new FileInputStream(file);
+        try (FileInputStream istr = new FileInputStream(file)) {
             FileChannel chan = istr.getChannel();
             buffer = chan.map(FileChannel.MapMode.READ_ONLY, 0, chan.size());
-        } catch (Throwable th) {
-            throw closer.rethrow(th);
-        } finally {
-            closer.close();
         }
 
         BinaryRatingDAO dao = BinaryRatingDAO.fromBuffer(buffer);

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/graph/GraphDumper.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/graph/GraphDumper.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.common.io.Closer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.grouplens.grapht.Component;
 import org.grouplens.grapht.Dependency;
@@ -337,10 +336,9 @@ public class GraphDumper {
         RecommenderInstantiator instantiator = RecommenderInstantiator.create(graph);
         DAGNode<Component, Dependency> unshared = instantiator.simulate();
         logger.debug("unshared graph has {} nodes", unshared.getReachableNodes().size());
-        Closer close = Closer.create();
-        try {
-            Writer writer = close.register(new FileWriter(graphvizFile));
-            GraphWriter gw = close.register(new GraphWriter(writer));
+        try (Writer writer = new FileWriter(graphvizFile);
+             GraphWriter gw = new GraphWriter(writer)) {
+
             GraphDumper dumper = new GraphDumper(graph, unshared.getReachableNodes(), gw);
             logger.debug("writing root node");
             String rid = dumper.setRoot(graph);
@@ -358,10 +356,6 @@ public class GraphDumper {
             }
             // and we're done
             dumper.finish();
-        } catch (Throwable th) { // NOSONAR using a closer
-            throw close.rethrow(th);
-        } finally {
-            close.close();
         }
     }
 


### PR DESCRIPTION
In the LensKit 3.0 cleanups, this replaces a bunch of `Closer` usages with the Java 7 try-with-resources syntax, so we can get rid of catching `Throwable` in those cases.