### PR TITLE
Synchronize the NodeInstantiator

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/inject/NodeInstantiator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/inject/NodeInstantiator.java
@@ -73,7 +73,11 @@ public abstract class NodeInstantiator implements Function<DAGNode<Component,Dep
 
         @Override
         public Object instantiate(DAGNode<Component, Dependency> node) throws InjectionException {
-            return container.makeInstantiator(node).instantiate();
+            Instantiator inst;
+            synchronized (container) {
+                inst = container.makeInstantiator(node);
+            }
+            return inst.instantiate();
         }
     }
 }


### PR DESCRIPTION
It seems that, in rare cases, we may be triggering the WeakHashMap live-lock discussed here: https://java.net/jira/browse/JAVASERVERFACES-2544

This synchronizes our use of InjectionContainer to avoid that live-lock.