### PR TITLE
Add and use keyed object map data set

### DIFF
--- a/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/BasicResultMap.java
@@ -20,10 +20,13 @@
  */
 package org.lenskit.results;
 
-import com.google.common.collect.Iterators;
-import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.longs.AbstractLong2DoubleMap;
+import it.unimi.dsi.fastutil.longs.AbstractLong2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.*;
 import org.lenskit.api.Result;
+import org.lenskit.util.keys.KeyedObjectMap;
 
 import javax.annotation.concurrent.Immutable;
 import java.util.Collection;
@@ -37,17 +40,14 @@ import java.util.Map;
 public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements LenskitResultMap {
     private static final long serialVersionUID = 1L;
 
-    private final Long2ObjectMap<Result> delegate;
+    private final KeyedObjectMap<Result> delegate;
 
     /**
      * Create a new result map from a collection of results.
      * @param objs The results.
      */
     public BasicResultMap(Collection<? extends Result> objs) {
-        delegate = new Long2ObjectLinkedOpenHashMap<>();
-        for (Result r: objs) {
-            delegate.put(r.getId(), r);
-        }
+        delegate = new KeyedObjectMap<>(objs, Results.keyExtractor());
     }
 
     @Override
@@ -57,12 +57,12 @@ public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements Le
 
     @Override
     public Iterator<Result> iterator() {
-        return Iterators.unmodifiableIterator(delegate.values().iterator());
+        return delegate.values().iterator();
     }
 
     @Override
     public ObjectSet<Entry<Result>> long2ObjectEntrySet() {
-        return ObjectSets.unmodifiable(delegate.long2ObjectEntrySet());
+        return delegate.long2ObjectEntrySet();
     }
 
     @Override
@@ -77,17 +77,17 @@ public class BasicResultMap extends AbstractLong2ObjectMap<Result> implements Le
 
     @Override
     public ObjectCollection<Result> values() {
-        return ObjectCollections.unmodifiable(delegate.values());
+        return delegate.values();
     }
 
     @Override
     public ObjectSet<Map.Entry<Long, Result>> entrySet() {
-        return ObjectSets.unmodifiable(delegate.entrySet());
+        return delegate.entrySet();
     }
 
     @Override
     public LongSet keySet() {
-        return LongSets.unmodifiable(delegate.keySet());
+        return delegate.keySet();
     }
 
     @Override

--- a/lenskit-core/src/main/java/org/lenskit/results/Results.java
+++ b/lenskit-core/src/main/java/org/lenskit/results/Results.java
@@ -28,6 +28,7 @@ import com.google.common.primitives.Longs;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
 import org.lenskit.api.ResultMap;
+import org.lenskit.util.keys.KeyExtractor;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -143,6 +144,14 @@ public final class Results {
         return ScoreOrder.INSTANCE;
     }
 
+    /**
+     * Get a key extractor that extracts the result's ID as its key.
+     * @return The key extractor.
+     */
+    public static KeyExtractor<Result> keyExtractor() {
+        return KeyEx.INSTANCE;
+    }
+
     private enum BasicCopyFunction implements Function<Result,BasicResult> {
         INSTANCE {
             @Override
@@ -165,6 +174,14 @@ public final class Results {
         @Override
         public int compare(Result left, Result right) {
             return Doubles.compare(left.getScore(), right.getScore());
+        }
+    }
+
+    private static class KeyEx implements KeyExtractor<Result> {
+        private static final KeyEx INSTANCE = new KeyEx();
+        @Override
+        public long getKey(Result obj) {
+            return obj.getId();
         }
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/util/keys/KeyExtractor.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/keys/KeyExtractor.java
@@ -1,0 +1,41 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.util.keys;
+
+import java.io.Serializable;
+
+/**
+ * Extract keys from objects.  An implementation of this interface extracts keys from objects such that two objects have
+ * the same key if and only if they should be considered equivalent objects in some context.  This is used for objects
+ * that contain information about some key, such as ratings for an item.
+ *
+ * Key extractors must be serializable so that the object maps that use them can be serialized.
+ *
+ * @since 3.0
+ */
+public interface KeyExtractor<T> extends Serializable {
+    /**
+     * Get the key for an object.
+     * @param obj The object.
+     * @return The object's key.
+     */
+    long getKey(T obj);
+}

--- a/lenskit-core/src/main/java/org/lenskit/util/keys/KeyedObjectMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/keys/KeyedObjectMap.java
@@ -1,0 +1,347 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.util.keys;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Longs;
+import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.objects.*;
+import org.lenskit.util.BinarySearch;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A mapping that indexes keyed objects by their keys.  This structure works on objects that have an associated key,
+ * such as recommendation results or ratings (keyed by user or item ID).  The key is extracted from an object by means
+ * of a {@link KeyExtractor}.  This allows the objects to be stored directly, without separate storage for keys.  This
+ * map stores objects in a list sorted by key, and looks them up with binary search.  Therefore, the key extractor
+ * should generally be fast (e.g. just calling a getter), in order for this class to be performant.
+ */
+@Immutable
+public class KeyedObjectMap<T> extends AbstractLong2ObjectSortedMap<T> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final KeyExtractor<? super T> extractor;
+    private final ImmutableList<T> data;
+    private transient KeySet keySet;
+    private transient EntrySet entrySet;
+
+    /**
+     * Create a new keyed object map from a collection of data.
+     * @param objs The input data.
+     */
+    public KeyedObjectMap(Collection<? extends T> objs, KeyExtractor<? super T> ex) {
+        this(objs, ex, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private KeyedObjectMap(Collection<? extends T> objs, KeyExtractor<? super T> ex, boolean sorted) {
+        if (sorted) {
+            if (objs instanceof ImmutableList) {
+                data = (ImmutableList<T>) objs;
+            } else {
+                data = ImmutableList.copyOf(objs);
+            }
+        } else {
+            data = Keys.keyOrdering(ex).immutableSortedCopy((Collection<T>) objs);
+        }
+        extractor = ex;
+    }
+
+    @Override
+    public ObjectSortedSet<Entry<T>> long2ObjectEntrySet() {
+        if (entrySet == null) {
+            entrySet = new EntrySet();
+        }
+        return entrySet;
+    }
+
+    @Override
+    public LongSortedSet keySet() {
+        if (keySet == null) {
+            keySet = new KeySet();
+        }
+        return keySet;
+    }
+
+    @Override
+    public ObjectCollection<T> values() {
+        return new AbstractObjectCollection<T>() {
+            @Override
+            public ObjectIterator<T> iterator() {
+                return ObjectIterators.asObjectIterator(data.iterator());
+            }
+
+            @Override
+            public int size() {
+                return data.size();
+            }
+        };
+    }
+
+    @Override
+    public LongComparator comparator() {
+        return null; // keys use natural comparator
+    }
+
+    @Override
+    public KeyedObjectMap<T> subMap(long from, long to) {
+        int start = findIndex(from);
+        int stop = findIndex(to);
+        start = BinarySearch.resultToIndex(start);
+        stop = BinarySearch.resultToIndex(stop);
+        return new KeyedObjectMap<>(data.subList(start, stop), extractor, true);
+    }
+
+    @Override
+    public KeyedObjectMap<T> headMap(long l) {
+        int stop = findIndex(l);
+        stop = BinarySearch.resultToIndex(stop);
+        return new KeyedObjectMap<>(data.subList(0, stop), extractor, true);
+    }
+
+    @Override
+    public KeyedObjectMap<T> tailMap(long l) {
+        int start = findIndex(l);
+        start = BinarySearch.resultToIndex(start);
+        return new KeyedObjectMap<>(data.subList(start, data.size()), extractor, true);
+    }
+
+    @Override
+    public long firstLongKey() {
+        if (data.isEmpty()) {
+            throw new NoSuchElementException();
+        } else {
+            return extractor.getKey(data.get(0));
+        }
+    }
+
+    @Override
+    public long lastLongKey() {
+        if (data.isEmpty()) {
+            throw new NoSuchElementException();
+        } else {
+            return extractor.getKey(data.get(data.size() - 1));
+        }
+    }
+
+    private int findIndex(long k) {
+        Search search = new Search(k);
+        return search.search(0, data.size());
+    }
+
+    @Override
+    public T get(long k) {
+        int idx = findIndex(k);
+        if (idx >= 0) {
+            return data.get(idx);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public int size() {
+        return data.size();
+    }
+
+    private class KeySet extends AbstractLongSortedSet {
+        @Override
+        public LongBidirectionalIterator iterator() {
+            return new KeyIterator(data.listIterator());
+        }
+
+        @Override
+        public int size() {
+            return data.size();
+        }
+
+        @Override
+        public LongBidirectionalIterator iterator(long l) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LongComparator comparator() {
+            return null; // keys use natural comparator
+        }
+
+        @Override
+        public LongSortedSet subSet(long l, long l1) {
+            return subMap(l, l1).keySet();
+        }
+
+        @Override
+        public LongSortedSet headSet(long l) {
+            return headMap(l).keySet();
+        }
+
+        @Override
+        public LongSortedSet tailSet(long l) {
+            return tailMap(l).keySet();
+        }
+
+        @Override
+        public long firstLong() {
+            return firstLongKey();
+        }
+
+        @Override
+        public long lastLong() {
+            return lastLongKey();
+        }
+    }
+
+    private class EntrySet extends AbstractObjectSortedSet<Entry<T>> {
+        @Override
+        public ObjectBidirectionalIterator<Entry<T>> iterator() {
+            return new EntryIterator(data.listIterator());
+        }
+
+        @Override
+        public int size() {
+            return data.size();
+        }
+
+        @Override
+        public ObjectBidirectionalIterator<Entry<T>> iterator(Entry<T> tEntry) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ObjectSortedSet<Entry<T>> subSet(Entry<T> e1, Entry<T> e2) {
+            return subMap(e1.getLongKey(), e2.getLongKey()).long2ObjectEntrySet();
+        }
+
+        @Override
+        public ObjectSortedSet<Entry<T>> headSet(Entry<T> tEntry) {
+            return headMap(tEntry.getLongKey()).long2ObjectEntrySet();
+        }
+
+        @Override
+        public ObjectSortedSet<Entry<T>> tailSet(Entry<T> tEntry) {
+            return tailMap(tEntry.getLongKey()).long2ObjectEntrySet();
+        }
+
+        @Override
+        public Comparator<? super Entry<T>> comparator() {
+            return null; // FIXME return a comparator
+        }
+
+        @Override
+        public Entry<T> first() {
+            if (data.isEmpty()) {
+                throw new IllegalArgumentException();
+            } else {
+                T obj = data.get(0);
+                return new BasicEntry<T>(extractor.getKey(obj), obj);
+            }
+        }
+
+        @Override
+        public Entry<T> last() {
+            if (data.isEmpty()) {
+                throw new IllegalArgumentException();
+            } else {
+                T obj = data.get(data.size() - 1);
+                return new BasicEntry<T>(extractor.getKey(obj), obj);
+            }
+        }
+
+
+    }
+
+    private class KeyIterator extends AbstractLongBidirectionalIterator {
+        private final ListIterator<T> delegate;
+
+        public KeyIterator(ListIterator<T> iter) {
+            delegate = iter;
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return delegate.hasPrevious();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public long previousLong() {
+            return extractor.getKey(delegate.previous());
+        }
+
+        @Override
+        public long nextLong() {
+            return extractor.getKey(delegate.next());
+        }
+    }
+
+    private class EntryIterator extends AbstractObjectBidirectionalIterator<Entry<T>> {
+        private final ListIterator<T> iter;
+
+        public EntryIterator(ListIterator<T> it) {
+            iter = it;
+        }
+
+        @Override
+        public Entry<T> previous() {
+            T obj = iter.previous();
+            return new BasicEntry<T>(extractor.getKey(obj), obj);
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return iter.hasPrevious();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iter.hasNext();
+        }
+
+        @Override
+        public Entry<T> next() {
+            T obj = iter.next();
+            return new BasicEntry<T>(extractor.getKey(obj), obj);
+        }
+    }
+
+    private class Search extends BinarySearch {
+        private final long target;
+
+        public Search(long tgt) {
+            target = tgt;
+        }
+
+        @Override
+        protected int test(int pos) {
+            return Longs.compare(target, extractor.getKey(data.get(pos)));
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/util/keys/Keys.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/keys/Keys.java
@@ -1,0 +1,40 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.util.keys;
+
+import com.google.common.collect.Ordering;
+import com.google.common.primitives.Longs;
+
+/**
+ * Utility class for key extractors.
+ */
+public final class Keys {
+    private Keys() {}
+
+    public static <T> Ordering<T> keyOrdering(final KeyExtractor<T> ex) {
+        return new Ordering<T>() {
+            @Override
+            public int compare(T left, T right) {
+                return Longs.compare(ex.getKey(left), ex.getKey(right));
+            }
+        };
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/results/BasicResultMapTest.java
@@ -42,7 +42,7 @@ public class BasicResultMapTest {
     public void testSingletonMap() {
         ResultMap r = Results.<Result>newResultMap(Results.create(42L, 3.5));
         assertThat(r.size(), equalTo(1));
-        assertThat(r, contains((Result) Results.create(42L, 3.5)));
+        assertThat(r, containsInAnyOrder((Result) Results.create(42L, 3.5)));
         assertThat(r.get(42L), equalTo((Result) Results.create(42L, 3.5)));
         assertThat(r.getScore(42), equalTo(3.5));
     }
@@ -52,9 +52,9 @@ public class BasicResultMapTest {
         ResultMap r = Results.<Result>newResultMap(Results.create(42L, 3.5),
                                                    Results.create(37L, 4.2));
         assertThat(r.size(), equalTo(2));
-        assertThat(r.keySet(), contains(42L, 37L));
-        assertThat(r, contains((Result) Results.create(42L, 3.5),
-                               (Result) Results.create(37L, 4.2)));
+        assertThat(r.keySet(), containsInAnyOrder(42L, 37L));
+        assertThat(r, containsInAnyOrder((Result) Results.create(42L, 3.5),
+                                         (Result) Results.create(37L, 4.2)));
         assertThat(r.getScore(42), equalTo(3.5));
         assertThat(r.getScore(37), equalTo(4.2));
         assertThat(r.getScore(28), notANumber());

--- a/lenskit-core/src/test/java/org/lenskit/util/keys/KeyedObjectMapTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/util/keys/KeyedObjectMapTest.java
@@ -1,0 +1,142 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.util.keys;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class KeyedObjectMapTest {
+    @Test
+    public void testEmptyMap() {
+        KeyedObjectMap<String> m = createMap();
+        assertThat(m.size(), equalTo(0));
+        assertThat(m.isEmpty(), equalTo(true));
+        assertThat(m.get(42L), nullValue());
+
+        assertThat(m.keySet(), hasSize(0));
+        assertThat(m.values(), hasSize(0));
+        assertThat(m.entrySet(), hasSize(0));
+
+        try {
+            m.firstLongKey();
+            fail("firstLongKey should fail on empty map");
+        } catch (NoSuchElementException e) {
+            /* expected */
+        }
+        try {
+            m.lastLongKey();
+            fail("lastLongKey should fail on empty map");
+        } catch (NoSuchElementException e) {
+            /* expected */
+        }
+    }
+
+    @Test
+    public void testSingletonMap() {
+        KeyedObjectMap<String> m = createMap("42");
+        assertThat(m.size(), equalTo(1));
+        assertThat(m.isEmpty(), equalTo(false));
+        assertThat(m.get(42L), equalTo("42"));
+        assertThat(m.get(39L), nullValue());
+        assertThat(m.firstLongKey(), equalTo(42L));
+        assertThat(m.lastLongKey(), equalTo(42L));
+
+        assertThat(m.keySet(), hasSize(1));
+        assertThat(m.values(), hasSize(1));
+        assertThat(m.entrySet(), hasSize(1));
+        assertThat(m.keySet(), contains(42L));
+        assertThat(m.values(), contains("42"));
+    }
+
+    @Test
+    public void testSomeItems() {
+        KeyedObjectMap<String> m = createMap("37", "59", "42", "67");
+
+        assertThat(m.size(), equalTo(4));
+        assertThat(m.keySet(), hasSize(4));
+        assertThat(m.values(), hasSize(4));
+        assertThat(m.entrySet(), hasSize(4));
+
+        assertThat(m.get(42L), equalTo("42"));
+        assertThat(m.get(37L), equalTo("37"));
+        assertThat(m.get(59L), equalTo("59"));
+        assertThat(m.get(67L), equalTo("67"));
+
+        assertThat(m.containsKey(42L), equalTo(true));
+        assertThat(m.containsKey(2L), equalTo(false));
+        assertThat(m.containsKey(45L), equalTo(false));
+        assertThat(m.get(45L), nullValue());
+
+        assertThat(m.keySet(), contains(37L, 42L, 59L, 67L));
+        assertThat(m.values(), contains("37", "42", "59", "67"));
+    }
+
+    @Test
+    public void testSubMap() {
+        KeyedObjectMap<String> m = createMap("37", "59", "42", "67");
+        KeyedObjectMap<String> m2 = m.subMap(42L, 66L);
+        assertThat(m2.size(), equalTo(2));
+        assertThat(m2.keySet(), contains(42L, 59L));
+        assertThat(m2.values(), contains("42", "59"));
+        assertThat(m2.get(42L), equalTo("42"));
+        assertThat(m2.get(37L), nullValue());
+    }
+
+    @Test
+    public void testTailMap() {
+        KeyedObjectMap<String> m = createMap("37", "59", "42", "67");
+        KeyedObjectMap<String> m2 = m.tailMap(59L);
+        assertThat(m2.size(), equalTo(2));
+        assertThat(m2.keySet(), contains(59L, 67L));
+        assertThat(m2.values(), contains("59", "67"));
+        assertThat(m2.get(59L), equalTo("59"));
+        assertThat(m2.get(42L), nullValue());
+    }
+
+    @Test
+    public void testHeadMap() {
+        KeyedObjectMap<String> m = createMap("37", "59", "42", "67");
+        KeyedObjectMap<String> m2 = m.headMap(59L);
+        assertThat(m2.size(), equalTo(2));
+        assertThat(m2.keySet(), contains(37L, 42L));
+        assertThat(m2.values(), contains("37", "42"));
+        assertThat(m2.get(59L), nullValue());
+        assertThat(m2.get(42L), equalTo("42"));
+    }
+
+    static KeyedObjectMap<String> createMap(String... strings) {
+        return new KeyedObjectMap<>(Arrays.asList(strings), StringEx.INSTANCE);
+    }
+
+    enum StringEx implements KeyExtractor<String> {
+        INSTANCE {
+            @Override
+            public long getKey(String obj) {
+                return Long.parseLong(obj);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This introduces a new data structure for storing keyed objects, such as results, and looking them up by key without requiring separate key storage.  It uses it in `BasicResultMap` to store data in a structure that is documented to be immutable and serializable.