### PR TITLE
Make recommend and prediction output more consistent and configurable

### DIFF
--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/topn/TopNMetricBuilder.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/metrics/topn/TopNMetricBuilder.java
@@ -21,12 +21,11 @@
 package org.grouplens.lenskit.eval.metrics.topn;
 
 import org.apache.commons.lang3.builder.Builder;
-import org.grouplens.lenskit.eval.metrics.Metric;
 
 /**
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
-public abstract class TopNMetricBuilder<K extends Metric<?>> implements Builder<K> {
+public abstract class TopNMetricBuilder<K> implements Builder<K> {
     protected int listSize = 5;
     protected ItemSelector candidates = ItemSelectors.testItems();
     protected ItemSelector exclude = ItemSelectors.trainingItems();

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/MetricFactory.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/MetricFactory.java
@@ -48,6 +48,21 @@ public abstract class MetricFactory<T> {
         return new Preinstantiated<T>(m);
     }
 
+    /**
+     * Create a metric factory that wraps a class.  The class is instantiated immediately.
+     * @param m The metric class.
+     * @return A metric factory that returns {@code m}.
+     */
+    public static <T> MetricFactory<T> forMetricClass(Class<? extends Metric<T>> m) {
+        try {
+            return new Preinstantiated<T>(m.newInstance());
+        } catch (InstantiationException e) {
+            throw new RuntimeException("cannot instantiate " + m, e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("cannot instantiate " + m, e);
+        }
+    }
+
     private static class Preinstantiated<T> extends MetricFactory<T> {
         private final Metric<T> metric;
 

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/OutputPredictMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/OutputPredictMetric.java
@@ -175,6 +175,10 @@ public class OutputPredictMetric extends AbstractMetric<OutputPredictMetric.Cont
             file = f;
         }
 
+        public void setFile(String fn) {
+            setFile(new File(fn));
+        }
+
         public void addChannel(Symbol chan, String col) {
             channels.add(Pair.of(chan, col));
         }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/OutputTopNMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/OutputTopNMetric.java
@@ -89,6 +89,7 @@ public class OutputTopNMetric extends AbstractMetric<OutputTopNMetric.Context, V
             try {
                 context.writer.writeRow(user.getUserId(), rec.getId(),
                                         counter, rec.getScore());
+                counter += 1;
             } catch (IOException e) {
                 throw Throwables.propagate(e);
             }

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/OutputTopNMetric.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/OutputTopNMetric.java
@@ -164,6 +164,10 @@ public class OutputTopNMetric extends AbstractMetric<OutputTopNMetric.Context, V
             file = f;
         }
 
