### PR TITLE
Item-item speedups

### DIFF
--- a/lenskit-data-structures/src/main/java/org/grouplens/lenskit/vectors/SparseVector.java
+++ b/lenskit-data-structures/src/main/java/org/grouplens/lenskit/vectors/SparseVector.java
@@ -520,6 +520,26 @@ public abstract class SparseVector implements Iterable<VectorEntry>, Serializabl
     }
 
     /**
+     * Compute and return the sum of the absolute values of the vector.
+     *
+     * @return the sum of the vector's absolute values
+     */
+    public double sumAbs() {
+        double result = 0;
+        if (keys.isCompletelySet()) {
+            for (int i = keys.domainSize() - 1; i >= 0; i--) {
+                result += Math.abs(values[i]);
+            }
+        } else {
+            DoubleIterator iter = values().iterator();
+            while (iter.hasNext()) {
+                result += Math.abs(iter.nextDouble());
+            }
+        }
+        return result;
+    }
+
+    /**
      * Compute and return the mean of the vector's values.
      *
      * @return the mean of the vector

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/DefaultItemScoreAlgorithm.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/DefaultItemScoreAlgorithm.java
@@ -20,7 +20,6 @@
  */
 package org.grouplens.lenskit.knn.item;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import org.grouplens.lenskit.knn.MinNeighbors;
 import org.grouplens.lenskit.knn.NeighborhoodSize;
