### PR TITLE
Route data sources through Gradle tasks

### DIFF
--- a/lenskit-gradle/src/it/gradle/task-deps/build.gradle
+++ b/lenskit-gradle/src/it/gradle/task-deps/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+    repositories {
+        maven {
+            url "$project.testRepoURI"
+        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.hamcrest:hamcrest-library:1.3'
+        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+    }
+}
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+import org.lenskit.gradle.*
+
+apply plugin: 'java'
+apply plugin: 'lenskit'
+
+task crossfold(type: Crossfold)
+
+task('check', overwrite: true) {
+    doLast {
+        def dep = crossfold.taskDependencies
+        def deps = dep.getDependencies(crossfold)
+        assertThat(deps, hasItem(classes))
+    }
+}

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/Crossfold.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/Crossfold.groovy
@@ -23,6 +23,7 @@ package org.lenskit.gradle
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
+import org.lenskit.gradle.traits.DataBuilder
 import org.lenskit.gradle.traits.DataSources
 import org.lenskit.specs.SpecUtils
 import org.lenskit.specs.data.DataSourceSpec
@@ -60,6 +61,11 @@ class Crossfold extends LenskitTask implements DataSources {
 
     void input(DataSourceSpec src) {
         spec.source = src
+    }
+
+    void input(DataBuilder bld) {
+        dependsOn bld
+        spec.deferredSource = bld.deferredDataSourceSpec
     }
 
     /**

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/Crossfold.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/Crossfold.groovy
@@ -79,9 +79,9 @@ class Crossfold extends LenskitTask implements DataSources {
 
     @InputFiles
     Set<File> getInputFiles() {
-        return spec.source.inputFiles.collect {
+        return spec.source?.inputFiles?.collect {
             it.toFile()
-        }
+        } ?: []
     }
 
     @OutputFiles

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitTask.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitTask.groovy
@@ -78,7 +78,6 @@ public abstract class LenskitTask extends ConventionTask {
         conventionMapping.maxMemory = { ext.maxMemory }
         conventionMapping.logLevel = { ext.logLevel }
         conventionMapping.logFileLevel = { ext.logFileLevel }
-        // FIXME Make dependencies work!
         conventionMapping.classpath = { ext.classpath ?: project.sourceSets.main.runtimeClasspath }
     }
 

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/PackRatings.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/PackRatings.groovy
@@ -20,18 +20,18 @@
  */
 package org.lenskit.gradle
 
-import groovy.json.JsonBuilder
-import groovy.json.JsonOutput
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
+import org.lenskit.gradle.traits.DataBuilder
 import org.lenskit.gradle.traits.DataSources
 import org.lenskit.specs.SpecUtils
 import org.lenskit.specs.data.DataSourceSpec
+import org.lenskit.specs.data.PackedDataSourceSpec
 
 /**
  * Pack a data set.
  */
-class PackRatings extends LenskitTask implements DataSources {
+class PackRatings extends LenskitTask implements DataBuilder, DataSources {
     DataSourceSpec inputSpec
     /**
      * The output file.  Defaults to "build/$name.pack", where $name is the name of the task.
@@ -50,8 +50,7 @@ class PackRatings extends LenskitTask implements DataSources {
     }
 
     /**
-     * Configure the input data.  This should be an input specification in Groovy {@link JsonBuilder} syntax.  Common
-     * input types should be configured with {@link #input(Map)}.
+     * Configure the input data.
      *
      * @param inputSpec The input specification.
      */
@@ -60,7 +59,7 @@ class PackRatings extends LenskitTask implements DataSources {
     }
 
     /**
-     * Configure an input CSV file of ratings.  Convenience method; {@link #input(Closure)} is more general.
+     * Configure an input CSV file of ratings.  Convenience method; {@link #input(DataSourceSpec)} is more general.
      * @param csv A CSV file containing ratings.
      */
     void inputFile(File csv) {
@@ -107,5 +106,16 @@ class PackRatings extends LenskitTask implements DataSources {
     File getSpecFile() {
         File specFile = new File(project.buildDir, "${name}.input.json")
         return specFile
+    }
+
+    @Override
+    DataSourceSpec getDataSourceSpec() {
+        def spec = new PackedDataSourceSpec()
+        spec.name = name
+        spec.file = getOutputFile().toPath()
+        if (inputSpec.hasProperty('domain')) {
+            spec.domain = inputSpec.domain
+        }
+        return spec
     }
 }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/traits/DataBuilder.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/traits/DataBuilder.groovy
@@ -25,7 +25,8 @@ import org.gradle.api.Task
 import org.lenskit.specs.data.DataSourceSpec
 
 /**
- * Something that builds data sources.
+ * Something that builds data sources.  Tasks can implement this interface to be able to provide
+ * individual data sources that will be automatically routed to other tasks.
  */
 trait DataBuilder implements Task {
     abstract DataSourceSpec getDataSourceSpec();

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/traits/DataBuilder.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/traits/DataBuilder.groovy
@@ -1,0 +1,48 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.gradle.traits
+
+import com.google.common.base.Supplier
+import org.gradle.api.Task
+import org.lenskit.specs.data.DataSourceSpec
+
+/**
+ * Something that builds data sources.
+ */
+trait DataBuilder implements Task {
+    abstract DataSourceSpec getDataSourceSpec();
+
+    Supplier<DataSourceSpec> getDeferredDataSourceSpec() {
+        return new DeferredSource(this)
+    }
+
+    private static class DeferredSource implements Supplier<DataSourceSpec> {
+        final DataBuilder task
+
+        DeferredSource(DataBuilder db) {
+            task = db
+        }
+
+        DataSourceSpec get() {
+            task.dataSourceSpec
+        }
+    }
+}

--- a/lenskit-integration-tests/src/it/gradle/gradle-crossfold-packed/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-crossfold-packed/build.gradle
@@ -1,0 +1,62 @@
+/* Test routing a packed data source through a crossfolder, to validate the data plubming logic.
+ */
+buildscript {
+    repositories {
+        maven {
+            url "$project.testRepoURI"
+        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.hamcrest:hamcrest-library:1.3'
+        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+    }
+}
+
+import org.lenskit.gradle.*
+import static org.hamcrest.MatcherAssert.*
+import static org.hamcrest.Matchers.*
+
+apply plugin: 'java'
+apply plugin: 'lenskit'
+
+repositories {
+    maven {
+        url testRepoURI
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
+    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
+}
+
+task pack(type: PackRatings) {
+    input textFile {
+        file ratingsFile
+        delimiter "\t"
+    }
+    output "$buildDir/ml-100k.pack"
+}
+
+task crossfold(type: Crossfold) {
+    input pack
+    outputFormat "PACK"
+    includeTimestamps false
+}
+
+check {
+    dependsOn crossfold
+    doLast {
+        def dir = file("$buildDir/crossfold.out")
+        assertThat dir.exists(), equalTo(true)
+        assertThat "packed data exists", file("$buildDir/ml-100k.pack").exists()
+        assertThat "all-partitions exists", file("$dir/all-partitions.json").exists()
+        for (int i = 1; i <= 5; i++) {
+            assertThat "spec file $i exists", file(String.format("$dir/part%02d.json", i)).exists()
+            assertThat "train file $i exists", file(String.format("$dir/part%02d.train.pack", i)).exists()
+            assertThat "test file $i exists", file(String.format("$dir/part%02d.test.pack", i)).exists()
+        }
+    }
+}

--- a/lenskit-specs/build.gradle
+++ b/lenskit-specs/build.gradle
@@ -38,6 +38,7 @@ apply plugin: 'java'
 apply from: "$rootDir/gradle/test-utils.gradle"
 
 dependencies {
+    compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.5.4'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.3'
 }

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
@@ -21,6 +21,8 @@
 package org.lenskit.specs.eval;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.lenskit.specs.AbstractSpec;
 import org.lenskit.specs.data.DataSourceSpec;
 
@@ -31,7 +33,8 @@ import java.nio.file.Path;
  */
 public class CrossfoldSpec extends AbstractSpec {
     private String name;
-    private DataSourceSpec source;
+    // source is a supplier to allow it to be deferred
+    private Supplier<DataSourceSpec> source;
 
     private int partitionCount = 5;
 
@@ -49,6 +52,7 @@ public class CrossfoldSpec extends AbstractSpec {
         hold.setOrder("random");
         hold.setCount(10);
         userPartitionMethod = hold;
+        source = Suppliers.ofInstance(null);
     }
 
     public String getName() {
@@ -60,11 +64,15 @@ public class CrossfoldSpec extends AbstractSpec {
     }
 
     public DataSourceSpec getSource() {
-        return source;
+        return source.get();
+    }
+
+    public void setDeferredSource(Supplier<DataSourceSpec> deferredSource) {
+        source = deferredSource;
     }
 
     public void setSource(DataSourceSpec source) {
-        this.source = source;
+        setDeferredSource(Suppliers.ofInstance(source));
     }
 
     public int getPartitionCount() {


### PR DESCRIPTION
This augments the Gradle plugin to address #747, allowing data sources to automatically be detected and routed through tasks so that a LensKit Gradle task can take another task as input. It adds support for this to `Crossfold` (consumer) and `PackRatings` (supplier) to test it. 

It also adds a test to make sure that LensKit tasks automatically depend on Java compilation if they are running from the project's classpath.