### PR TITLE
Switch to Pegdown doclet

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -52,12 +52,22 @@ task javadoc(type: Javadoc, group: 'build') {
 // Set up JavaDoc configuration
 allprojects {
     logger.info 'configuring JavaDoc for {}', name
+    dependencies {
+        support 'ch.raffael.pegdown-doclet:pegdown-doclet:1.1'
+    }
     tasks.withType(Javadoc) { task ->
         task.configure {
             onlyIf {
                 JavaVersion.current() >= JavaVersion.VERSION_1_7
             }
+            doFirst {
+                for (file in configurations.support) {
+                    options.docletpath file
+                }
+            }
             options {
+                doclet 'ch.raffael.doclets.pegdown.PegdownDoclet'
+
                 tags 'todo:a:To Do:', 'review:a:Review:'
 
                 tags "compat:pt:<a href=\"$webUrl/documentation/versioning/\">Compatibility</a>"

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/baseline/MeanDamping.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/baseline/MeanDamping.java
@@ -33,8 +33,8 @@ import java.lang.annotation.*;
  * The smoothing enabled by this parameter is based on <a
  * href="http://sifter.org/~simon/journal/20061211.html">FunkSVD</a>. The idea
  * is to bias item or user means towards the global mean based on how many items
- * or users are involved. So, if the global mean is \(\mu\) and smoothing \(\gamma\),
- * the mean of some values is \[\frac{\gamma\mu + \sum r}{\gamma + n}\]
+ * or users are involved. So, if the global mean is \\(\mu\\) and smoothing \\(\gamma\\),
+ * the mean of some values is \\[\frac{\gamma\mu + \sum r}{\gamma + n}\\]
  */
 @Documented
 @DefaultDouble(0.0)

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommender.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommender.java
@@ -34,12 +34,11 @@ import java.lang.annotation.Annotation;
  * with {@link LenskitRecommenderEngine} will produce this type of
  * recommender.
  *
- * <p>The {@link Recommender} interface will meet most needs, so most users can
+ * The {@link Recommender} interface will meet most needs, so most users can
  * ignore this class.  However, if you need to inspect internal components of a
  * recommender (e.g. extract the item-item similarity matrix), this class and its
  * {@link #get(Class)} method can be useful.
  *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @compat Public
  */
 public class LenskitRecommender implements Recommender {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommenderEngine.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommenderEngine.java
@@ -46,13 +46,17 @@ import java.io.*;
  * LensKit implementation of a recommender engine.  It uses containers set up by
  * the {@link LenskitConfiguration} to set up actual recommenders, and can build
  * multiple recommenders from the same model.
- * <p>If you just want to quick create a recommender for evaluation or testing,
- * consider using {@link LenskitRecommender#build(LenskitConfiguration)}.</p>
  *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * If you just want to quick create a recommender for evaluation or testing,
+ * consider using {@link LenskitRecommender#build(LenskitConfiguration)}.  For more
+ * control, use {@link LenskitRecommenderEngineBuilder}; to load a pre-built recommender
+ * engine, use {@link LenskitRecommenderEngineLoader}.
+ *
  * @compat Public
  * @see LenskitConfiguration
  * @see LenskitRecommender
+ * @see LenskitRecommenderEngineBuilder
+ * @see LenskitRecommenderEngineLoader
  */
 public final class LenskitRecommenderEngine implements RecommenderEngine {
     private static final Logger logger = LoggerFactory.getLogger(LenskitRecommenderEngine.class);


### PR DESCRIPTION
This adds support for the Pegdown doclet (#593), and starts to use it in a couple of files.

This will allow us to write JavaDoc in Markdown (with highlight.js), rather than HTML.