@@ -33,7 +32,6 @@ import org.grouplens.lenskit.vectors.VectorEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 
@@ -60,7 +58,6 @@ public class DefaultItemScoreAlgorithm implements ItemScoreAlgorithm {
     public void scoreItems(ItemItemModel model, SparseVector userData,
                            MutableSparseVector scores,
                            NeighborhoodScorer scorer) {
-        Predicate<ScoredId> usable = new VectorKeyPredicate(userData);
         List<ScoredId> neighbors = Lists.newArrayListWithCapacity(neighborhoodSize);
 
         // Create a channel for recording the neighborhoodsize
@@ -73,7 +70,7 @@ public class DefaultItemScoreAlgorithm implements ItemScoreAlgorithm {
             for (ScoredId nbr: model.getNeighbors(item)) {
                 if (userData.containsKey(nbr.getId())) {
                     neighbors.add(nbr);
-                    if (neighbors.size() >= neighborhoodSize) {
+                    if (neighborhoodSize > 0 && neighbors.size() >= neighborhoodSize) {
                         break;
                     }
                 }
@@ -95,18 +92,6 @@ public class DefaultItemScoreAlgorithm implements ItemScoreAlgorithm {
             }
 
             sizeChannel.set(e, neighbors.size());
-        }
-    }
-
-    private static class VectorKeyPredicate implements Predicate<ScoredId> {
-        private final SparseVector vector;
-
-        public VectorKeyPredicate(SparseVector v) {
-            vector = v;
-        }
-        @Override
-        public boolean apply(@Nullable ScoredId input) {
-            return input != null && vector.containsKey(input.getId());
         }
     }
 }

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/NeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/NeighborhoodScorer.java
@@ -50,5 +50,5 @@ public interface NeighborhoodScorer {
      * @return An accumulated score from the neighbors, or {@code null} if
      *         no score could be computed.
      */
-    ScoredId score(long item, Iterable<ScoredId> neighbors, SparseVector scores);
+    ScoredId score(long item, SparseVector neighbors, SparseVector scores);
 }

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
@@ -37,17 +37,11 @@ public class SimilaritySumNeighborhoodScorer implements NeighborhoodScorer, Seri
     private static final long serialVersionUID = 1L;
 
     @Override
-    public ScoredId score(long item, Iterable<ScoredId> neighbors, SparseVector scores) {
-        double sum = 0;
-        int n = 0;
-        for (ScoredId id: neighbors) {
-            sum += id.getScore();
-            n++;
-        }
-        if (n > 0) {
-            return ScoredIds.create(item, sum);
-        } else {
+    public ScoredId score(long item, SparseVector neighbors, SparseVector scores) {
+        if (neighbors.size() == 0) {
             return null;
+        } else {
+            return ScoredIds.create(item, neighbors.sum());
         }
     }
 

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/model/ItemItemModel.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/model/ItemItemModel.java
@@ -22,10 +22,9 @@ package org.grouplens.lenskit.knn.item.model;
 
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
 import org.grouplens.grapht.annotation.DefaultImplementation;
-import org.grouplens.lenskit.scored.ScoredId;
+import org.grouplens.lenskit.vectors.SparseVector;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 /**
  * Item-item similarity model. It makes available the similarities
@@ -53,8 +52,8 @@ public interface ItemItemModel {
      *
      * @param item The item to get the neighborhood for.
      * @return The row of the similarity matrix. If the item is unknown, an empty
-     *         list is returned.  The list is sorted in nonincreasing order by score.
+     *         vector is returned.
      */
     @Nonnull
-    List<ScoredId> getNeighbors(long item);
+    SparseVector getNeighbors(long item);
 }

--- a/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/model/ItemItemModelBuilder.java
+++ b/lenskit-knn/src/main/java/org/grouplens/lenskit/knn/item/model/ItemItemModelBuilder.java
@@ -26,11 +26,11 @@ import org.grouplens.lenskit.core.Transient;
 import org.grouplens.lenskit.knn.item.ItemSimilarity;
 import org.grouplens.lenskit.knn.item.ItemSimilarityThreshold;
 import org.grouplens.lenskit.knn.item.ModelSize;
-import org.grouplens.lenskit.scored.ScoredId;
 import org.grouplens.lenskit.transform.threshold.Threshold;
 import org.grouplens.lenskit.util.ScoredItemAccumulator;
 import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
 import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
+import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -144,10 +143,10 @@ public class ItemItemModelBuilder implements Provider<ItemItemModel> {
         return rows;
     }
 
-    private Long2ObjectMap<List<ScoredId>> finishRows(Long2ObjectMap<ScoredItemAccumulator> rows) {
-        Long2ObjectMap<List<ScoredId>> results = new Long2ObjectOpenHashMap<List<ScoredId>>(rows.size());
+    private Long2ObjectMap<ImmutableSparseVector> finishRows(Long2ObjectMap<ScoredItemAccumulator> rows) {
+        Long2ObjectMap<ImmutableSparseVector> results = new Long2ObjectOpenHashMap<ImmutableSparseVector>(rows.size());
         for (Long2ObjectMap.Entry<ScoredItemAccumulator> e: rows.long2ObjectEntrySet()) {
-            results.put(e.getLongKey(), e.getValue().finish());
+            results.put(e.getLongKey(), e.getValue().finishVector().freeze());
         }
         return results;
     }

--- a/lenskit-knn/src/test/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorerTest.java
+++ b/lenskit-knn/src/test/java/org/grouplens/lenskit/knn/item/SimilaritySumNeighborhoodScorerTest.java
@@ -20,18 +20,13 @@
  */
 package org.grouplens.lenskit.knn.item;
 
-import com.google.common.collect.Lists;
-import org.grouplens.lenskit.scored.ScoredId;
-import org.grouplens.lenskit.scored.ScoredIds;
+import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -50,35 +45,33 @@ public class SimilaritySumNeighborhoodScorerTest {
 
     @Test
     public void testEmpty() {
-        List<ScoredId> nbrs = Collections.emptyList();
+        SparseVector nbrs = ImmutableSparseVector.empty();
         SparseVector scores = MutableSparseVector.create();
         assertThat(scorer.score(42, nbrs, scores), nullValue());
     }
 
     @Test
     public void testEmptyNbrs() {
-        List<ScoredId> nbrs = Collections.emptyList();
+        SparseVector nbrs = ImmutableSparseVector.empty();
         SparseVector scores = MutableSparseVector.wrap(new long[]{5}, new double[]{3.7}).freeze();
         assertThat(scorer.score(42, nbrs, scores), nullValue());
     }
 
     @Test
     public void testOneNbr() {
-        List<ScoredId> nbrs = Lists.newArrayList(ScoredIds.newBuilder()
-                                                          .setId(5)
-                                                          .setScore(1.0)
-                                                          .build());
+        MutableSparseVector nbrs = MutableSparseVector.create(5);
+        nbrs.set(5, 1.0);
         SparseVector scores = MutableSparseVector.wrap(new long[]{5}, new double[]{3.7}).freeze();
         assertThat(scorer.score(42, nbrs, scores).getScore(), closeTo(1.0));
     }
 
     @Test
     public void testMultipleNeighbors() {
-        List<ScoredId> nbrs = ScoredIds.newListBuilder()
-                                       .add(2, 0.5)
-                                       .add(5, 1.0)
-                                       .add(7, 0.92)
-                                       .build();
+        MutableSparseVector nbrs = MutableSparseVector.create(2, 5, 7);
+        nbrs.set(2, 0.5);
+        nbrs.set(5, 1.0);
+        nbrs.set(7, 0.92);
+
         long[] scoreKeys = {2, 3, 5, 7};
         double[] scoreValues = {3.7, 4.2, 1.2, 7.8};
         SparseVector scores = MutableSparseVector.wrap(scoreKeys, scoreValues).freeze();


### PR DESCRIPTION
This greatly improves the item-item recommender's performance by using sparse vectors instead of lists of scored IDs for similarity matrices.