### PR TITLE
Create result set APIs

### DIFF
--- a/lenskit-api/src/main/java/org/lenskit/api/ItemRecommender.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemRecommender.java
@@ -62,7 +62,7 @@ public interface ItemRecommender {
      * @return The recommended items.
      * @see #recommend(long, int, Set, Set)
      */
-    ResultList<Result> recommend(long user);
+    ResultList recommend(long user);
 
     /**
      * Recommend up to <var>n</var> items for a user using the default exclude
@@ -73,7 +73,7 @@ public interface ItemRecommender {
      * @return The recommended items.
      * @see #recommend(long, int, Set, Set)
      */
-    ResultList<Result> recommend(long user, int n);
+    ResultList recommend(long user, int n);
 
     /**
      * Recommend all possible items for a user from a set of candidates using
@@ -85,7 +85,7 @@ public interface ItemRecommender {
      * @return The recommended items.
      * @see #recommend(long, int, Set, Set)
      */
-    ResultList<Result> recommend(long user, @Nullable Set<Long> candidates);
+    ResultList recommend(long user, @Nullable Set<Long> candidates);
 
     /**
      * Produce a set of recommendations for the user. This is the most general
@@ -107,7 +107,7 @@ public interface ItemRecommender {
      *         decreasing order of score. This is not a hard requirement — e.g.
      *         set recommenders are allowed to be more flexible.
      */
-    ResultList<Result> recommend(long user, int n, @Nullable Set<Long> candidates,
+    ResultList recommend(long user, int n, @Nullable Set<Long> candidates,
                                  @Nullable Set<Long> exclude);
 
     /**
@@ -128,6 +128,6 @@ public interface ItemRecommender {
      *         decreasing order of score. This is not a hard requirement — e.g.
      *         set recommenders are allowed to be more flexible.
      */
-    ResultList<? extends Result> recommendWithDetails(long user, int n, @Nullable Set<Long> candidates,
-                                                      @Nullable Set<Long> exclude);
+    ResultList recommendWithDetails(long user, int n, @Nullable Set<Long> candidates,
+                                    @Nullable Set<Long> exclude);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/ItemRecommender.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemRecommender.java
@@ -21,17 +21,16 @@
 package org.lenskit.api;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 
 /**
- * Interface for recommending items. Several methods are provided, of varying
- * generality.
+ * Interface for recommending items. This interface provides APIs for both basic (recommend for a given user)
+ * and complex (recommend at most *n* items from a given set to the user) recommendation tasks.
  *
- * The core idea of the recommend API is to recommend <i>n</i> items for a user,
+ * The core idea of the recommend API is to recommend *n* items for a user,
  * where the items recommended are taken from a set of candidate items and
- * further constrained by an exclude set of forbidden items. Items in the
- * candidate set but not in the exclude set are considered viable for
- * recommendation.
+ * further constrained by an exclude set of forbidden items.
  *
  * ## Candidate Items
  *
@@ -62,18 +61,19 @@ public interface ItemRecommender {
      * @return The recommended items.
      * @see #recommend(long, int, Set, Set)
      */
-    ResultList recommend(long user);
+    List<Long> recommend(long user);
 
     /**
-     * Recommend up to <var>n</var> items for a user using the default exclude
+     * Recommend up to `n` items for a user using the default exclude
      * set.
      *
      * @param user The user ID.
-     * @param n    The number of recommendations to return.
+     * @param n    The number of recommendations to return.  Negative values indicate no preference of recommendation
+     *             list size.
      * @return The recommended items.
      * @see #recommend(long, int, Set, Set)
      */
-    ResultList recommend(long user, int n);
+    List<Long> recommend(long user, int n);
 
     /**
      * Recommend all possible items for a user from a set of candidates using
@@ -85,7 +85,7 @@ public interface ItemRecommender {
      * @return The recommended items.
      * @see #recommend(long, int, Set, Set)
      */
-    ResultList recommend(long user, @Nullable Set<Long> candidates);
+    List<Long> recommend(long user, @Nullable Set<Long> candidates);
 
     /**
      * Produce a set of recommendations for the user. This is the most general
@@ -101,14 +101,10 @@ public interface ItemRecommender {
      *                   {@code null}, all items are considered candidates.
      * @param exclude    A set of items to be excluded. If {@code null}, a default
      *                   exclude set is used.
-     * @return A list of recommended items. If the recommender cannot assign
-     *         meaningful scores, the scores will be {@link Double#NaN}. For
-     *         most scoring recommenders, the items will be ordered in
-     *         decreasing order of score. This is not a hard requirement — e.g.
-     *         set recommenders are allowed to be more flexible.
+     * @return A list of recommended items.
      */
-    ResultList recommend(long user, int n, @Nullable Set<Long> candidates,
-                                 @Nullable Set<Long> exclude);
+    List<Long> recommend(long user, int n, @Nullable Set<Long> candidates,
+                         @Nullable Set<Long> exclude);
 
     /**
      * Produce a set of recommendations for the user with additional details. This method functions identically to

--- a/lenskit-api/src/main/java/org/lenskit/api/ItemRecommender.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemRecommender.java
@@ -1,0 +1,133 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+
+/**
+ * Interface for recommending items. Several methods are provided, of varying
+ * generality.
+ *
+ * The core idea of the recommend API is to recommend <i>n</i> items for a user,
+ * where the items recommended are taken from a set of candidate items and
+ * further constrained by an exclude set of forbidden items. Items in the
+ * candidate set but not in the exclude set are considered viable for
+ * recommendation.
+ *
+ * ## Candidate Items
+ *
+ * By default, the candidate set is the universe of all items the recommender
+ * knows about. The default exclude set is somewhat more subtle. Its exact
+ * definition varies across implementations, but will be the set of items the
+ * system believes the user will not be interested in by virtue of already
+ * having or knowing about them. For example, rating-based recommenders will
+ * exclude the items the user has rated, and purchase-based recommenders will
+ * typically exclude items the user has purchased. Some implementations may
+ * allow this to be configured. Client code always has the option of manually
+ * specifying the exclude set, however, so applications with particular needs in
+ * this respect can manually provide the sets they need respected.
+ *
+ * ## Ordering
+ *
+ * If the recommender has an opinion about the order in which recommendations should be displayed,
+ * the result set will present items in that order.  For many recommenders, this will be descending order
+ * by score; however, this interface does not guarantee a relationship between scores and ordering.
+ *
+ * @compat Public
+ */
+public interface ItemRecommender {
+    /**
+     * Recommend all possible items for a user using the default exclude set.
+     *
+     * @param user The user ID.
+     * @return The recommended items.
+     * @see #recommend(long, int, Set, Set)
+     */
+    ResultList<Result> recommend(long user);
+
+    /**
+     * Recommend up to <var>n</var> items for a user using the default exclude
+     * set.
+     *
+     * @param user The user ID.
+     * @param n    The number of recommendations to return.
+     * @return The recommended items.
+     * @see #recommend(long, int, Set, Set)
+     */
+    ResultList<Result> recommend(long user, int n);
+
+    /**
+     * Recommend all possible items for a user from a set of candidates using
+     * the default exclude set.
+     *
+     * @param user       The user ID.
+     * @param candidates The candidate set (can be null to represent the
+     *                   universe).
+     * @return The recommended items.
+     * @see #recommend(long, int, Set, Set)
+     */
+    ResultList<Result> recommend(long user, @Nullable Set<Long> candidates);
+
+    /**
+     * Produce a set of recommendations for the user. This is the most general
+     * recommendation method, allowing the recommendations to be constrained by
+     * both a candidate set and an exclude set. The exclude set is applied to
+     * the candidate set, so the final effective candidate set is
+     * <var>canditates</var> minus <var>exclude</var>.
+     *
+     * @param user       The user's ID
+     * @param n          The number of ratings to return. If negative, there is
+     *                   no specific recommendation list size requested.
+     * @param candidates A set of candidate items which can be recommended. If
+     *                   {@code null}, all items are considered candidates.
+     * @param exclude    A set of items to be excluded. If {@code null}, a default
+     *                   exclude set is used.
+     * @return A list of recommended items. If the recommender cannot assign
+     *         meaningful scores, the scores will be {@link Double#NaN}. For
+     *         most scoring recommenders, the items will be ordered in
+     *         decreasing order of score. This is not a hard requirement — e.g.
+     *         set recommenders are allowed to be more flexible.
+     */
+    ResultList<Result> recommend(long user, int n, @Nullable Set<Long> candidates,
+                                 @Nullable Set<Long> exclude);
+
+    /**
+     * Produce a set of recommendations for the user with additional details. This method functions identically to
+     * {@link #recommend(long, int, Set, Set)}, except that it may produce more detailed results. Implementations will
+     * return subclasses of {@link ResultList} that provide access to additional details about each recommendation.
+     *
+     * @param user       The user's ID
+     * @param n          The number of ratings to return. If negative, there is
+     *                   no specific recommendation list size requested.
+     * @param candidates A set of candidate items which can be recommended. If
+     *                   {@code null}, all items are considered candidates.
+     * @param exclude    A set of items to be excluded. If {@code null}, a default
+     *                   exclude set is used.
+     * @return A list of recommended items. If the recommender cannot assign
+     *         meaningful scores, the scores will be {@link Double#NaN}. For
+     *         most scoring recommenders, the items will be ordered in
+     *         decreasing order of score. This is not a hard requirement — e.g.
+     *         set recommenders are allowed to be more flexible.
+     */
+    ResultList<? extends Result> recommendWithDetails(long user, int n, @Nullable Set<Long> candidates,
+                                                      @Nullable Set<Long> exclude);
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
@@ -1,0 +1,63 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * Score items for users.  These scores can be predicted ratings, relevance
+ * scores, purchase probabilities, or any other real-valued score which can be
+ * assigned to an item for a particular user.
+ *
+ * @compat Public
+ */
+public interface ItemScorer {
+    /**
+     * Score a single item.
+     *
+     * @param user The user ID for whom to generate a score.
+     * @param item The item ID to score.
+     * @return The score, or `null` if no score can be generated.
+     */
+    Result score(long user, long item);
+
+    /**
+     * Score a collection of items.
+     *
+     * @param user  The user ID for whom to generate scores.
+     * @param items The item to score.
+     * @return The scores for the items. This result set may not contain all requested items.
+     */
+    @Nonnull
+    ResultMap<Result> score(long user, @Nonnull Collection<Long> items);
+
+    /**
+     * Score a collection of items and potentially return more details on the scores.
+     *
+     * @param user  The user ID for whom to generate scores.
+     * @param items The item to score.
+     * @return The scores for the items. This result set may not contain all requested items.  Implementations that
+     * support additional details will return a subclass of {@link ResultMap} that provides access to those details.
+     */
+    @Nonnull
+    ResultMap<? extends Result> scoreWithDetails(long user, @Nonnull Collection<Long> items);
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
@@ -22,6 +22,7 @@ package org.lenskit.api;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Score items for users.  These scores can be predicted ratings, relevance
@@ -48,7 +49,7 @@ public interface ItemScorer {
      * @return The scores for the items. This result set may not contain all requested items.
      */
     @Nonnull
-    ResultMap score(long user, @Nonnull Collection<Long> items);
+    Map<Long,Double> score(long user, @Nonnull Collection<Long> items);
 
     /**
      * Score a collection of items and potentially return more details on the scores.

--- a/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
@@ -28,7 +28,7 @@ import java.util.Collection;
  * scores, purchase probabilities, or any other real-valued score which can be
  * assigned to an item for a particular user.
  *
- * @compat Public
+ *  @compat Public
  */
 public interface ItemScorer {
     /**

--- a/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ItemScorer.java
@@ -48,7 +48,7 @@ public interface ItemScorer {
      * @return The scores for the items. This result set may not contain all requested items.
      */
     @Nonnull
-    ResultMap<Result> score(long user, @Nonnull Collection<Long> items);
+    ResultMap score(long user, @Nonnull Collection<Long> items);
 
     /**
      * Score a collection of items and potentially return more details on the scores.
@@ -59,5 +59,5 @@ public interface ItemScorer {
      * support additional details will return a subclass of {@link ResultMap} that provides access to those details.
      */
     @Nonnull
-    ResultMap<? extends Result> scoreWithDetails(long user, @Nonnull Collection<Long> items);
+    ResultMap scoreWithDetails(long user, @Nonnull Collection<Long> items);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/RatingPredictor.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/RatingPredictor.java
@@ -22,12 +22,14 @@ package org.lenskit.api;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Map;
 
 /**
- * Predict user ratings.  A rating predictor is like an {@link ItemScorer}, but its output will be
- * predicted ratings.
+ * Predict user ratings.  A rating predictor is like an {@link ItemScorer}, but its output is scaled or otherwise
+ * transformed for rating prediction.  An item score can be anything that meets the requirement 'higher is better';
+ * a rating prediction can be interpreted as an estimate of the user's expected rating, within the system's stated
+ * range of valid ratings.  Depending on the predictor used, rating predictions may also be quantized.
  *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @compat Public
  */
 public interface RatingPredictor {
@@ -50,7 +52,7 @@ public interface RatingPredictor {
      *         not contain all requested items.
      */
     @Nonnull
-    ResultMap predict(long user, @Nonnull Collection<Long> items);
+    Map<Long,Double> predict(long user, @Nonnull Collection<Long> items);
 
     /**
      * Predict the user's preference for a collection of items, potentially with additional details.

--- a/lenskit-api/src/main/java/org/lenskit/api/RatingPredictor.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/RatingPredictor.java
@@ -1,0 +1,65 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * Predict user ratings.  A rating predictor is like an {@link ItemScorer}, but its output will be
+ * predicted ratings.
+ *
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * @compat Public
+ */
+public interface RatingPredictor {
+    /**
+     * Predict a user's rating for a single item.
+     *
+     * @param user The user ID for whom to generate a prediction.
+     * @param item The item ID whose rating is to be predicted.
+     * @return The predicted preference, or {@link Double#NaN} if no preference can be
+     *         predicted.
+     */
+    Result predict(long user, long item);
+
+    /**
+     * Predict the user's preference for a collection of items.
+     *
+     * @param user  The user ID for whom to generate predicts.
+     * @param items The items to predict for.
+     * @return A mapping from item IDs to predicted preference. This mapping may
+     *         not contain all requested items.
+     */
+    @Nonnull
+    ResultMap<Result> predict(long user, @Nonnull Collection<Long> items);
+
+    /**
+     * Predict the user's preference for a collection of items, potentially with additional details.
+     *
+     * @param user  The user ID for whom to generate predicts.
+     * @param items The items to predict for.
+     * @return A mapping from item IDs to predicted preference. This mapping may
+     *         not contain all requested items.
+     */
+    @Nonnull
+    ResultMap<? extends Result> predictWithDetails(long user, @Nonnull Collection<Long> items);
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/RatingPredictor.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/RatingPredictor.java
@@ -50,7 +50,7 @@ public interface RatingPredictor {
      *         not contain all requested items.
      */
     @Nonnull
-    ResultMap<Result> predict(long user, @Nonnull Collection<Long> items);
+    ResultMap predict(long user, @Nonnull Collection<Long> items);
 
     /**
      * Predict the user's preference for a collection of items, potentially with additional details.
@@ -61,5 +61,5 @@ public interface RatingPredictor {
      *         not contain all requested items.
      */
     @Nonnull
-    ResultMap<? extends Result> predictWithDetails(long user, @Nonnull Collection<Long> items);
+    ResultMap predictWithDetails(long user, @Nonnull Collection<Long> items);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/Recommender.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Recommender.java
@@ -1,0 +1,65 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+import javax.annotation.Nullable;
+
+/**
+ * Main entry point for accessing recommender components.  A recommender object
+ * is effectively a recommender <i>session</i>: it is a per-thread or per-request
+ * object, likely connected to a database connection or persistence session, that
+ * needs to be closed when the client code is finished with it.
+ *
+ * <p>The various methods in this class return {@code null} if the corresponding
+ * operation is not supported by the underlying recommender configuration.  This
+ * ensures that, if you can actually get an object implementing a particular interface,
+ * you are guaranteed to be able to use it.
+ *
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * @compat Public
+ * @see RecommenderEngine
+ */
+public interface Recommender extends AutoCloseable {
+    /**
+     * Get the recommender's rating scorer.
+     *
+     * @return The rating predictor for this recommender configuration, or
+     *         {@code null} if rating prediction is not supported.
+     */
+    @Nullable
+    RatingPredictor getRatingPredictor();
+
+    /**
+     * Get the recommender's item recommender.
+     *
+     * @return The item recommender for this recommender configuration, or
+     *         {@code null} if item recommendation is not supported.
+     */
+    @Nullable
+    ItemRecommender getItemRecommender();
+
+    /**
+     * Close the recommender.  This closes underlying resources such as database collections. Components retrieved
+     * from the recommender cannot be used once the recommender is closed.
+     */
+    @Override
+    void close();
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/Recommender.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Recommender.java
@@ -28,12 +28,11 @@ import javax.annotation.Nullable;
  * object, likely connected to a database connection or persistence session, that
  * needs to be closed when the client code is finished with it.
  *
- * <p>The various methods in this class return {@code null} if the corresponding
+ * The various methods in this class return {@code null} if the corresponding
  * operation is not supported by the underlying recommender configuration.  This
  * ensures that, if you can actually get an object implementing a particular interface,
  * you are guaranteed to be able to use it.
  *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @compat Public
  * @see RecommenderEngine
  */
@@ -65,7 +64,10 @@ public interface Recommender extends AutoCloseable {
 
     /**
      * Close the recommender.  This closes underlying resources such as database collections. Components retrieved
-     * from the recommender cannot be used once the recommender is closed.
+     * from the recommender must be used once the recommender is closed.  Components capable of explicitly detecting
+     * use-after-close will indicate such invalid use by throwing {@link IllegalStateException}, although they may
+     * fail with other exceptions.  The results of using a component after its recommender has been closed are formally
+     * undefined.
      */
     @Override
     void close();

--- a/lenskit-api/src/main/java/org/lenskit/api/Recommender.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Recommender.java
@@ -57,6 +57,13 @@ public interface Recommender extends AutoCloseable {
     ItemRecommender getItemRecommender();
 
     /**
+     * Get the recommender's item scorer.
+     * @return The item scorer for the configured recommender, or {@code null} if item scoring is not supported.
+     */
+    @Nullable
+    ItemScorer getItemScorer();
+
+    /**
      * Close the recommender.  This closes underlying resources such as database collections. Components retrieved
      * from the recommender cannot be used once the recommender is closed.
      */

--- a/lenskit-api/src/main/java/org/lenskit/api/RecommenderEngine.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/RecommenderEngine.java
@@ -18,7 +18,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit;
+package org.lenskit.api;
 
 
 /**

--- a/lenskit-api/src/main/java/org/lenskit/api/Result.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Result.java
@@ -20,6 +20,9 @@
  */
 package org.lenskit.api;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * A LensKit result, consisting of a score and an ID.  Individual recommenders may subclass this component to provide
  * more detailed results.
@@ -47,4 +50,28 @@ public interface Result {
      * @return `true` if the result has a score.
      */
     boolean hasScore();
+
+    /**
+     * Convert this result to the specified type, if possible.
+     *
+     * @param type The desired result type.
+     * @param <T> The desired result type.
+     * @return The result as a result of type `T`, or `null` if the type cannot be cast.  This may be done by casting
+     * this type, or by unwrapping wrapper result types, but it will not search multiple alternatives.
+     * @see #find(Class)
+     */
+    @Nullable
+    <T extends Result> T as(@Nonnull Class<T> type);
+
+    /**
+     * Attempt to view this result as another type, searching through alternatives if necessary.
+     *
+     * @param type The type to find.
+     * @param <T> The desired result type.
+     * @return The first result of type `T` found by searching this result and all results it contains.  Each type of
+     * result will define some search order for the purpose of defining the 'first' result of type `T`.
+     * @see #as(Class)
+     */
+    @Nullable
+    <T extends Result> T find(@Nonnull Class<T> type);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/Result.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Result.java
@@ -20,12 +20,19 @@
  */
 package org.lenskit.api;
 
+/**
+ * A LensKit result, consisting of a score and an ID.  Individual recommenders may subclass this component to provide
+ * more detailed results.
+ *
+ * Implementations must create well-defined equality. However, instances of different implementations are not required
+ * or expected to be able to be equal to each other.
+ */
 public interface Result {
     /**
      * Get the ID for the result.
      * @return The user or item ID for this result.
      */
-    int getId();
+    long getId();
 
     /**
      * Get the score (value) associated with this result.

--- a/lenskit-api/src/main/java/org/lenskit/api/Result.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Result.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * more detailed results.
  *
  * Implementations must create well-defined equality. However, instances of different implementations are not required
- * or expected to be able to be equal to each other.
+ * or expected to be able to be equal to each other.  Instances are not allowed to be equal if they have different IDs.
  */
 public interface Result {
     /**

--- a/lenskit-api/src/main/java/org/lenskit/api/Result.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Result.java
@@ -1,0 +1,43 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+public interface Result {
+    /**
+     * Get the ID for the result.
+     * @return The user or item ID for this result.
+     */
+    int getId();
+
+    /**
+     * Get the score (value) associated with this result.
+     * @return The score associated with this entry (or {@link Double#NaN} if the result does not have a score).
+     */
+    double getScore();
+
+    /**
+     * Query whether the result has a score.  This is equivalent to testing the return value of {@link #getScore()} with
+     * {@link Double#isNaN(double)}, but may make the resulting code more readable.
+     *
+     * @return `true` if the result has a score.
+     */
+    boolean hasScore();
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/Result.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/Result.java
@@ -57,21 +57,8 @@ public interface Result {
      * @param type The desired result type.
      * @param <T> The desired result type.
      * @return The result as a result of type `T`, or `null` if the type cannot be cast.  This may be done by casting
-     * this type, or by unwrapping wrapper result types, but it will not search multiple alternatives.
-     * @see #find(Class)
+     * this type, or by unwrapping wrapper result types.
      */
     @Nullable
     <T extends Result> T as(@Nonnull Class<T> type);
-
-    /**
-     * Attempt to view this result as another type, searching through alternatives if necessary.
-     *
-     * @param type The type to find.
-     * @param <T> The desired result type.
-     * @return The first result of type `T` found by searching this result and all results it contains.  Each type of
-     * result will define some search order for the purpose of defining the 'first' result of type `T`.
-     * @see #as(Class)
-     */
-    @Nullable
-    <T extends Result> T find(@Nonnull Class<T> type);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultList.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultList.java
@@ -38,19 +38,4 @@ public interface ResultList<E extends Result> extends List<E> {
      * @return The list of IDs.
      */
     List<Long> idList();
-
-    /**
-     * Convert this result list to a list with a different type of result.  Technically, this provides a runtime-checked
-     * means of making the result list type *covariant* in its result type, since Java does not allow us to encode this
-     * allowance in the type system.
-     *
-     * @param type The result type to cast to.  It is always valid for this type to be a supertype of `E`; the method
-     *             will also succeed if every non-null result is an instance of this type (or one of its subtypes).
-     * @param <T> The result type.
-     * @return A result list statically typed to contain results of type `T`.
-     * @throws IllegalArgumentException if not all results can be cast type type `T`.
-     * @throws UnsupportedOperationException if the result list is mutable (very rare, only used for intermediate
-     * working objects).
-     */
-    <T extends Result> ResultList<T> castResults(Class<T> type);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultList.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultList.java
@@ -23,15 +23,10 @@ package org.lenskit.api;
 import java.util.List;
 
 /**
- * A set of results from a recommender operation.  Recommendation results conceptually map item
- * (or user, for a few operations) IDs to corresponding scores, and have some order over their IDs.
- * Depending on the operation that produced the result set, that order may be arbitrary, but
- * operations that find things (recommendation, related item and user queries) will usually
- * return results in order from most to least relevant or wanted.
- *
- * @param <E> The entry type (parameterized to make extension cleaner).
+ * A list of results from a recommender operation.  This is used for operations such as top-*N* recommendation that
+ * produce a list (or occasionally set) of items.
  */
-public interface ResultList<E extends Result> extends List<E> {
+public interface ResultList extends List<Result> {
     /**
      * Return a list of the item (or user) IDs in this result list.
      *

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultList.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultList.java
@@ -1,0 +1,56 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+import java.util.List;
+
+/**
+ * A set of results from a recommender operation.  Recommendation results conceptually map item
+ * (or user, for a few operations) IDs to corresponding scores, and have some order over their IDs.
+ * Depending on the operation that produced the result set, that order may be arbitrary, but
+ * operations that find things (recommendation, related item and user queries) will usually
+ * return results in order from most to least relevant or wanted.
+ *
+ * @param <E> The entry type (parameterized to make extension cleaner).
+ */
+public interface ResultList<E extends Result> extends List<E> {
+    /**
+     * Return a list of the item (or user) IDs in this result list.
+     *
+     * @return The list of IDs.
+     */
+    List<Long> idList();
+
+    /**
+     * Convert this result list to a list with a different type of result.  Technically, this provides a runtime-checked
+     * means of making the result list type *covariant* in its result type, since Java does not allow us to encode this
+     * allowance in the type system.
+     *
+     * @param type The result type to cast to.  It is always valid for this type to be a supertype of `E`; the method
+     *             will also succeed if every non-null result is an instance of this type (or one of its subtypes).
+     * @param <T> The result type.
+     * @return A result list statically typed to contain results of type `T`.
+     * @throws IllegalArgumentException if not all results can be cast type type `T`.
+     * @throws UnsupportedOperationException if the result list is mutable (very rare, only used for intermediate
+     * working objects).
+     */
+    <T extends Result> ResultList<T> castResults(Class<T> type);
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
@@ -44,19 +44,4 @@ public interface ResultMap<E extends Result> extends Map<Long,E>, Iterable<E> {
      * @return The score associated with `id`, or {@link Double#NaN} if there is no score.
      */
     double getScore(long id);
-
-    /**
-     * Convert this result map to a map with a different type of result.  Technically, this provides a runtime-checked
-     * means of making the result map type *covariant* in its result type, since Java does not allow us to encode this
-     * allowance in the type system.
-     *
-     * @param type The result type to cast to.  It is always valid for this type to be a supertype of `E`; the method
-     *             will also succeed if every non-null result is an instance of this type (or one of its subtypes).
-     * @param <T> The result type.
-     * @return A result map statically typed to contain results of type `T`.
-     * @throws IllegalArgumentException if not all results can be cast type type `T`.
-     * @throws UnsupportedOperationException if the result map is mutable (very rare, only used for intermediate
-     * working objects).
-     */
-    <T extends Result> ResultMap<T> castResults(Class<T> type);
 }

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
@@ -21,7 +21,6 @@
 package org.lenskit.api;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A map of results from a recommender operation.  This is returned from operations such as *predict* that provide
@@ -33,12 +32,6 @@ public interface ResultMap extends Map<Long,Result>, Iterable<Result> {
      * @return A map view of this result set.
      */
     Map<Long,Double> scoreMap();
-
-    /**
-     * View the results as a set.
-     * @return The result set.
-     */
-    Set<Result> resultSet();
 
     /**
      * Get the score associated with an ID.

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
@@ -21,22 +21,24 @@
 package org.lenskit.api;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
- * A set of results from a recommender operation.  Recommendation results conceptually map item
- * (or user, for a few operations) IDs to corresponding scores, and have some order over their IDs.
- * Depending on the operation that produced the result set, that order may be arbitrary, but
- * operations that find things (recommendation, related item and user queries) will usually
- * return results in order from most to least relevant or wanted.
- *
- * @param <E> The entry type (parameterized to make extension cleaner).
+ * A map of results from a recommender operation.  This is returned from operations such as *predict* that provide
+ * scores or values for a collection of items, but do not rank or find items.
  */
-public interface ResultMap<E extends Result> extends Map<Long,E>, Iterable<E> {
+public interface ResultMap extends Map<Long,Result>, Iterable<Result> {
     /**
      * View this result set as a map from longs to doubles.
      * @return A map view of this result set.
      */
     Map<Long,Double> scoreMap();
+
+    /**
+     * View the results as a set.
+     * @return The result set.
+     */
+    Set<Result> resultSet();
 
     /**
      * Get the score associated with an ID.

--- a/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/ResultMap.java
@@ -1,0 +1,62 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.api;
+
+import java.util.Map;
+
+/**
+ * A set of results from a recommender operation.  Recommendation results conceptually map item
+ * (or user, for a few operations) IDs to corresponding scores, and have some order over their IDs.
+ * Depending on the operation that produced the result set, that order may be arbitrary, but
+ * operations that find things (recommendation, related item and user queries) will usually
+ * return results in order from most to least relevant or wanted.
+ *
+ * @param <E> The entry type (parameterized to make extension cleaner).
+ */
+public interface ResultMap<E extends Result> extends Map<Long,E>, Iterable<E> {
+    /**
+     * View this result set as a map from longs to doubles.
+     * @return A map view of this result set.
+     */
+    Map<Long,Double> scoreMap();
+
+    /**
+     * Get the score associated with an ID.
+     * @param id The ID to query.
+     * @return The score associated with `id`, or {@link Double#NaN} if there is no score.
+     */
+    double getScore(long id);
+
+    /**
+     * Convert this result map to a map with a different type of result.  Technically, this provides a runtime-checked
+     * means of making the result map type *covariant* in its result type, since Java does not allow us to encode this
+     * allowance in the type system.
+     *
+     * @param type The result type to cast to.  It is always valid for this type to be a supertype of `E`; the method
+     *             will also succeed if every non-null result is an instance of this type (or one of its subtypes).
+     * @param <T> The result type.
+     * @return A result map statically typed to contain results of type `T`.
+     * @throws IllegalArgumentException if not all results can be cast type type `T`.
+     * @throws UnsupportedOperationException if the result map is mutable (very rare, only used for intermediate
+     * working objects).
+     */
+    <T extends Result> ResultMap<T> castResults(Class<T> type);
+}

--- a/lenskit-api/src/main/java/org/lenskit/api/package-info.java
+++ b/lenskit-api/src/main/java/org/lenskit/api/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+/**
+ * Interfaces defining an implementation-independent recommendation API.
+ */
+package org.lenskit.api;

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemRecommenderCompatWrapper.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemRecommenderCompatWrapper.java
@@ -1,0 +1,69 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.core;
+
+
+import org.grouplens.lenskit.scored.ScoredId;
+import org.grouplens.lenskit.scored.ScoredIdListBuilder;
+import org.grouplens.lenskit.scored.ScoredIds;
+import org.lenskit.api.ItemRecommender;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultList;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+
+class ItemRecommenderCompatWrapper implements org.grouplens.lenskit.ItemRecommender {
+    private final ItemRecommender delegate;
+
+    public ItemRecommenderCompatWrapper(ItemRecommender rec) {
+        delegate = rec;
+    }
+
+    private List<ScoredId> makeResultList(ResultList results) {
+        ScoredIdListBuilder bld = ScoredIds.newListBuilder(results.size());
+        for (Result r: results) {
+            bld.add(r.getId(), r.getScore());
+        }
+        return bld.build();
+    }
+
+    @Override
+    public List<ScoredId> recommend(long user) {
+        return makeResultList(delegate.recommend(user));
+    }
+
+    @Override
+    public List<ScoredId> recommend(long user, int n) {
+        return makeResultList(delegate.recommend(user, n));
+    }
+
+    @Override
+    public List<ScoredId> recommend(long user, @Nullable Set<Long> candidates) {
+        return makeResultList(delegate.recommend(user, candidates));
+    }
+
+    @Override
+    public List<ScoredId> recommend(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
+        return makeResultList(delegate.recommend(user, n, candidates, exclude));
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemRecommenderCompatWrapper.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemRecommenderCompatWrapper.java
@@ -49,21 +49,21 @@ class ItemRecommenderCompatWrapper implements org.grouplens.lenskit.ItemRecommen
 
     @Override
     public List<ScoredId> recommend(long user) {
-        return makeResultList(delegate.recommend(user));
+        return makeResultList(delegate.recommendWithDetails(user, -1, null, null));
     }
 
     @Override
     public List<ScoredId> recommend(long user, int n) {
-        return makeResultList(delegate.recommend(user, n));
+        return makeResultList(delegate.recommendWithDetails(user, n, null, null));
     }
 
     @Override
     public List<ScoredId> recommend(long user, @Nullable Set<Long> candidates) {
-        return makeResultList(delegate.recommend(user, candidates));
+        return makeResultList(delegate.recommendWithDetails(user, -1, candidates, null));
     }
 
     @Override
     public List<ScoredId> recommend(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
-        return makeResultList(delegate.recommend(user, n, candidates, exclude));
+        return makeResultList(delegate.recommendWithDetails(user, n, candidates, exclude));
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemScorerCompatWrapper.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemScorerCompatWrapper.java
@@ -1,0 +1,65 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.core;
+
+
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.grouplens.lenskit.vectors.SparseVector;
+import org.lenskit.api.ItemScorer;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+class ItemScorerCompatWrapper implements org.grouplens.lenskit.ItemScorer {
+    private final ItemScorer delegate;
+
+    public ItemScorerCompatWrapper(ItemScorer rec) {
+        delegate = rec;
+    }
+
+    @Override
+    public double score(long user, long item) {
+        Result r = delegate.score(user, item);
+        if (r == null) {
+            return Double.NaN;
+        } else {
+            return r.getScore();
+        }
+    }
+
+    @Nonnull
+    @Override
+    public SparseVector score(long user, @Nonnull Collection<Long> items) {
+        MutableSparseVector scores = MutableSparseVector.create(items);
+        score(user, scores);
+        return scores;
+    }
+
+    @Override
+    public void score(long user, @Nonnull MutableSparseVector scores) {
+        ResultMap results = delegate.score(user, scores.keyDomain());
+        for (Result r: results) {
+            scores.set(r.getId(), r.getScore());
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemScorerCompatWrapper.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/ItemScorerCompatWrapper.java
@@ -57,7 +57,7 @@ class ItemScorerCompatWrapper implements org.grouplens.lenskit.ItemScorer {
 
     @Override
     public void score(long user, @Nonnull MutableSparseVector scores) {
-        ResultMap results = delegate.score(user, scores.keyDomain());
+        ResultMap results = delegate.scoreWithDetails(user, scores.keyDomain());
         for (Result r: results) {
             scores.set(r.getId(), r.getScore());
         }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/RatingPredictorCompatWrapper.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/RatingPredictorCompatWrapper.java
@@ -21,14 +21,15 @@
 package org.grouplens.lenskit.core;
 
 
+import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
 import org.lenskit.api.RatingPredictor;
 import org.lenskit.api.Result;
-import org.lenskit.api.ResultMap;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Map;
 
 class RatingPredictorCompatWrapper implements org.grouplens.lenskit.RatingPredictor {
     private final RatingPredictor delegate;
@@ -57,9 +58,7 @@ class RatingPredictorCompatWrapper implements org.grouplens.lenskit.RatingPredic
 
     @Override
     public void predict(long user, @Nonnull MutableSparseVector scores) {
-        ResultMap results = delegate.predict(user, scores.keyDomain());
-        for (Result r: results) {
-            scores.set(r.getId(), r.getScore());
-        }
+        Map<Long, Double> results = delegate.predict(user, scores.keyDomain());
+        scores.set(ImmutableSparseVector.create(results));
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/RatingPredictorCompatWrapper.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/RatingPredictorCompatWrapper.java
@@ -1,0 +1,65 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.core;
+
+
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.grouplens.lenskit.vectors.SparseVector;
+import org.lenskit.api.RatingPredictor;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+class RatingPredictorCompatWrapper implements org.grouplens.lenskit.RatingPredictor {
+    private final RatingPredictor delegate;
+
+    public RatingPredictorCompatWrapper(RatingPredictor rec) {
+        delegate = rec;
+    }
+
+    @Override
+    public double predict(long user, long item) {
+        Result r = delegate.predict(user, item);
+        if (r == null) {
+            return Double.NaN;
+        } else {
+            return r.getScore();
+        }
+    }
+
+    @Nonnull
+    @Override
+    public SparseVector predict(long user, @Nonnull Collection<Long> items) {
+        MutableSparseVector scores = MutableSparseVector.create(items);
+        predict(user, scores);
+        return scores;
+    }
+
+    @Override
+    public void predict(long user, @Nonnull MutableSparseVector scores) {
+        ResultMap results = delegate.predict(user, scores.keyDomain());
+        for (Result r: results) {
+            scores.set(r.getId(), r.getScore());
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
@@ -18,14 +18,19 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit.core;
+package org.lenskit;
 
 import org.grouplens.grapht.Component;
 import org.grouplens.grapht.Dependency;
 import org.grouplens.grapht.InjectionException;
 import org.grouplens.grapht.graph.DAGNode;
-import org.grouplens.lenskit.*;
+import org.grouplens.lenskit.RecommenderBuildException;
+import org.grouplens.lenskit.core.LenskitConfiguration;
 import org.grouplens.lenskit.inject.StaticInjector;
+import org.lenskit.api.ItemRecommender;
+import org.lenskit.api.ItemScorer;
+import org.lenskit.api.RatingPredictor;
+import org.lenskit.api.Recommender;
 
 import java.lang.annotation.Annotation;
 
@@ -50,7 +55,7 @@ public class LenskitRecommender implements Recommender {
      *
      * @param graph This recommender's configuration graph.
      */
-    public LenskitRecommender(DAGNode<Component,Dependency> graph) {
+    public LenskitRecommender(DAGNode<Component, Dependency> graph) {
         injector = new StaticInjector(graph);
     }
 
@@ -112,48 +117,22 @@ public class LenskitRecommender implements Recommender {
 
     @Override
     public ItemScorer getItemScorer() {
-        ItemScorer scorer = get(ItemScorer.class);
-        if (scorer == null) {
-            org.lenskit.api.ItemScorer ns = get(org.lenskit.api.ItemScorer.class);
-            if (ns != null) {
-                scorer = new ItemScorerCompatWrapper(ns);
-            }
-        }
-        return scorer;
-    }
-
-    @Override
-    public GlobalItemScorer getGlobalItemScorer() {
-        return get(GlobalItemScorer.class);
+        return get(ItemScorer.class);
     }
 
     @Override
     public RatingPredictor getRatingPredictor() {
-        RatingPredictor scorer = get(RatingPredictor.class);
-        if (scorer == null) {
-            org.lenskit.api.RatingPredictor ns = get(org.lenskit.api.RatingPredictor.class);
-            if (ns != null) {
-                scorer = new RatingPredictorCompatWrapper(ns);
-            }
-        }
-        return scorer;
+        return get(RatingPredictor.class);
     }
 
     @Override
     public ItemRecommender getItemRecommender() {
-        ItemRecommender rec = get(ItemRecommender.class);
-        if (rec == null) {
-            org.lenskit.api.ItemRecommender ns = get(org.lenskit.api.ItemRecommender.class);
-            if (ns != null) {
-                rec = new ItemRecommenderCompatWrapper(ns);
-            }
-        }
-        return rec;
+        return get(ItemRecommender.class);
     }
 
     @Override
-    public GlobalItemRecommender getGlobalItemRecommender() {
-        return get(GlobalItemRecommender.class);
+    public void close() {
+        // TODO Implement closing
     }
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit;
+
+import org.grouplens.lenskit.RecommenderBuildException;
+import org.grouplens.lenskit.core.LenskitConfiguration;
+import org.grouplens.lenskit.core.ModelDisposition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builds LensKit recommender engines from configurations.
+ *
+ * <p>
+ * If multiple configurations are used, later configurations superseded previous configurations.
+ * This allows you to add a configuration of defaults, followed by a custom configuration.  The
+ * final build process takes the <em>union</em> of the roots of all provided configurations as
+ * the roots of the configured object graph.
+ * </p>
+ *
+ * @see LenskitConfiguration
+ * @see LenskitRecommenderEngine
+ * @since 2.1
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+public class LenskitRecommenderEngineBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(LenskitRecommenderEngineBuilder.class);
+    private org.grouplens.lenskit.core.LenskitRecommenderEngineBuilder delegate =
+            new org.grouplens.lenskit.core.LenskitRecommenderEngineBuilder();
+
+    /**
+     * Get the class loader this builder will use.  By default, it uses the thread's current context
+     * class loader (if set).
+     *
+     * @return The class loader to be used.
+     */
+    public ClassLoader getClassLoader() {
+        return delegate.getClassLoader();
+    }
+
+    /**
+     * Set the class loader to use.
+     * @param classLoader The class loader to use when building the recommender.
+     * @return The builder (for chaining).
+     */
+    public LenskitRecommenderEngineBuilder setClassLoader(ClassLoader classLoader) {
+        delegate.setClassLoader(classLoader);
+        return this;
+    }
+
+    /**
+     * Add a configuration to be included in the recommender engine.  This is the equivalent of
+     * calling {@link #addConfiguration(LenskitConfiguration, ModelDisposition)} with the {@link ModelDisposition#INCLUDED}.
+     * @param config The configuration.
+     * @return The builder (for chaining).
+     */
+    public LenskitRecommenderEngineBuilder addConfiguration(LenskitConfiguration config) {
+        return addConfiguration(config, ModelDisposition.INCLUDED);
+    }
+
+    /**
+     * Add a configuration to be used when building the engine.
+     * @param config The configuration.
+     * @param disp The disposition for this configuration.
+     * @return The builder (for chaining).
+     */
+    public LenskitRecommenderEngineBuilder addConfiguration(LenskitConfiguration config, ModelDisposition disp) {
+        delegate.addConfiguration(config, disp);
+        return this;
+    }
+
+    /**
+     * Build the recommender engine.
+     *
+     * @return The built recommender engine, with {@linkplain ModelDisposition#EXCLUDED excluded}
+     *         components removed.
+     * @throws RecommenderBuildException
+     */
+    public LenskitRecommenderEngine build() throws RecommenderBuildException {
+        return new LenskitRecommenderEngine(delegate.build());
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineLoader.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineLoader.java
@@ -1,0 +1,133 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit;
+
+import com.google.common.base.Preconditions;
+import org.grouplens.lenskit.core.EngineValidationMode;
+import org.grouplens.lenskit.core.LenskitConfiguration;
+import org.grouplens.lenskit.core.RecommenderConfigurationException;
+import org.grouplens.lenskit.util.io.CompressionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.WillClose;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Load a pre-built recommender engine from a file.
+ *
+ * @since 2.1
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+public class LenskitRecommenderEngineLoader {
+    private static final Logger logger = LoggerFactory.getLogger(LenskitRecommenderEngineLoader.class);
+    private org.grouplens.lenskit.core.LenskitRecommenderEngineLoader delegate =
+            new org.grouplens.lenskit.core.LenskitRecommenderEngineLoader();
+
+    /**
+     * Get the configured class loader.
+     * @return The class loader that will be used when loading the engine.
+     */
+    public ClassLoader getClassLoader() {
+        return delegate.getClassLoader();
+    }
+
+    /**
+     * Set the class loader to use when reading the engine.
+     * @param classLoader The class loader to use.
+     * @return The loader (for chaining).
+     */
+    public LenskitRecommenderEngineLoader setClassLoader(ClassLoader classLoader) {
+        delegate.setClassLoader(classLoader);
+        return this;
+    }
+
+    /**
+     * Add a configuration to use when loading the configuration.  The loaded graph will be
+     * post-processed to add in components bound by this configuration.  If the engine was saved
+     * with excluded configurations, then this method should be used to provide configurations to
+     * reinstate any objects excluded from the saved model.  The loader will throw an exception if
+     * the loaded model has any unresolved placeholders.
+     *
+     * @param config The configuration to add.
+     * @return The loader (for chaining).
+     */
+    public LenskitRecommenderEngineLoader addConfiguration(LenskitConfiguration config) {
+        delegate.addConfiguration(config);
+        return this;
+    }
+
+    /**
+     * Set the validation mode for loading the recommender engine.  The default mode is
+     * {@link EngineValidationMode#IMMEDIATE}.
+     * @param mode The validation mode.
+     * @return The loader (for chaining).
+     */
+    public LenskitRecommenderEngineLoader setValidationMode(EngineValidationMode mode) {
+        Preconditions.checkNotNull(mode, "validation mode");
+        delegate.setValidationMode(mode);
+        return this;
+    }
+
+    /**
+     * Set the compression mode to use.  The default is {@link CompressionMode#AUTO}.
+     * @param comp The compression mode.
+     */
+    public void setCompressionMode(CompressionMode comp) {
+        delegate.setCompressionMode(comp);
+    }
+
+    /**
+     * Load a recommender engine from an input stream.
+     * <p>
+     * <strong>Note:</strong> this method is only capable of auto-detecting gzip-compressed data.
+     * If the {@linkplain #setCompressionMode(CompressionMode) compression mode} is {@link CompressionMode#AUTO},
+     * only gzip-compressed streams are supported.  Set the compression mode manually if you are
+     * using XZ compression.
+     * </p>
+     *
+     * @param stream The input stream.
+     * @return The deserialized recommender.
+     * @throws IOException if there is an error reading the input data.
+     * @throws RecommenderConfigurationException
+     *                     if there is a configuration error with the deserialized recommender or
+     *                     the configurations applied to it.
+     */
+    public LenskitRecommenderEngine load(@WillClose InputStream stream) throws IOException, RecommenderConfigurationException {
+        return new LenskitRecommenderEngine(delegate.load(stream));
+    }
+
+    /**
+     * Load a recommender from a file.
+     *
+     * @param file The recommender model file to load.
+     * @return The recommender engine.
+     * @throws IOException if there is an error reading the input data.
+     * @throws RecommenderConfigurationException
+     *                     if there is a configuration error with the deserialized recommender or
+     *                     the configurations applied to it.
+     */
+    public LenskitRecommenderEngine load(File file) throws IOException, RecommenderConfigurationException {
+        return new LenskitRecommenderEngine(delegate.load(file));
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemRecommenderAdapter.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemRecommenderAdapter.java
@@ -20,6 +20,8 @@
  */
 package org.lenskit.basic;
 
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.lenskit.api.ItemRecommender;
 import org.lenskit.api.Result;
@@ -48,28 +50,36 @@ public class LegacyItemRecommenderAdapter implements ItemRecommender {
         return Results.newResultList(results);
     }
 
-    @Override
-    public ResultList recommend(long user) {
-        return makeResultList(delegate.recommend(user));
+    private List<Long> idList(List<ScoredId> sids) {
+        LongList results = new LongArrayList(sids.size());
+        for (ScoredId r: sids) {
+            results.add(r.getId());
+        }
+        return results;
     }
 
     @Override
-    public ResultList recommend(long user, int n) {
-        return makeResultList(delegate.recommend(user, n));
+    public List<Long> recommend(long user) {
+        return idList(delegate.recommend(user));
     }
 
     @Override
-    public ResultList recommend(long user, @Nullable Set<Long> candidates) {
-        return makeResultList(delegate.recommend(user, candidates));
+    public List<Long> recommend(long user, int n) {
+        return idList(delegate.recommend(user, n));
     }
 
     @Override
-    public ResultList recommend(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
-        return makeResultList(delegate.recommend(user, n, candidates, exclude));
+    public List<Long> recommend(long user, @Nullable Set<Long> candidates) {
+        return idList(delegate.recommend(user, candidates));
+    }
+
+    @Override
+    public List<Long> recommend(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
+        return idList(delegate.recommend(user, n, candidates, exclude));
     }
 
     @Override
     public ResultList recommendWithDetails(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
-        return recommend(user, n, candidates, exclude);
+        return makeResultList(delegate.recommend(user, n, candidates, exclude));
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemRecommenderAdapter.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemRecommenderAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.basic;
+
+import org.grouplens.lenskit.scored.ScoredId;
+import org.lenskit.api.ItemRecommender;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultList;
+import org.lenskit.results.Results;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LegacyItemRecommenderAdapter implements ItemRecommender {
+    private final org.grouplens.lenskit.ItemRecommender delegate;
+
+    @Inject
+    public LegacyItemRecommenderAdapter(org.grouplens.lenskit.ItemRecommender old) {
+        delegate = old;
+    }
+
+    private ResultList makeResultList(List<ScoredId> sids) {
+        List<Result> results = new ArrayList<>(sids.size());
+        for (ScoredId r: sids) {
+            results.add(Results.create(r.getId(), r.getScore()));
+        }
+        return Results.newResultList(results);
+    }
+
+    @Override
+    public ResultList recommend(long user) {
+        return makeResultList(delegate.recommend(user));
+    }
+
+    @Override
+    public ResultList recommend(long user, int n) {
+        return makeResultList(delegate.recommend(user, n));
+    }
+
+    @Override
+    public ResultList recommend(long user, @Nullable Set<Long> candidates) {
+        return makeResultList(delegate.recommend(user, candidates));
+    }
+
+    @Override
+    public ResultList recommend(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
+        return makeResultList(delegate.recommend(user, n, candidates, exclude));
+    }
+
+    @Override
+    public ResultList recommendWithDetails(long user, int n, @Nullable Set<Long> candidates, @Nullable Set<Long> exclude) {
+        return recommend(user, n, candidates, exclude);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemScorerAdapter.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemScorerAdapter.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public class LegacyItemScorerAdapter implements ItemScorer {
     private final org.grouplens.lenskit.ItemScorer delegate;
@@ -53,18 +54,18 @@ public class LegacyItemScorerAdapter implements ItemScorer {
 
     @Nonnull
     @Override
-    public ResultMap score(long user, @Nonnull Collection<Long> items) {
+    public Map<Long,Double> score(long user, @Nonnull Collection<Long> items) {
+        return scoreWithDetails(user, items).scoreMap();
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap scoreWithDetails(long user, @Nonnull Collection<Long> items) {
         SparseVector res = delegate.score(user, items);
         List<Result> results = new ArrayList<>(res.size());
         for (VectorEntry e: res) {
             results.add(Results.create(e.getKey(), e.getValue()));
         }
         return Results.newResultMap(results);
-    }
-
-    @Nonnull
-    @Override
-    public ResultMap scoreWithDetails(long user, @Nonnull Collection<Long> items) {
-        return score(user, items);
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemScorerAdapter.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/LegacyItemScorerAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.basic;
+
+import org.grouplens.lenskit.vectors.SparseVector;
+import org.grouplens.lenskit.vectors.VectorEntry;
+import org.lenskit.api.ItemScorer;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+import org.lenskit.results.Results;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class LegacyItemScorerAdapter implements ItemScorer {
+    private final org.grouplens.lenskit.ItemScorer delegate;
+
+    @Inject
+    public LegacyItemScorerAdapter(org.grouplens.lenskit.ItemScorer old) {
+        delegate = old;
+    }
+
+    @Override
+    public Result score(long user, long item) {
+        double score = delegate.score(user, item);
+        if (Double.isNaN(score)) {
+            return null;
+        } else {
+            return Results.create(item, score);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap score(long user, @Nonnull Collection<Long> items) {
+        SparseVector res = delegate.score(user, items);
+        List<Result> results = new ArrayList<>(res.size());
+        for (VectorEntry e: res) {
+            results.add(Results.create(e.getKey(), e.getValue()));
+        }
+        return Results.newResultMap(results);
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap scoreWithDetails(long user, @Nonnull Collection<Long> items) {
+        return score(user, items);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/basic/LegacyRatingPredictorAdapter.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/LegacyRatingPredictorAdapter.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public class LegacyRatingPredictorAdapter implements RatingPredictor {
     private final org.grouplens.lenskit.RatingPredictor delegate;
@@ -53,18 +54,18 @@ public class LegacyRatingPredictorAdapter implements RatingPredictor {
 
     @Nonnull
     @Override
-    public ResultMap predict(long user, @Nonnull Collection<Long> items) {
+    public Map<Long, Double> predict(long user, @Nonnull Collection<Long> items) {
+        return predictWithDetails(user, items).scoreMap();
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap predictWithDetails(long user, @Nonnull Collection<Long> items) {
         SparseVector res = delegate.predict(user, items);
         List<Result> results = new ArrayList<>(res.size());
         for (VectorEntry e: res) {
             results.add(Results.create(e.getKey(), e.getValue()));
         }
         return Results.newResultMap(results);
-    }
-
-    @Nonnull
-    @Override
-    public ResultMap predictWithDetails(long user, @Nonnull Collection<Long> items) {
-        return predict(user, items);
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/basic/LegacyRatingPredictorAdapter.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/LegacyRatingPredictorAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.basic;
+
+import org.grouplens.lenskit.vectors.SparseVector;
+import org.grouplens.lenskit.vectors.VectorEntry;
+import org.lenskit.api.RatingPredictor;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+import org.lenskit.results.Results;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class LegacyRatingPredictorAdapter implements RatingPredictor {
+    private final org.grouplens.lenskit.RatingPredictor delegate;
+
+    @Inject
+    public LegacyRatingPredictorAdapter(org.grouplens.lenskit.RatingPredictor old) {
+        delegate = old;
+    }
+
+    @Override
+    public Result predict(long user, long item) {
+        double predict = delegate.predict(user, item);
+        if (Double.isNaN(predict)) {
+            return null;
+        } else {
+            return Results.create(item, predict);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap predict(long user, @Nonnull Collection<Long> items) {
+        SparseVector res = delegate.predict(user, items);
+        List<Result> results = new ArrayList<>(res.size());
+        for (VectorEntry e: res) {
+            results.add(Results.create(e.getKey(), e.getValue()));
+        }
+        return Results.newResultMap(results);
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap predictWithDetails(long user, @Nonnull Collection<Long> items) {
+        return predict(user, items);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/basic/package-info.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+/**
+ * Basic component implementations.  Most of these won't do any good without another,
+ * more sophisticated implementation of some component backing them.
+ */
+package org.lenskit.basic;

--- a/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;

--- a/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
@@ -79,16 +79,6 @@ public abstract class AbstractResult implements Result {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * The default implementation simply calls {@link #as(Class)}.
-     */
-    @Override
-    public <T extends Result> T find(@Nonnull Class<T> type) {
-        return as(type);
-    }
-
-    /**
      * Create a hash code builder, populated with the ID and score.  Subclasses can use this as a starting point for
      * building a hash code.
      *

--- a/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
@@ -24,11 +24,13 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.lenskit.api.Result;
 
+import javax.annotation.Nonnull;
+
 /**
  * Base class for basic result types.  It provides storage for the ID and score, as well as helper methods for hashing
  * and equality checking.  This type does not directly enforce immutability, but subclasses should be immutable.
  */
-public class AbstractResult implements Result {
+public abstract class AbstractResult implements Result {
     protected long id;
     protected double score;
 
@@ -60,6 +62,30 @@ public class AbstractResult implements Result {
     @Override
     public boolean hasScore() {
         return !Double.isNaN(score);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * The default implementation simply casts the result to type `type` if possible.
+     */
+    @Override
+    public <T extends Result> T as(@Nonnull Class<T> type) {
+        if (type.isInstance(this)) {
+            return type.cast(this);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * The default implementation simply calls {@link #as(Class)}.
+     */
+    @Override
+    public <T extends Result> T find(@Nonnull Class<T> type) {
+        return as(type);
     }
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/AbstractResult.java
@@ -1,0 +1,66 @@
+package org.lenskit.results;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.lenskit.api.Result;
+
+/**
+ * Base class for basic result types.  It provides storage for the ID and score, as well as helper methods for hashing
+ * and equality checking.  This type does not directly enforce immutability, but subclasses should be immutable.
+ */
+public class AbstractResult implements Result {
+    protected long id;
+    protected double score;
+
+    /**
+     * Create a new result.
+     * @param id The result ID.
+     * @param score The result score.
+     */
+    protected AbstractResult(long id, double score) {
+        this.id = id;
+        this.score = score;
+    }
+
+    /**
+     * Create a new, uninitialized result.
+     */
+    protected AbstractResult() {}
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public double getScore() {
+        return score;
+    }
+
+    @Override
+    public boolean hasScore() {
+        return !Double.isNaN(score);
+    }
+
+    /**
+     * Create a hash code builder, populated with the ID and score.  Subclasses can use this as a starting point for
+     * building a hash code.
+     *
+     * @return A hash code builder that has the ID and score already appended.
+     */
+    protected HashCodeBuilder startHashCode() {
+        return new HashCodeBuilder().append(id).append(score);
+    }
+
+    /**
+     * Create an equality builder, populated with the ID and score.  Subclasses can use this as a starting point for
+     * checking equality.
+     *
+     * @param r The other result.
+     * @return An equality builder, that has the ID and score of this result and `r` already appended to it.
+     */
+    protected EqualsBuilder startEquality(Result r) {
+        return new EqualsBuilder().append(id, r.getId())
+                                  .append(score, r.getScore());
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -45,6 +45,9 @@ public class BasicResult implements Result, Serializable {
      * {@link Results#basicCopy(Result)}.  Detailed results that extend this class **must** override both this method
      * and {@link #hashCode()}.
      *
+     * Subclasses should **not** call this method; they can use {@link #startEquality(Result)} to reuse the logic for
+     * checking ID and score.
+     *
      * @param o The object to compare with.
      * @return `true` if the objects are equivalent.
      */
@@ -55,17 +58,43 @@ public class BasicResult implements Result, Serializable {
             return true;
         } else if (o != null && o.getClass().equals(BasicResult.class)) {
             BasicResult or = (BasicResult) o;
-            return new EqualsBuilder().append(id, or.id)
-                                      .append(score, or.score)
-                                      .isEquals();
+            return startEquality(or).isEquals();
         } else {
             return false;
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * Subclasses should **not** call this method; they can use {@link #startHashCode()} to reuse the logic for
+     * hashing the ID and score.
+     */
     @Override
     public int hashCode() {
         assert getClass().equals(BasicResult.class): "subclass failed to override hashCode()";
-        return new HashCodeBuilder().append(id).append(score).toHashCode();
+        return startHashCode().toHashCode();
+    }
+
+    /**
+     * Create a hash code builder, populated with the ID and score.  Subclasses can use this as a starting point for
+     * building a hash code.
+     *
+     * @return A hash code builder that has the ID and score already appended.
+     */
+    protected HashCodeBuilder startHashCode() {
+        return new HashCodeBuilder().append(id).append(score);
+    }
+
+    /**
+     * Create an equality builder, populated with the ID and score.  Subclasses can use this as a starting point for
+     * checking equality.
+     *
+     * @param r The other result.
+     * @return An equality builder, that has the ID and score of this result and `r` already appended to it.
+     */
+    protected EqualsBuilder startEquality(Result r) {
+        return new EqualsBuilder().append(id, r.getId())
+                                  .append(score, r.getScore());
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -1,11 +1,9 @@
 package org.lenskit.results;
 
-import jdk.nashorn.internal.ir.annotations.Immutable;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.lenskit.api.Result;
 
-import java.io.Serializable;
+import javax.annotation.concurrent.Immutable;
+import java.io.*;
 
 /**
  * A basic {@link Result} implementation with no details.
@@ -13,47 +11,43 @@ import java.io.Serializable;
  * @see Results
  */
 @Immutable
-public class BasicResult implements Result, Serializable {
+public final class BasicResult extends AbstractResult implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    protected final long id;
-    protected final double score;
-
+    /**
+     * Create a new basic result.
+     * @param id The result ID.
+     * @param score The result score.
+     * @see Results#create(long, double)
+     */
     public BasicResult(long id, double score) {
-        this.id = id;
-        this.score = score;
+        super(id, score);
     }
 
-    @Override
-    public long getId() {
-        return id;
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeLong(id);
+        out.writeDouble(score);
     }
 
-    @Override
-    public double getScore() {
-        return score;
+    private void readObject(ObjectInputStream in) throws IOException {
+        id = in.readLong();
+        score = in.readDouble();
     }
 
-    @Override
-    public boolean hasScore() {
-        return !Double.isNaN(score);
+    private void readObjectNoData() throws ObjectStreamException {
+        throw new InvalidObjectException("basic result must have data");
     }
 
     /**
      * Compare this result with another for equality.  Instance of this result type are only equal with other basic
      * result instances; to compare general results for equality, first convert them to basic results with
-     * {@link Results#basicCopy(Result)}.  Detailed results that extend this class **must** override both this method
-     * and {@link #hashCode()}.
-     *
-     * Subclasses should **not** call this method; they can use {@link #startEquality(Result)} to reuse the logic for
-     * checking ID and score.
+     * {@link Results#basicCopy(Result)}.
      *
      * @param o The object to compare with.
      * @return `true` if the objects are equivalent.
      */
     @Override
     public boolean equals(Object o) {
-        assert getClass().equals(BasicResult.class): "subclass failed to override equals()";
         if (o == this) {
             return true;
         } else if (o != null && o.getClass().equals(BasicResult.class)) {
@@ -64,37 +58,8 @@ public class BasicResult implements Result, Serializable {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * Subclasses should **not** call this method; they can use {@link #startHashCode()} to reuse the logic for
-     * hashing the ID and score.
-     */
     @Override
     public int hashCode() {
-        assert getClass().equals(BasicResult.class): "subclass failed to override hashCode()";
         return startHashCode().toHashCode();
-    }
-
-    /**
-     * Create a hash code builder, populated with the ID and score.  Subclasses can use this as a starting point for
-     * building a hash code.
-     *
-     * @return A hash code builder that has the ID and score already appended.
-     */
-    protected HashCodeBuilder startHashCode() {
-        return new HashCodeBuilder().append(id).append(score);
-    }
-
-    /**
-     * Create an equality builder, populated with the ID and score.  Subclasses can use this as a starting point for
-     * checking equality.
-     *
-     * @param r The other result.
-     * @return An equality builder, that has the ID and score of this result and `r` already appended to it.
-     */
-    protected EqualsBuilder startEquality(Result r) {
-        return new EqualsBuilder().append(id, r.getId())
-                                  .append(score, r.getScore());
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -1,0 +1,68 @@
+package org.lenskit.results;
+
+import jdk.nashorn.internal.ir.annotations.Immutable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.lenskit.api.Result;
+
+import java.io.Serializable;
+
+/**
+ * A basic {@link Result} implementation with no details.
+ *
+ * @see Results
+ */
+@Immutable
+public class BasicResult implements Result, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final long id;
+    private final double score;
+
+    public BasicResult(long id, double score) {
+        this.id = id;
+        this.score = score;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public double getScore() {
+        return score;
+    }
+
+    @Override
+    public boolean hasScore() {
+        return !Double.isNaN(score);
+    }
+
+    /**
+     * Compare this result with another for equality.  Instance of this result type are only equal with other basic
+     * result instances; to compare general results for equality, first convert them to basic results with
+     * {@link Results#basicCopy(Result)}.
+     *
+     * @param o The object to compare with.
+     * @return `true` if the objects are equivalent.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        } else if (o instanceof BasicResult) {
+            BasicResult or = (BasicResult) o;
+            return new EqualsBuilder().append(id, or.id)
+                                      .append(score, or.score)
+                                      .isEquals();
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(id).append(score).toHashCode();
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -16,8 +16,8 @@ import java.io.Serializable;
 public class BasicResult implements Result, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final long id;
-    private final double score;
+    protected final long id;
+    protected final double score;
 
     public BasicResult(long id, double score) {
         this.id = id;
@@ -42,16 +42,18 @@ public class BasicResult implements Result, Serializable {
     /**
      * Compare this result with another for equality.  Instance of this result type are only equal with other basic
      * result instances; to compare general results for equality, first convert them to basic results with
-     * {@link Results#basicCopy(Result)}.
+     * {@link Results#basicCopy(Result)}.  Detailed results that extend this class **must** override both this method
+     * and {@link #hashCode()}.
      *
      * @param o The object to compare with.
      * @return `true` if the objects are equivalent.
      */
     @Override
     public boolean equals(Object o) {
+        assert getClass().equals(BasicResult.class): "subclass failed to override equals()";
         if (o == this) {
             return true;
-        } else if (o instanceof BasicResult) {
+        } else if (o != null && o.getClass().equals(BasicResult.class)) {
             BasicResult or = (BasicResult) o;
             return new EqualsBuilder().append(id, or.id)
                                       .append(score, or.score)
@@ -63,6 +65,7 @@ public class BasicResult implements Result, Serializable {
 
     @Override
     public int hashCode() {
+        assert getClass().equals(BasicResult.class): "subclass failed to override hashCode()";
         return new HashCodeBuilder().append(id).append(score).toHashCode();
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -20,6 +20,7 @@
  */
 package org.lenskit.results;
 
+import com.google.common.base.MoreObjects;
 import org.lenskit.api.Result;
 
 import javax.annotation.concurrent.Immutable;
@@ -81,5 +82,13 @@ public final class BasicResult extends AbstractResult implements Serializable {
     @Override
     public int hashCode() {
         return startHashCode().toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("id", id)
+                          .add("score", score)
+                          .toString();
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -45,6 +45,7 @@ public final class BasicResult extends AbstractResult implements Serializable {
         super(id, score);
     }
 
+    //region Serialization support
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.writeLong(id);
         out.writeDouble(score);
@@ -58,7 +59,9 @@ public final class BasicResult extends AbstractResult implements Serializable {
     private void readObjectNoData() throws ObjectStreamException {
         throw new InvalidObjectException("basic result must have data");
     }
+    //endregion
 
+    //region Value object behavior
     /**
      * Compare this result with another for equality.  Instance of this result type are only equal with other basic
      * result instances; to compare general results for equality, first convert them to basic results with
@@ -91,4 +94,5 @@ public final class BasicResult extends AbstractResult implements Serializable {
                           .add("score", score)
                           .toString();
     }
+    //endregion
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResult.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import org.lenskit.api.Result;

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
@@ -35,20 +35,20 @@ import java.util.List;
 /**
  * Basic list-based implementation of a result list.
  */
-public class BasicResultList<E extends Result> extends AbstractList<E> implements LenskitResultList<E> {
-    private final ImmutableList<E> results;
+public class BasicResultList extends AbstractList<Result> implements LenskitResultList {
+    private final ImmutableList<Result> results;
     private final IdList idList = new IdList();
 
     /**
      * Create a new result list from a list of results.
      * @param rss The result list.
      */
-    public BasicResultList(List<? extends E> rss) {
+    public BasicResultList(List<? extends Result> rss) {
         results = ImmutableList.copyOf(rss);
     }
 
     @Override
-    public E get(int index) {
+    public Result get(int index) {
         return results.get(index);
     }
 
@@ -58,17 +58,17 @@ public class BasicResultList<E extends Result> extends AbstractList<E> implement
     }
 
     @Override
-    public UnmodifiableIterator<E> iterator() {
+    public UnmodifiableIterator<Result> iterator() {
         return results.iterator();
     }
 
     @Override
-    public UnmodifiableListIterator<E> listIterator() {
+    public UnmodifiableListIterator<Result> listIterator() {
         return results.listIterator();
     }
 
     @Override
-    public UnmodifiableListIterator<E> listIterator(int index) {
+    public UnmodifiableListIterator<Result> listIterator(int index) {
         return results.listIterator(index);
     }
 
@@ -88,7 +88,7 @@ public class BasicResultList<E extends Result> extends AbstractList<E> implement
     }
 
     @Override
-    public ImmutableList<E> subList(int fromIndex, int toIndex) {
+    public ImmutableList<Result> subList(int fromIndex, int toIndex) {
         return results.subList(fromIndex, toIndex);
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
@@ -1,0 +1,127 @@
+package org.lenskit.results;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+import com.google.common.collect.UnmodifiableListIterator;
+import it.unimi.dsi.fastutil.longs.AbstractLongList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultList;
+
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Basic list-based implementation of a result list.
+ */
+public class BasicResultList<E extends Result> extends AbstractList<E> implements LenskitResultList<E> {
+    private final ImmutableList<E> results;
+    private final IdList idList = new IdList();
+
+    /**
+     * Create a new result list from a list of results.
+     * @param rss The result list.
+     */
+    public BasicResultList(List<? extends E> rss) {
+        results = ImmutableList.copyOf(rss);
+    }
+
+    @Override
+    public E get(int index) {
+        return results.get(index);
+    }
+
+    @Override
+    public int size() {
+        return results.size();
+    }
+
+    @Override
+    public UnmodifiableIterator<E> iterator() {
+        return results.iterator();
+    }
+
+    @Override
+    public UnmodifiableListIterator<E> listIterator() {
+        return results.listIterator();
+    }
+
+    @Override
+    public UnmodifiableListIterator<E> listIterator(int index) {
+        return results.listIterator(index);
+    }
+
+    @Override
+    public int indexOf(Object object) {
+        return results.indexOf(object);
+    }
+
+    @Override
+    public int lastIndexOf(Object object) {
+        return results.lastIndexOf(object);
+    }
+
+    @Override
+    public boolean contains(Object object) {
+        return results.contains(object);
+    }
+
+    @Override
+    public ImmutableList<E> subList(int fromIndex, int toIndex) {
+        return results.subList(fromIndex, toIndex);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj instanceof ResultList) {
+            return results.equals(obj);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return results.hashCode();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return results.isEmpty();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return results.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return results.toArray(a);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return results.containsAll(c);
+    }
+
+    @Override
+    public LongList idList() {
+        return idList;
+    }
+
+    private class IdList extends AbstractLongList {
+        @Override
+        public int size() {
+            return results.size();
+        }
+
+        @Override
+        public long getLong(int i) {
+            return results.get(i).getId();
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import com.google.common.collect.ImmutableList;

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultList.java
@@ -28,6 +28,7 @@ import it.unimi.dsi.fastutil.longs.LongList;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.List;
@@ -35,6 +36,7 @@ import java.util.List;
 /**
  * Basic list-based implementation of a result list.
  */
+@Immutable
 public class BasicResultList extends AbstractList<Result> implements LenskitResultList {
     private final ImmutableList<Result> results;
     private final IdList idList = new IdList();

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import com.google.common.collect.Iterators;

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
@@ -26,16 +26,15 @@ import it.unimi.dsi.fastutil.objects.*;
 import org.lenskit.api.Result;
 
 import javax.annotation.concurrent.Immutable;
-import java.util.AbstractSet;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Standard result map implementation.
  */
 @Immutable
 public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements LenskitResultMap {
+    private static final long serialVersionUID = 1L;
+
     private final Long2ObjectMap<Result> delegate;
 
     /**
@@ -67,6 +66,26 @@ public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements Le
     @Override
     public Result get(long l) {
         return delegate.get(l);
+    }
+
+    @Override
+    public boolean containsKey(long l) {
+        return delegate.containsKey(l);
+    }
+
+    @Override
+    public ObjectCollection<Result> values() {
+        return ObjectCollections.unmodifiable(delegate.values());
+    }
+
+    @Override
+    public ObjectSet<Map.Entry<Long, Result>> entrySet() {
+        return ObjectSets.unmodifiable(delegate.entrySet());
+    }
+
+    @Override
+    public LongSet keySet() {
+        return LongSets.unmodifiable(delegate.keySet());
     }
 
     @Override

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
@@ -1,0 +1,65 @@
+package org.lenskit.results;
+
+import com.google.common.collect.Iterators;
+import it.unimi.dsi.fastutil.longs.AbstractLong2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import it.unimi.dsi.fastutil.objects.ObjectSets;
+import org.lenskit.api.Result;
+
+import java.util.Iterator;
+import java.util.Set;
+
+public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements LenskitResultMap {
+    private final Long2ObjectMap<Result> delegate;
+
+    public BasicResultMap(Long2ObjectMap<Result> map) {
+        // TODO find way to avoid copy when map is already immutable
+        this(map, true);
+    }
+
+    BasicResultMap(Long2ObjectMap<Result> map, boolean copy) {
+        if (copy) {
+            delegate = new Long2ObjectLinkedOpenHashMap<>(map);
+        } else {
+            delegate = map;
+        }
+    }
+
+    @Override
+    public Long2DoubleMap scoreMap() {
+        return null;
+    }
+
+    @Override
+    public Iterator<Result> iterator() {
+        return Iterators.unmodifiableIterator(delegate.values().iterator());
+    }
+
+    @Override
+    public ObjectSet<Entry<Result>> long2ObjectEntrySet() {
+        return ObjectSets.unmodifiable(delegate.long2ObjectEntrySet());
+    }
+
+    @Override
+    public Result get(long l) {
+        return delegate.get(l);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public Set<Result> resultSet() {
+        return null;
+    }
+
+    @Override
+    public double getScore(long id) {
+        return 0;
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
@@ -21,36 +21,37 @@
 package org.lenskit.results;
 
 import com.google.common.collect.Iterators;
-import it.unimi.dsi.fastutil.longs.AbstractLong2ObjectMap;
-import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.objects.ObjectSet;
-import it.unimi.dsi.fastutil.objects.ObjectSets;
+import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.objects.*;
 import org.lenskit.api.Result;
 
+import javax.annotation.concurrent.Immutable;
+import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
+/**
+ * Standard result map implementation.
+ */
+@Immutable
 public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements LenskitResultMap {
     private final Long2ObjectMap<Result> delegate;
 
-    public BasicResultMap(Long2ObjectMap<Result> map) {
-        // TODO find way to avoid copy when map is already immutable
-        this(map, true);
-    }
-
-    BasicResultMap(Long2ObjectMap<Result> map, boolean copy) {
-        if (copy) {
-            delegate = new Long2ObjectLinkedOpenHashMap<>(map);
-        } else {
-            delegate = map;
+    /**
+     * Create a new result map from a collection of results.
+     * @param objs The results.
+     */
+    public BasicResultMap(Collection<? extends Result> objs) {
+        delegate = new Long2ObjectLinkedOpenHashMap<>();
+        for (Result r: objs) {
+            delegate.put(r.getId(), r);
         }
     }
 
     @Override
     public Long2DoubleMap scoreMap() {
-        return null;
+        return new ScoreMapImpl();
     }
 
     @Override
@@ -75,11 +76,85 @@ public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements Le
 
     @Override
     public Set<Result> resultSet() {
-        return null;
+        return new ResultSetImpl();
     }
 
     @Override
     public double getScore(long id) {
-        return 0;
+        Result r = delegate.get(id);
+        if (r == null) {
+            return Double.NaN;
+        } else {
+            return r.getScore();
+        }
+    }
+
+    private class ScoreMapImpl extends AbstractLong2DoubleMap {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public ObjectSet<Entry> long2DoubleEntrySet() {
+            return new AbstractObjectSet<Entry>() {
+                @Override
+                public ObjectIterator<Entry> iterator() {
+                    return new AbstractObjectIterator<Entry>() {
+                        Iterator<Result> results = delegate.values().iterator();
+
+                        public boolean hasNext() {
+                            return results.hasNext();
+                        }
+
+                        @Override
+                        public Entry next() {
+                            Result r = results.next();
+                            return new BasicEntry(r.getId(), r.getScore());
+                        }
+                    };
+                }
+
+                @Override
+                public int size() {
+                    return delegate.size();
+                }
+            };
+        }
+
+        @Override
+        public double get(long l) {
+            return getScore(l);
+        }
+
+        @Override
+        public boolean containsKey(long l) {
+            return delegate.containsKey(l);
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+    }
+
+    private class ResultSetImpl extends AbstractSet<Result> {
+        @Override
+        public Iterator<Result> iterator() {
+            return Iterators.unmodifiableIterator(delegate.values().iterator());
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            if (o instanceof Result) {
+                Result or = (Result) o;
+                Result found = delegate.get(or.getId());
+                return or.equals(found);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
@@ -26,7 +26,9 @@ import it.unimi.dsi.fastutil.objects.*;
 import org.lenskit.api.Result;
 
 import javax.annotation.concurrent.Immutable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Standard result map implementation.
@@ -94,11 +96,6 @@ public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements Le
     }
 
     @Override
-    public Set<Result> resultSet() {
-        return new ResultSetImpl();
-    }
-
-    @Override
     public double getScore(long id) {
         Result r = delegate.get(id);
         if (r == null) {
@@ -146,29 +143,6 @@ public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements Le
         @Override
         public boolean containsKey(long l) {
             return delegate.containsKey(l);
-        }
-
-        @Override
-        public int size() {
-            return delegate.size();
-        }
-    }
-
-    private class ResultSetImpl extends AbstractSet<Result> {
-        @Override
-        public Iterator<Result> iterator() {
-            return Iterators.unmodifiableIterator(delegate.values().iterator());
-        }
-
-        @Override
-        public boolean contains(Object o) {
-            if (o instanceof Result) {
-                Result or = (Result) o;
-                Result found = delegate.get(or.getId());
-                return or.equals(found);
-            } else {
-                return false;
-            }
         }
 
         @Override

--- a/lenskit-core/src/main/java/org/lenskit/results/LenskitResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/LenskitResultList.java
@@ -1,0 +1,13 @@
+package org.lenskit.results;
+
+import it.unimi.dsi.fastutil.longs.LongList;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultList;
+
+/**
+ * LensKit refinement of the general result list type.
+ * @param <E> The result type.
+ */
+public interface LenskitResultList<E extends Result> extends ResultList<E> {
+    LongList idList();
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/LenskitResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/LenskitResultList.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import it.unimi.dsi.fastutil.longs.LongList;

--- a/lenskit-core/src/main/java/org/lenskit/results/LenskitResultList.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/LenskitResultList.java
@@ -21,13 +21,11 @@
 package org.lenskit.results;
 
 import it.unimi.dsi.fastutil.longs.LongList;
-import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
 
 /**
  * LensKit refinement of the general result list type.
- * @param <E> The result type.
  */
-public interface LenskitResultList<E extends Result> extends ResultList<E> {
+public interface LenskitResultList extends ResultList {
     LongList idList();
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/LenskitResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/LenskitResultMap.java
@@ -27,8 +27,7 @@ import org.lenskit.api.ResultMap;
 
 /**
  * LensKit refinement of the general result map type.
- * @param <E> The result type.
  */
-public interface LenskitResultMap<E extends Result> extends ResultMap<E>, Long2ObjectMap<E> {
+public interface LenskitResultMap extends ResultMap, Long2ObjectMap<Result> {
     Long2DoubleMap scoreMap();
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/LenskitResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/LenskitResultMap.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;

--- a/lenskit-core/src/main/java/org/lenskit/results/LenskitResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/LenskitResultMap.java
@@ -1,0 +1,14 @@
+package org.lenskit.results;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+
+/**
+ * LensKit refinement of the general result map type.
+ * @param <E> The result type.
+ */
+public interface LenskitResultMap<E extends Result> extends ResultMap<E>, Long2ObjectMap<E> {
+    Long2DoubleMap scoreMap();
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -1,0 +1,35 @@
+package org.lenskit.results;
+
+import org.lenskit.api.Result;
+
+/**
+ * Utility functions for working with results.
+ */
+public final class Results {
+    private Results() {}
+
+    /**
+     * Create a new result with just and ID and a score.
+     * @param id The ID.
+     * @param score The score.
+     * @return The result instance.
+     */
+    public static BasicResult create(long id, double score) {
+        return new BasicResult(id, score);
+    }
+
+    /**
+     * Create a basic result that has the same ID and score as another result (a basic copy of the result).
+     *
+     * @param r The result to copy.
+     * @return A basic result with the same ID and score as `r`.  This may be the same object as `r`, since basic
+     * results are immutable.
+     */
+    public static BasicResult basicCopy(Result r) {
+        if (r instanceof BasicResult) {
+            return (BasicResult) r;
+        } else {
+            return create(r.getId(), r.getScore());
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -1,5 +1,7 @@
 package org.lenskit.results;
 
+import com.google.common.base.Equivalence;
+import com.google.common.base.Function;
 import org.lenskit.api.Result;
 
 /**
@@ -30,6 +32,34 @@ public final class Results {
             return (BasicResult) r;
         } else {
             return create(r.getId(), r.getScore());
+        }
+    }
+
+    /**
+     * Guava function that converts a result to a basic result.  This is just {@link #basicCopy(Result)} exposed as
+     * a Guava {@link Function} for use in processing lists, etc.
+     *
+     * @return A function that maps results to basic (only score and ID) versions of them.
+     */
+    public static Function<Result,BasicResult> basicCopyFunction() {
+        return BasicCopyFunction.INSTANCE;
+    }
+
+    /**
+     * An equivalence relation that considers objects to be equal if they are equal after being converted to
+     * basic results (that is, their IDs and scores are equal).
+     * @return The equivalence relation.
+     */
+    public static Equivalence<Result> basicEquivalence() {
+        return Equivalence.equals().onResultOf(basicCopyFunction());
+    }
+
+    private enum BasicCopyFunction implements Function<Result,BasicResult> {
+        INSTANCE {
+            @Override
+            public BasicResult apply(Result result) {
+                return basicCopy(result);
+            }
         }
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -22,11 +22,15 @@ package org.lenskit.results;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Longs;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
+import org.lenskit.api.ResultMap;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -79,7 +83,29 @@ public final class Results {
     @SafeVarargs
     @Nonnull
     public static <R extends Result> ResultList newResultList(R... results) {
-        return new BasicResultList(ImmutableList.copyOf(results));
+        return new BasicResultList(Arrays.asList(results));
+    }
+
+    /**
+     * Create a new result list.
+     * @param results The results to include in the list.
+     * @return The result list.
+     */
+    @Nonnull
+    public static ResultMap newResultMap(@Nonnull List<? extends Result> results) {
+        return new BasicResultMap(results);
+    }
+
+    /**
+     * Create a new result list.
+     * @param results The results to include in the list.
+     * @param <R> the result type
+     * @return The result list.
+     */
+    @SafeVarargs
+    @Nonnull
+    public static <R extends Result> ResultMap newResultMap(R... results) {
+        return new BasicResultMap(Arrays.asList(results));
     }
 
     /**
@@ -101,12 +127,44 @@ public final class Results {
         return Equivalence.equals().onResultOf(basicCopyFunction());
     }
 
+    /**
+     * Get an ordering (comparator) that orders results by ID.
+     * @return An ordering that orders results by ID (increasing).
+     */
+    public static Ordering<Result> idOrder() {
+        return IdOrder.INSTANCE;
+    }
+
+    /**
+     * Get an ordering (comparator) that orders results by score.
+     * @return An ordering that orders results by score (increasing).
+     */
+    public static Ordering<Result> scoreOrder() {
+        return ScoreOrder.INSTANCE;
+    }
+
     private enum BasicCopyFunction implements Function<Result,BasicResult> {
         INSTANCE {
             @Override
             public BasicResult apply(Result result) {
                 return basicCopy(result);
             }
+        }
+    }
+
+    private static class IdOrder extends Ordering<Result> {
+        private static final IdOrder INSTANCE = new IdOrder();
+        @Override
+        public int compare(Result left, Result right) {
+            return Longs.compare(left.getId(), right.getId());
+        }
+    }
+
+    private static class ScoreOrder extends Ordering<Result> {
+        private static final ScoreOrder INSTANCE = new ScoreOrder();
+        @Override
+        public int compare(Result left, Result right) {
+            return Doubles.compare(left.getScore(), right.getScore());
         }
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -2,7 +2,12 @@ package org.lenskit.results;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import org.lenskit.api.Result;
+import org.lenskit.api.ResultList;
+
+import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * Utility functions for working with results.
@@ -33,6 +38,29 @@ public final class Results {
         } else {
             return create(r.getId(), r.getScore());
         }
+    }
+
+    /**
+     * Create a new result list.
+     * @param results The results to include in the list.
+     * @param <R> the result type
+     * @return The result list.
+     */
+    @Nonnull
+    public static <R extends Result> ResultList<R> newResultList(@Nonnull List<? extends R> results) {
+        return new BasicResultList<>(results);
+    }
+
+    /**
+     * Create a new result list.
+     * @param results The results to include in the list.
+     * @param <R> the result type
+     * @return The result list.
+     */
+    @SafeVarargs
+    @Nonnull
+    public static <R extends Result> ResultList<R> newResultList(R... results) {
+        return new BasicResultList<R>(ImmutableList.copyOf(results));
     }
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import com.google.common.base.Equivalence;

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -63,12 +63,11 @@ public final class Results {
     /**
      * Create a new result list.
      * @param results The results to include in the list.
-     * @param <R> the result type
      * @return The result list.
      */
     @Nonnull
-    public static <R extends Result> ResultList<R> newResultList(@Nonnull List<? extends R> results) {
-        return new BasicResultList<>(results);
+    public static ResultList newResultList(@Nonnull List<? extends Result> results) {
+        return new BasicResultList(results);
     }
 
     /**
@@ -79,8 +78,8 @@ public final class Results {
      */
     @SafeVarargs
     @Nonnull
-    public static <R extends Result> ResultList<R> newResultList(R... results) {
-        return new BasicResultList<R>(ImmutableList.copyOf(results));
+    public static <R extends Result> ResultList newResultList(R... results) {
+        return new BasicResultList(ImmutableList.copyOf(results));
     }
 
     /**

--- a/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.lenskit.api.ItemRecommender.properties
+++ b/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.lenskit.api.ItemRecommender.properties
@@ -1,0 +1,1 @@
+implementation=org.lenskit.basic.LegacyItemRecommenderAdapter

--- a/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.lenskit.api.ItemScorer.properties
+++ b/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.lenskit.api.ItemScorer.properties
@@ -1,0 +1,1 @@
+implementation=org.lenskit.basic.LegacyItemScorerAdapter

--- a/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.lenskit.api.RatingPredictor.properties
+++ b/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.lenskit.api.RatingPredictor.properties
@@ -1,0 +1,1 @@
+implementation=org.lenskit.basic.LegacyRatingPredictorAdapter

--- a/lenskit-core/src/test/groovy/org/lenskit/LenskitRecommenderEngineTest.groovy
+++ b/lenskit-core/src/test/groovy/org/lenskit/LenskitRecommenderEngineTest.groovy
@@ -1,0 +1,538 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit
+
+import org.grouplens.grapht.Component
+import org.grouplens.grapht.graph.DAGNode
+import org.grouplens.grapht.reflect.Satisfaction
+import org.grouplens.grapht.reflect.internal.InstanceSatisfaction
+import org.grouplens.grapht.solver.DesireChain
+import org.grouplens.lenskit.ItemRecommender
+import org.grouplens.lenskit.ItemScorer
+import org.grouplens.lenskit.RecommenderBuildException
+import org.grouplens.lenskit.baseline.*
+import org.grouplens.lenskit.basic.PrecomputedItemScorer
+import org.grouplens.lenskit.basic.SimpleRatingPredictor
+import org.grouplens.lenskit.basic.TopNItemRecommender
+import org.grouplens.lenskit.core.*
+import org.grouplens.lenskit.data.dao.EventCollectionDAO
+import org.grouplens.lenskit.data.dao.EventDAO
+import org.grouplens.lenskit.data.event.Event
+import org.grouplens.lenskit.data.snapshot.PreferenceSnapshot
+import org.grouplens.lenskit.iterative.StoppingThreshold
+import org.grouplens.lenskit.iterative.ThresholdStoppingCondition
+import org.grouplens.lenskit.transform.normalize.MeanVarianceNormalizer
+import org.grouplens.lenskit.transform.normalize.VectorNormalizer
+import org.grouplens.lenskit.util.io.CompressionMode
+import org.junit.Before
+import org.junit.Test
+
+import javax.inject.Inject
+import javax.inject.Provider
+import java.nio.ByteBuffer
+
+import static groovy.test.GroovyAssert.shouldFail
+import static org.hamcrest.Matchers.*
+import static org.junit.Assert.assertThat
+
+/**
+ * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ */
+public class LenskitRecommenderEngineTest {
+    private EventDAO dao
+
+    @Before
+    public void setup() {
+        dao = new EventCollectionDAO(Collections.<Event>emptyList())
+    }
+
+    @Test
+    public void testBasicRec() throws RecommenderBuildException {
+        LenskitConfiguration config = configureBasicRecommender(true)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        verifyBasicRecommender(engine.createRecommender())
+    }
+
+    @Test
+    public void testGetComponent() throws RecommenderBuildException {
+        LenskitConfiguration config = configureBasicRecommender(true)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        assertThat(engine.getComponent(ItemScorer.class),
+                   notNullValue());
+        assertThat(engine.getComponent(ItemScorer.class),
+                   instanceOf(ConstantItemScorer.class));
+    }
+
+    @Test
+    public void testBasicNoEngine() throws RecommenderBuildException {
+        LenskitConfiguration config = configureBasicRecommender(true)
+
+        org.grouplens.lenskit.core.LenskitRecommender rec = org.grouplens.lenskit.core.LenskitRecommender.build(config)
+        verifyBasicRecommender(rec)
+    }
+
+    private LenskitConfiguration configureBasicRecommender(boolean includeData) {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(ItemScorer.class)
+              .to(ConstantItemScorer.class)
+        config.bind(ItemRecommender.class)
+              .to(TopNItemRecommender.class)
+        if (includeData) {
+            makeDAOConfig(config)
+        }
+        return config
+    }
+
+    private LenskitConfiguration makeDAOConfig(LenskitConfiguration config) {
+        if (config == null) {
+            config = new LenskitConfiguration()
+        }
+        config.bind(EventDAO.class)
+              .to(dao)
+        return config
+    }
+
+    private void verifyBasicRecommender(org.grouplens.lenskit.core.LenskitRecommender rec) {
+        assertThat(rec.getItemRecommender(),
+                   instanceOf(TopNItemRecommender.class))
+        assertThat(rec.getItemScorer(),
+                   instanceOf(ConstantItemScorer.class))
+        assertThat(rec.getRatingPredictor(),
+                   instanceOf(SimpleRatingPredictor.class))
+        // Since we have an item scorer, we should have a recommender too
+        assertThat(rec.getItemRecommender(),
+                   instanceOf(TopNItemRecommender.class))
+    }
+
+    @Test
+    public void testAddComponentInstance() throws RecommenderBuildException {
+        LenskitConfiguration config = configureBasicRecommender(false)
+        config.addComponent(dao)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        verifyBasicRecommender(engine.createRecommender())
+    }
+
+    @Test
+    public void testAddComponentClass() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.addComponent(ConstantItemScorer.class)
+        makeDAOConfig(config)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        verifyBasicRecommender(engine.createRecommender())
+    }
+
+    @Test
+    public void testArbitraryRoot() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(EventDAO.class).to(dao)
+        config.bind(VectorNormalizer.class)
+              .to(MeanVarianceNormalizer.class)
+        config.addRoot(VectorNormalizer.class)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        org.grouplens.lenskit.core.LenskitRecommender rec = engine.createRecommender()
+        assertThat(rec.get(VectorNormalizer.class),
+                   instanceOf(MeanVarianceNormalizer.class))
+    }
+
+    @Test
+    public void testSeparatePredictor() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(EventDAO.class).to(dao)
+        config.bind(UserMeanBaseline.class, ItemScorer.class)
+              .to(GlobalMeanRatingItemScorer.class)
+        config.bind(ItemScorer.class)
+              .to(UserMeanItemScorer.class)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+
+        org.grouplens.lenskit.core.LenskitRecommender rec1 = engine.createRecommender()
+        org.grouplens.lenskit.core.LenskitRecommender rec2 = engine.createRecommender()
+        assertThat(rec1.getItemScorer(),
+                   instanceOf(UserMeanItemScorer.class))
+        assertThat(rec2.getItemScorer(),
+                   instanceOf(UserMeanItemScorer.class))
+
+        // verify that recommenders have different scorers
+        assertThat(rec1.getItemScorer(),
+                   not(sameInstance(rec2.getItemScorer())))
+
+        // verify that recommenders have different rating predictors
+        assertThat(rec1.getRatingPredictor(),
+                   not(sameInstance(rec2.getRatingPredictor())))
+
+        // verify that recommenders have same baseline
+        assertThat(rec1.get(UserMeanBaseline.class, ItemScorer.class),
+                   sameInstance(rec2.get(UserMeanBaseline.class, ItemScorer.class)))
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testParameter() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        // FIXME This DAO binding should not be required
+        config.bind(EventDAO.class).to(dao)
+        config.set(StoppingThreshold.class).to(0.042)
+        config.addRoot(ThresholdStoppingCondition.class)
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        org.grouplens.lenskit.core.LenskitRecommender rec = engine.createRecommender()
+        ThresholdStoppingCondition stop = rec.get(ThresholdStoppingCondition.class)
+        assertThat(stop, notNullValue())
+        assertThat(stop.getThreshold(),
+                   closeTo(0.042d, 1.0e-6d))
+    }
+
+    private void assertNodeNotEVDao(DAGNode<Component,DesireChain> node) {
+        def lbl = node.getLabel()
+        if (lbl == null) {
+            return
+        }
+        Satisfaction sat = lbl.getSatisfaction()
+        if (sat instanceof InstanceSatisfaction) {
+            assertThat((Class) sat.getErasedType(),
+                       not(equalTo((Class) EventCollectionDAO.class)))
+        }
+    }
+
+    /**
+     * Test that we can configure data separately.
+     */
+    @Test
+    public void testSeparateBuild() throws RecommenderBuildException {
+        org.grouplens.lenskit.core.LenskitRecommenderEngineBuilder reb = org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+        reb.addConfiguration(configureBasicRecommender(false))
+        LenskitConfiguration daoConfig = new LenskitConfiguration()
+        daoConfig.bind(EventDAO.class).to(dao)
+        reb.addConfiguration(daoConfig)
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = reb.build()
+        org.grouplens.lenskit.core.LenskitRecommender rec = engine.createRecommender()
+        verifyBasicRecommender(rec)
+    }
+
+    /**
+     * Test that no instance satisfaction contains an event collection DAO reference.
+     */
+    @Test
+    public void testBasicNoInstance() throws RecommenderBuildException, IOException, ClassNotFoundException {
+        LenskitConfiguration config = configureBasicRecommender(false)
+        LenskitConfiguration daoConfig = makeDAOConfig(null)
+
+        def engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                             .addConfiguration(config)
+                                             .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                             .build()
+
+        def g = engine.getGraph()
+        // make sure we have no record of an instance dao
+        for (n in g.getReachableNodes()) {
+            assertNodeNotEVDao(n)
+        }
+    }
+
+    @Test
+    public void testSerialize() throws RecommenderBuildException, IOException, ClassNotFoundException {
+        LenskitConfiguration config = configureBasicRecommender(false)
+        LenskitConfiguration daoConfig = makeDAOConfig(null)
+
+        def engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                             .addConfiguration(config)
+                                             .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                             .build()
+
+        // engine.setSymbolMapping(null)
+        File tfile = File.createTempFile("lenskit", "engine")
+        try {
+            engine.write(tfile)
+            def e2 = org.grouplens.lenskit.core.LenskitRecommenderEngine.newLoader()
+                                             .addConfiguration(daoConfig)
+                                             .load(tfile)
+            // e2.setSymbolMapping(mapping)
+            verifyBasicRecommender(e2.createRecommender())
+        } finally {
+            tfile.delete()
+        }
+    }
+
+    @Test
+    public void testSerializeCompressed() throws RecommenderBuildException, IOException, ClassNotFoundException {
+        LenskitConfiguration config = configureBasicRecommender(false)
+        LenskitConfiguration daoConfig = makeDAOConfig(null)
+
+        def engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                             .addConfiguration(config)
+                                             .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                             .build()
+
+        // engine.setSymbolMapping(null)
+        File tfile = File.createTempFile("lenskit", "engine.gz")
+        try {
+            engine.write(tfile, CompressionMode.GZIP)
+            def e2 = org.grouplens.lenskit.core.LenskitRecommenderEngine.newLoader()
+                                             .addConfiguration(daoConfig)
+                                             .load(tfile)
+            // e2.setSymbolMapping(mapping)
+            verifyBasicRecommender(e2.createRecommender())
+        } finally {
+            tfile.delete()
+        }
+    }
+
+    @Test
+    public void testDeserializeValidate() throws RecommenderBuildException, IOException, ClassNotFoundException {
+        LenskitConfiguration config = configureBasicRecommender(false)
+        LenskitConfiguration daoConfig = makeDAOConfig(null)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine =
+                org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                        .addConfiguration(config)
+                                        .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                        .build()
+
+        // engine.setSymbolMapping(null)
+        File tfile = File.createTempFile("lenskit", "engine")
+        try {
+            engine.write(tfile)
+            shouldFail(RecommenderConfigurationException) {
+                org.grouplens.lenskit.core.LenskitRecommenderEngine.newLoader().load(tfile)
+            }
+        } finally {
+            tfile.delete()
+        }
+    }
+
+    @Test
+    public void testDeserializeDeferredValidate() throws RecommenderBuildException, IOException, ClassNotFoundException {
+        LenskitConfiguration config = configureBasicRecommender(false)
+        LenskitConfiguration daoConfig = makeDAOConfig(null)
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine =
+            org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                    .addConfiguration(config)
+                                    .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                    .build()
+
+        // engine.setSymbolMapping(null)
+        File tfile = File.createTempFile("lenskit", "engine")
+        try {
+            engine.write(tfile)
+            // loading should succeed
+            def e2 = org.grouplens.lenskit.core.LenskitRecommenderEngine.newLoader()
+                                             .setValidationMode(EngineValidationMode.DEFERRED)
+                                             .load(tfile)
+            shouldFail(IllegalStateException) {
+                // creating the recommender should fail
+                e2.createRecommender()
+            }
+        } finally {
+            tfile.delete()
+        }
+    }
+
+    @Test
+    public void testContextDep() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(EventDAO.class)
+              .to(dao)
+        config.bind(ItemScorer.class)
+              .to(FallbackItemScorer.class)
+        config.bind(PrimaryScorer.class, ItemScorer.class)
+                .to(PrecomputedItemScorer.newBuilder()
+                                  .addScore(42, 15, 3.5)
+                                  .build())
+        config.bind(BaselineScorer.class, ItemScorer.class)
+              .to(FallbackItemScorer.class)
+        config.within(BaselineScorer.class, FallbackItemScorer.class)
+              .bind(PrimaryScorer.class, ItemScorer.class)
+              .to(PrecomputedItemScorer.newBuilder()
+                                .addScore(38, 10, 4.0)
+                                .build())
+        config.within(BaselineScorer.class, FallbackItemScorer.class)
+              .bind(BaselineScorer.class, ItemScorer.class)
+              .to(new ConstantItemScorer(3.0))
+
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        org.grouplens.lenskit.core.LenskitRecommender rec = engine.createRecommender()
+        ItemScorer scorer = rec.getItemScorer()
+        assertThat(scorer, notNullValue())
+        assert scorer != null
+        // first scorer
+        assertThat(scorer.score(42, 15), equalTo(3.5d))
+        // first fallback
+        assertThat(scorer.score(38, 10), equalTo(4.0d))
+        // second fallback
+        assertThat(scorer.score(42, 10), equalTo(3.0d))
+    }
+
+    /**
+     * Verify that we can inject subclassed DAOs.
+     */
+    @Test
+    public void testSubclassedDAO() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(EventDAO.class).to(dao)
+        config.addRoot(SubclassedDAODepComponent.class)
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+        org.grouplens.lenskit.core.LenskitRecommender rec = engine.createRecommender()
+        SubclassedDAODepComponent dep = rec.get(SubclassedDAODepComponent.class)
+        assertThat(dep, notNullValue())
+        assertThat(dep.dao, notNullValue())
+    }
+
+    public static class SubclassedDAODepComponent {
+        private final EventCollectionDAO dao
+
+        @Inject
+        public SubclassedDAODepComponent(EventCollectionDAO dao) {
+            this.dao = dao
+        }
+    }
+
+    /**
+     * Test anchoring to the root (#344).
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testAnchoredRoot() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(EventDAO.class).to(dao)
+        config.bind(ItemScorer.class)
+              .to(ConstantItemScorer.class)
+        config.set(ConstantItemScorer.Value.class)
+              .to(3.5)
+        config.at(null)
+              .bind(ItemScorer.class)
+              .to(FallbackItemScorer.class)
+        config.bind(BaselineScorer.class, ItemScorer.class)
+              .to(GlobalMeanRatingItemScorer.class)
+        org.grouplens.lenskit.core.LenskitRecommender rec = org.grouplens.lenskit.core.LenskitRecommender.build(config)
+        assertThat(rec.getItemScorer(), instanceOf(FallbackItemScorer.class))
+        SimpleRatingPredictor rp = (SimpleRatingPredictor) rec.getRatingPredictor()
+        assertThat(rp, notNullValue())
+        assert rp != null
+        assertThat(rp.getScorer(), instanceOf(ConstantItemScorer.class))
+        assertThat(((FallbackItemScorer) rec.getItemScorer()).getPrimaryScorer(),
+                   sameInstance(rp.getScorer()))
+    }
+
+    /**
+     * Test that recommender engines verify that they are instantiable.
+     */
+    @Test
+    public void testEngineChecksInstantiable() {
+        def config = configureBasicRecommender(false)
+        def daoConfig = new LenskitConfiguration()
+        makeDAOConfig(daoConfig)
+        def engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                             .addConfiguration(config)
+                                             .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                             .build()
+        shouldFail(IllegalStateException) {
+            engine.createRecommender()
+        }
+    }
+
+    @Test
+    public void testEngineRewriting() {
+        def config = configureBasicRecommender(false)
+        def daoConfig = new LenskitConfiguration()
+        makeDAOConfig(daoConfig)
+        def engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.newBuilder()
+                                             .addConfiguration(config)
+                                             .addConfiguration(daoConfig, ModelDisposition.EXCLUDED)
+                                             .build()
+        def rec = engine.createRecommender(daoConfig)
+        verifyBasicRecommender(rec)
+    }
+
+    //region Test shareable providers
+    @Test
+    public void testShareableProvider() throws RecommenderBuildException {
+        LenskitConfiguration config = new LenskitConfiguration()
+        config.bind(EventDAO.class)
+              .to(dao)
+        config.addRoot(RootComp.class)
+        config.bind(ByteBuffer.class)
+              .toProvider(BufferProvider.class)
+        config.bind(InputStream.class)
+              .toProvider(StreamProvider.class)
+        org.grouplens.lenskit.core.LenskitRecommenderEngine engine = org.grouplens.lenskit.core.LenskitRecommenderEngine.build(config)
+
+        org.grouplens.lenskit.core.LenskitRecommender rec1 = engine.createRecommender()
+        org.grouplens.lenskit.core.LenskitRecommender rec2 = engine.createRecommender()
+        assertThat(rec2, not(sameInstance(rec1)))
+
+        RootComp r1 = rec1.get(RootComp.class)
+        RootComp r2 = rec2.get(RootComp.class)
+        // byte buffers are shared
+        assertThat(r2.getBuffer(), sameInstance(r1.getBuffer()))
+        // streams are not
+        assertThat(r2.getStream(), not(sameInstance(r1.getStream())))
+    }
+
+    public static class RootComp {
+        private final ByteBuffer buf
+        private final InputStream stream
+
+        @Inject
+        public RootComp(ByteBuffer b, InputStream s) {
+            buf = b
+            stream = s
+        }
+
+        public ByteBuffer getBuffer() {
+            return buf
+        }
+
+        public InputStream getStream() {
+            return stream
+        }
+    }
+
+    public static class BufferProvider implements Provider<ByteBuffer> {
+        @Override
+        @Shareable
+        public ByteBuffer get() {
+            return ByteBuffer.allocate(32)
+        }
+    }
+
+    public static class StreamProvider implements Provider<InputStream> {
+        @Override
+        public InputStream get() {
+            return new ByteArrayInputStream([0, 3, 2] as byte[])
+        }
+    }
+    //endregion
+
+    @Test
+    public void testRemoveShareableSnapshot() {
+        def config = new LenskitConfiguration();
+        config.bind(ItemScorer).to(LeastSquaresItemScorer)
+        config.bind(EventDAO).to(dao)
+        org.grouplens.lenskit.core.LenskitRecommender rec = org.grouplens.lenskit.core.LenskitRecommender.build(config)
+        assertThat rec.getItemScorer(), instanceOf(LeastSquaresItemScorer)
+        assertThat rec.get(PreferenceSnapshot), nullValue()
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultListTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultListTest.java
@@ -1,0 +1,36 @@
+package org.lenskit.results;
+
+import org.junit.Test;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultList;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class BasicResultListTest {
+    @Test
+    public void testEmptyList() {
+        ResultList<Result> r = Results.newResultList();
+        assertThat(r.isEmpty(), equalTo(true));
+        assertThat(r.size(), equalTo(0));
+        assertThat(r.idList(), hasSize(0));
+    }
+
+    @Test
+    public void testSingletonList() {
+        ResultList<Result> r = Results.<Result>newResultList(Results.create(42L, 3.5));
+        assertThat(r, hasSize(1));
+        assertThat(r, contains((Result) Results.create(42L, 3.5)));
+        assertThat(r.idList(), hasSize(1));
+        assertThat(r.idList(), contains(42L));
+    }
+
+    @Test
+    public void testMultiList() {
+        ResultList<Result> r = Results.<Result>newResultList(Results.create(42L, 3.5),
+                                                             Results.create(37L, 4.2));
+        assertThat(r, hasSize(2));
+        assertThat(r, contains((Result) Results.create(42L, 3.5),
+                               (Result) Results.create(37L, 4.2)));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultListTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultListTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import org.junit.Test;

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultListTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultListTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.*;
 public class BasicResultListTest {
     @Test
     public void testEmptyList() {
-        ResultList<Result> r = Results.newResultList();
+        ResultList r = Results.newResultList();
         assertThat(r.isEmpty(), equalTo(true));
         assertThat(r.size(), equalTo(0));
         assertThat(r.idList(), hasSize(0));
@@ -38,7 +38,7 @@ public class BasicResultListTest {
 
     @Test
     public void testSingletonList() {
-        ResultList<Result> r = Results.<Result>newResultList(Results.create(42L, 3.5));
+        ResultList r = Results.<Result>newResultList(Results.create(42L, 3.5));
         assertThat(r, hasSize(1));
         assertThat(r, contains((Result) Results.create(42L, 3.5)));
         assertThat(r.idList(), hasSize(1));
@@ -47,7 +47,7 @@ public class BasicResultListTest {
 
     @Test
     public void testMultiList() {
-        ResultList<Result> r = Results.<Result>newResultList(Results.create(42L, 3.5),
+        ResultList r = Results.<Result>newResultList(Results.create(42L, 3.5),
                                                              Results.create(37L, 4.2));
         assertThat(r, hasSize(2));
         assertThat(r, contains((Result) Results.create(42L, 3.5),

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
@@ -1,0 +1,58 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.results;
+
+import org.junit.Test;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class BasicResultMapTest {
+    @Test
+    public void testEmptyMap() {
+        ResultMap r = Results.newResultMap();
+        assertThat(r.isEmpty(), equalTo(true));
+        assertThat(r.size(), equalTo(0));
+        assertThat(r.resultSet(), hasSize(0));
+        assertThat(r.scoreMap().size(), equalTo(0));
+    }
+
+    @Test
+    public void testSingletonMap() {
+        ResultMap r = Results.<Result>newResultMap(Results.create(42L, 3.5));
+        assertThat(r.size(), equalTo(1));
+        assertThat(r.resultSet(), contains((Result) Results.create(42L, 3.5)));
+        assertThat(r.resultSet(), hasSize(1));
+        assertThat(r.get(42L), equalTo((Result) Results.create(42L, 3.5)));
+    }
+
+    @Test
+    public void testMultiMap() {
+        ResultMap r = Results.<Result>newResultMap(Results.create(42L, 3.5),
+                                                   Results.create(37L, 4.2));
+        assertThat(r.size(), equalTo(2));
+        assertThat(r.keySet(), contains(42L, 37L));
+        assertThat(r.resultSet(), contains((Result) Results.create(42L, 3.5),
+                                           (Result) Results.create(37L, 4.2)));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
@@ -34,7 +34,6 @@ public class BasicResultMapTest {
         ResultMap r = Results.newResultMap();
         assertThat(r.isEmpty(), equalTo(true));
         assertThat(r.size(), equalTo(0));
-        assertThat(r.resultSet(), hasSize(0));
         assertThat(r.scoreMap().size(), equalTo(0));
         assertThat(r.getScore(42), notANumber());
     }
@@ -43,8 +42,7 @@ public class BasicResultMapTest {
     public void testSingletonMap() {
         ResultMap r = Results.<Result>newResultMap(Results.create(42L, 3.5));
         assertThat(r.size(), equalTo(1));
-        assertThat(r.resultSet(), contains((Result) Results.create(42L, 3.5)));
-        assertThat(r.resultSet(), hasSize(1));
+        assertThat(r, contains((Result) Results.create(42L, 3.5)));
         assertThat(r.get(42L), equalTo((Result) Results.create(42L, 3.5)));
         assertThat(r.getScore(42), equalTo(3.5));
     }
@@ -55,8 +53,8 @@ public class BasicResultMapTest {
                                                    Results.create(37L, 4.2));
         assertThat(r.size(), equalTo(2));
         assertThat(r.keySet(), contains(42L, 37L));
-        assertThat(r.resultSet(), contains((Result) Results.create(42L, 3.5),
-                                           (Result) Results.create(37L, 4.2)));
+        assertThat(r, contains((Result) Results.create(42L, 3.5),
+                               (Result) Results.create(37L, 4.2)));
         assertThat(r.getScore(42), equalTo(3.5));
         assertThat(r.getScore(37), equalTo(4.2));
         assertThat(r.getScore(28), notANumber());

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultMap;
 
+import static org.grouplens.lenskit.util.test.ExtraMatchers.notANumber;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -35,6 +36,7 @@ public class BasicResultMapTest {
         assertThat(r.size(), equalTo(0));
         assertThat(r.resultSet(), hasSize(0));
         assertThat(r.scoreMap().size(), equalTo(0));
+        assertThat(r.getScore(42), notANumber());
     }
 
     @Test
@@ -44,6 +46,7 @@ public class BasicResultMapTest {
         assertThat(r.resultSet(), contains((Result) Results.create(42L, 3.5)));
         assertThat(r.resultSet(), hasSize(1));
         assertThat(r.get(42L), equalTo((Result) Results.create(42L, 3.5)));
+        assertThat(r.getScore(42), equalTo(3.5));
     }
 
     @Test
@@ -54,5 +57,8 @@ public class BasicResultMapTest {
         assertThat(r.keySet(), contains(42L, 37L));
         assertThat(r.resultSet(), contains((Result) Results.create(42L, 3.5),
                                            (Result) Results.create(37L, 4.2)));
+        assertThat(r.getScore(42), equalTo(3.5));
+        assertThat(r.getScore(37), equalTo(4.2));
+        assertThat(r.getScore(28), notANumber());
     }
 }

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.results;
 
 import net.java.quickcheck.collection.Pair;

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultTest.java
@@ -1,0 +1,45 @@
+package org.lenskit.results;
+
+import net.java.quickcheck.collection.Pair;
+import org.junit.Test;
+import org.lenskit.api.Result;
+
+import static net.java.quickcheck.generator.CombinedGeneratorsIterables.somePairs;
+import static net.java.quickcheck.generator.PrimitiveGenerators.doubles;
+import static net.java.quickcheck.generator.PrimitiveGenerators.longs;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class BasicResultTest {
+    @Test
+    public void testGetters() {
+        for (Pair<Long,Double> pair: somePairs(longs(), doubles())) {
+            Result r = new BasicResult(pair.getFirst(), pair.getSecond());
+            assertThat(r.getId(), equalTo(pair.getFirst()));
+            assertThat(r.getScore(), equalTo(pair.getSecond()));
+            assertThat(r.hasScore(), equalTo(true));
+        }
+    }
+
+    @Test
+    public void testHasScore() {
+        Result r = new BasicResult(42, Double.NaN);
+        assertThat(r.hasScore(), equalTo(false));
+    }
+
+    @Test
+    public void testEquality() {
+        BasicResult result = new BasicResult(42, Math.PI);
+        BasicResult equal = new BasicResult(42, Math.PI);
+        BasicResult sameId = new BasicResult(42, Math.E);
+        BasicResult sameScore = new BasicResult(37, Math.PI);
+        BasicResult diff = new BasicResult(37, Math.E);
+
+        assertThat(result.equals(null), equalTo(false));
+        assertThat(result.equals(result), equalTo(true));
+        assertThat(result.equals(equal), equalTo(true));
+        assertThat(result.equals(sameId), equalTo(false));
+        assertThat(result.equals(sameScore), equalTo(false));
+        assertThat(result.equals(diff), equalTo(false));
+    }
+}


### PR DESCRIPTION
This works on #727.

We are not ready to merge this - it is just interfaces. However, I would like to think about interfaces before taking the time to implement.

The idea here is that (almost) all recommendation operations return a *result set*: a (possibly ordered) map of item (or user, for finding related users) IDs to values. Individual algorithms can extend the result set to provide additional details (see [DetailedResults](//github.com/lenskit/lenskit/wiki/DetailedResults)).

For recommendation, the result set will be ordered in decreasing order of score.

This subsumes both `SparseVector` and `List<ScoredId>` for recommendation and prediction results.