+        public void setFile(String fn) {
+            setFile(new File(fn));
+        }
+
         @Override
         public Factory build() {
             if (file == null) {

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/SimpleEvaluator.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/SimpleEvaluator.java
@@ -252,14 +252,8 @@ public class SimpleEvaluator implements Callable<Table> {
      * @param metric The metric to be added.
      * @return Itself for  method chaining.
      */
-    public SimpleEvaluator addMetric(Class<? extends Metric<?>> metric) {
-        try {
-            result.addMetric(metric);
-        } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException(e);
-        } catch (InstantiationException e) {
-            throw new IllegalArgumentException(e);
-        }
+    public <T> SimpleEvaluator addMetric(Class<? extends Metric<T>> metric) {
+        result.addMetric(metric);
         return this;
     }
 

--- a/lenskit-eval/src/main/resources/META-INF/lenskit-eval/methods/predictions.properties
+++ b/lenskit-eval/src/main/resources/META-INF/lenskit-eval/methods/predictions.properties
@@ -1,0 +1,1 @@
+builder=org.grouplens.lenskit.eval.traintest.OutputPredictMetric$FactoryBuilder

--- a/lenskit-eval/src/main/resources/META-INF/lenskit-eval/methods/recommendations.properties
+++ b/lenskit-eval/src/main/resources/META-INF/lenskit-eval/methods/recommendations.properties
@@ -1,0 +1,1 @@
+builder=org.grouplens.lenskit.eval.traintest.OutputTopNMetric$FactoryBuilder

--- a/lenskit-integration-tests/src/it/eval/all-output-files/eval.groovy
+++ b/lenskit-integration-tests/src/it/eval/all-output-files/eval.groovy
@@ -19,16 +19,13 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+
 import org.grouplens.lenskit.ItemScorer
 import org.grouplens.lenskit.baseline.BaselineScorer
 import org.grouplens.lenskit.baseline.ItemMeanRatingItemScorer
 import org.grouplens.lenskit.baseline.UserMeanBaseline
 import org.grouplens.lenskit.baseline.UserMeanItemScorer
-import org.grouplens.lenskit.eval.metrics.predict.CoveragePredictMetric
-import org.grouplens.lenskit.eval.metrics.predict.HLUtilityPredictMetric
-import org.grouplens.lenskit.eval.metrics.predict.MAEPredictMetric
-import org.grouplens.lenskit.eval.metrics.predict.NDCGPredictMetric
-import org.grouplens.lenskit.eval.metrics.predict.RMSEPredictMetric
+import org.grouplens.lenskit.eval.metrics.predict.*
 import org.grouplens.lenskit.knn.item.ItemItemScorer
 import org.grouplens.lenskit.knn.item.ModelSize
 
@@ -66,9 +63,15 @@ trainTest {
     metric MAEPredictMetric
     metric NDCGPredictMetric
     metric HLUtilityPredictMetric
+    metric predictions {
+        file 'predictions.csv'
+    }
+    metric recommendations {
+        file 'recommendations.csv.gz'
+    }
 
     output 'results.csv'
     userOutput 'users.csv'
-    predictOutput 'predictions.csv'
-    recommendOutput 'recommendations.csv.gz'
+    predictOutput 'deprecated-predictions.csv'
+    recommendOutput 'deprecated-recommendations.csv.gz'
 }

--- a/lenskit-integration-tests/src/it/eval/all-output-files/verify.groovy
+++ b/lenskit-integration-tests/src/it/eval/all-output-files/verify.groovy
@@ -1,4 +1,4 @@
-    /*
+/*
  * LensKit, an open source recommender systems toolkit.
  * Copyright 2010-2014 Regents of the University of Minnesota and contributors
  * Work on LensKit has been funded by the National Science Foundation under
@@ -20,7 +20,6 @@
  */
 
 
-import org.grouplens.lenskit.knn.item.model.ItemItemModel
 import org.grouplens.lenskit.knn.item.model.SimilarityMatrixModel
 
 import java.util.zip.GZIPInputStream
@@ -28,7 +27,8 @@ import java.util.zip.GZIPInputStream
 import static org.grouplens.lenskit.util.test.ExtraMatchers.existingFile
 import static org.grouplens.lenskit.util.test.ExtraMatchers.hasLineCount
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.allOf
+import static org.hamcrest.Matchers.equalTo
 
 File resultsFile = new File(basedir, "results.csv")
 File userFile = new File(basedir, "users.csv")
@@ -44,6 +44,11 @@ assertThat("output file existence",
            predictFile, existingFile());
 assertThat("output file existence",
            recommendFile, existingFile());
+
+assertThat("output file existence",
+           new File(basedir, "deprecated-predictions.csv"), existingFile());
+assertThat("output file existence",
+           new File(basedir, "deprecated-recommendations.csv.gz"), existingFile());
 
 assertThat(new File(basedir, 'train.1.pack'),
            existingFile())


### PR DESCRIPTION
This reworks how recommendation and prediction output are configured.

They are now both metrics (`recommendations` and `predictions`, respectively). Metric factories can now be directly configured as metrics. You can also now have multiple recommendation outputs, with different list lengths, candidates, etc., addressing #613.