### PR TITLE
Some basic cleanups

### DIFF
--- a/lenskit-cli/src/main/java/org/lenskit/cli/commands/Predict.java
+++ b/lenskit-cli/src/main/java/org/lenskit/cli/commands/Predict.java
@@ -93,7 +93,7 @@ public class Predict implements Command {
                 }
             }
         }
-        System.out.format("predictions for user %d:\n", user);
+        System.out.format("predictions for user %d:%n", user);
         for (VectorEntry e: preds) {
             System.out.format("  %d", e.getKey());
             if (names != null) {

--- a/lenskit-cli/src/main/java/org/lenskit/cli/commands/Recommend.java
+++ b/lenskit-cli/src/main/java/org/lenskit/cli/commands/Recommend.java
@@ -82,7 +82,7 @@ public class Recommend implements Command {
         Stopwatch timer = Stopwatch.createStarted();
         for (long user: users) {
             List<ScoredId> recs = irec.recommend(user, n);
-            System.out.format("recommendations for user %d:\n", user);
+            System.out.format("recommendations for user %d:%n", user);
             for (ScoredId item: recs) {
                 System.out.format("  %d", item.getId());
                 if (indao != null) {

--- a/lenskit-cli/src/main/java/org/lenskit/cli/commands/Version.java
+++ b/lenskit-cli/src/main/java/org/lenskit/cli/commands/Version.java
@@ -44,9 +44,9 @@ public class Version implements Command {
     @Override
     public void execute(Namespace opts) throws Exception {
         String version = LenskitInfo.lenskitVersion();
-        System.out.format("LensKit version %s\n", version);
+        System.out.format("LensKit version %s%n", version);
         if (version.endsWith("-SNAPSHOT")) {
-            System.out.format("Git revision %s\n", LenskitInfo.getHeadRevision());
+            System.out.format("Git revision %s%n", LenskitInfo.getHeadRevision());
         }
     }
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/inject/GraphtUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/inject/GraphtUtils.java
@@ -57,30 +57,6 @@ public final class GraphtUtils {
     private GraphtUtils() {
     }
 
-//    public static Node replaceNodeWithPlaceholder(InjectSPI spi, Graph graph, Node node) {
-//        // replace it with a null satisfaction
-//        final Component daoLbl = node.getLabel();
-//        assert daoLbl != null;
-//        final Satisfaction oldSat = daoLbl.getSatisfaction();
-//        final Class<?> type = oldSat.getErasedType();
-//        final Satisfaction sat = spi.satisfyWithNull(type);
-//        final Node placeholder = new Node(sat, CachePolicy.MEMOIZE);
-//        graph.replaceNode(node, placeholder);
-//
-//        // replace desires on edges (truncates desire chains to only contain head, dropping refs)
-//        for (Edge e: Lists.newArrayList(graph.getIncomingEdges(placeholder))) {
-//            Desire d = e.getDesire();
-//            List<Desire> lbl = null;
-//            if (d != null) {
-//                lbl = Collections.singletonList(d);
-//            }
-//            Edge replacement = new Edge(e.getHead(), e.getTail(), lbl);
-//            graph.replaceEdge(e, replacement);
-//        }
-//
-//        return placeholder;
-//    }
-
     /**
      * Check a graph for placeholder satisfactions.
      *
@@ -130,9 +106,6 @@ public final class GraphtUtils {
      */
     public static boolean isShareable(DAGNode<Component, Dependency> node) {
         Component label = node.getLabel();
-        if (label == null) {
-            return false;
-        }
 
         if (label.getSatisfaction().hasInstance()) {
             return true;
@@ -248,7 +221,7 @@ public final class GraphtUtils {
     /**
      * An ordering over dependency edges.
      */
-    public static Ordering<DAGEdge<Component, Dependency>> DEP_EDGE_ORDER =
+    public static final Ordering<DAGEdge<Component, Dependency>> DEP_EDGE_ORDER =
             Ordering.<String>natural()
                     .lexicographical()
                     .onResultOf(ORDER_KEY);
@@ -292,7 +265,6 @@ public final class GraphtUtils {
      *
      * @param type The type to look for.
      * @return A node whose satisfaction is compatible with {@code type}.
-     * @review Decide how to handle qualifiers and contexts
      */
     @Nullable
     public static DAGNode<Component,Dependency> findSatisfyingNode(DAGNode<Component,Dependency> graph,

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/graph/GraphDumper.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/graph/GraphDumper.java
@@ -41,10 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Provider;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
+import java.io.*;
 import java.lang.annotation.Annotation;
 import java.util.*;
 
@@ -337,7 +334,8 @@ public class GraphDumper {
         DAGNode<Component, Dependency> unshared = instantiator.simulate();
         logger.debug("unshared graph has {} nodes", unshared.getReachableNodes().size());
         try (Writer writer = new FileWriter(graphvizFile);
-             GraphWriter gw = new GraphWriter(writer)) {
+             BufferedWriter bw = new BufferedWriter(writer);
+             GraphWriter gw = new GraphWriter(bw)) {
 
             GraphDumper dumper = new GraphDumper(graph, unshared.getReachableNodes(), gw);
             logger.debug("writing root node");

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/graph/GraphWriter.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/graph/GraphWriter.java
@@ -73,8 +73,8 @@ class GraphWriter implements Closeable {
     public void close() throws IOException {
         // write the end of the GraphViz file, closing the writer when we're done
         try (BufferedWriter w = output) {
-            output.write("}");
-            output.newLine();
+            w.write("}");
+            w.newLine();
         }
     }
 
@@ -130,7 +130,8 @@ class GraphWriter implements Closeable {
         if (name != null) {
             output.append(name).append(" ");
         }
-        output.append("{\n");
+        output.append("{");
+        output.newLine();
         for (Map.Entry<String,Object> e: subgraph.getAttributes().entrySet()) {
             output.append("    ")
                   .append(e.getKey())

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/JobStatusWriter.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/eval/traintest/JobStatusWriter.java
@@ -127,7 +127,7 @@ class JobStatusWriter {
                     writer.print("- task: ");
                     writer.println(job);
                     DateTime start = startTime.get(job);
-                    writer.format("  started: %s\n", format.print(start));
+                    writer.format("  started: %s%n", format.print(start));
                     writer.println("  thread: " + threads.get(job).getName());
                 }
             } finally {

--- a/lenskit-eval/src/main/java/org/grouplens/lenskit/util/table/writer/CSVWriter.java
+++ b/lenskit-eval/src/main/java/org/grouplens/lenskit/util/table/writer/CSVWriter.java
@@ -20,6 +20,7 @@
  */
 package org.grouplens.lenskit.util.table.writer;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -46,7 +47,7 @@ import static org.apache.commons.lang3.StringEscapeUtils.escapeCsv;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class CSVWriter extends AbstractTableWriter {
-    private Writer writer;
+    private BufferedWriter writer;
     private TableLayout layout;
 
     /**
@@ -59,7 +60,11 @@ public class CSVWriter extends AbstractTableWriter {
     public CSVWriter(@Nonnull Writer w, @Nullable TableLayout l) throws IOException {
         Preconditions.checkNotNull(w, "writer must not be null");
         layout = l;
-        writer = w;
+        if (w instanceof BufferedWriter) {
+            writer = (BufferedWriter) w;
+        } else {
+            writer = new BufferedWriter(w);
+        }
         if (layout != null) {
             writeRow(layout.getColumns().toArray(new Object[l.getColumnCount()]));
         }
@@ -88,7 +93,7 @@ public class CSVWriter extends AbstractTableWriter {
                 writer.write(escapeCsv(val.toString()));
             }
         }
-        writer.write('\n');
+        writer.newLine();
         writer.flush();
     }
 


### PR DESCRIPTION
This addresses some Sonar warnings

- don't implement `Comparable` in a broken way (internal class, but decreases our noise)
- make some stuff final
- use platform-specific EOL consistently
- improve error handling in GraphWriter