### PR TITLE
Update to new Grapht and use skippable defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 before_install:
 - git fetch --depth=10000 origin
 install: ./gradlew ciPrep --stacktrace
-script: ./gradlew ciTest --stacktrace
+script: ./gradlew ciTest --stacktrace --parallel
 env:
   global:
   - TERM=dumb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
 - activate lenskit
 - gradlew.bat ciPrep
 build_script:
-- gradlew.bat ciBuild
+- gradlew.bat ciBuild --parallel
 test_script:
 - gradlew.bat check -Pjavadoc.skip=true
 deploy: off

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -40,9 +40,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
     }
     dependencies {
         classpath 'net.elehack.gradle:gradle-util:0.3'
@@ -124,6 +121,15 @@ task installForTesting(type: Upload) {
         }
     }
     configuration = configurations.archives
+}
+// enforce ordering on the testing-install operation for parallel builds
+// FIXME enforce ordering between adjacent projects
+afterEvaluate {
+    def pdeps = configurations.runtime.allDependencies.withType(ProjectDependency)
+    def pdNames = pdeps*.dependencyProject*.path
+    pdNames.each {
+        installForTesting.mustRunAfter "$it:installForTesting"
+    }
 }
 
 uploadArchives {

--- a/lenskit-core/build.gradle
+++ b/lenskit-core/build.gradle
@@ -40,7 +40,7 @@ apply from: "$rootDir/gradle/test-utils.gradle"
 dependencies {
     compile project(':lenskit-api')
     compile project(':lenskit-specs')
-    compile group: 'org.grouplens.grapht', name: 'grapht', version: '0.10.0'
+    compile group: 'org.grouplens.grapht', name: 'grapht', version: '0.11.0-SNAPSHOT'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compileOnly group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc2'
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/basic/SimpleRatingPredictor.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/basic/SimpleRatingPredictor.java
@@ -24,11 +24,9 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import org.grouplens.lenskit.ItemScorer;
-import org.grouplens.lenskit.RatingPredictor;
 import org.grouplens.lenskit.baseline.BaselineScorer;
 import org.grouplens.lenskit.baseline.PrimaryScorer;
 import org.grouplens.lenskit.baseline.ScoreSource;
-import org.grouplens.lenskit.data.dao.UserEventDAO;
 import org.grouplens.lenskit.data.pref.PreferenceDomain;
 import org.grouplens.lenskit.symbols.TypedSymbol;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
@@ -45,9 +43,6 @@ import javax.inject.Inject;
  *
  * <p>If a baseline predictor is provided, then it is used to supply predictions that the item
  * scorer could not.
- *
- * <p>This class has a provider {@link SimpleRatingPredictor.Provider} that is the default provider
- * for {@link RatingPredictor}.
  *
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @since 1.1
@@ -124,42 +119,6 @@ public final class SimpleRatingPredictor extends AbstractRatingPredictor {
 
         if (preferenceDomain != null) {
             preferenceDomain.clampVector(scores);
-        }
-    }
-
-    /**
-     * An intelligent provider for simple rating predictors. It provides a simple rating predictor
-     * if there are an {@link ItemScorer} and {@link UserEventDAO} available, and returns
-     * {@code null} otherwise.  This is the default provider for {@link RatingPredictor}.
-     */
-    public static class Provider implements javax.inject.Provider<RatingPredictor> {
-        private final ItemScorer scorer;
-        private final ItemScorer baseline;
-        private final PreferenceDomain domain;
-
-        /**
-         * Construct an automatic provider.
-         *
-         * @param s The item scorer.  If {@code null}, no rating predictor will be supplied.
-         * @param bp The baseline predictor, if configured.
-         * @param dom The preference domain, if known.
-         */
-        @Inject
-        public Provider(@Nullable ItemScorer s,
-                        @Nullable @BaselineScorer ItemScorer bp,
-                        @Nullable PreferenceDomain dom) {
-            scorer = s;
-            baseline = bp;
-            domain = dom;
-        }
-
-        @Override
-        public RatingPredictor get() {
-            if (scorer == null) {
-                return null;
-            } else {
-                return new SimpleRatingPredictor(scorer, baseline, domain);
-            }
         }
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNGlobalItemRecommender.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNGlobalItemRecommender.java
@@ -21,7 +21,6 @@
 package org.grouplens.lenskit.basic;
 
 import it.unimi.dsi.fastutil.longs.LongSet;
-import org.grouplens.lenskit.GlobalItemRecommender;
 import org.grouplens.lenskit.GlobalItemScorer;
 import org.grouplens.lenskit.data.dao.ItemDAO;
 import org.grouplens.lenskit.scored.ScoredId;
@@ -31,7 +30,6 @@ import org.grouplens.lenskit.vectors.SparseVector;
 import org.grouplens.lenskit.vectors.VectorEntry;
 import org.lenskit.util.collections.LongUtils;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +44,7 @@ public class TopNGlobalItemRecommender extends AbstractGlobalItemRecommender {
     protected final ItemDAO itemDAO;
     protected final GlobalItemScorer scorer;
 
+    @Inject
     public TopNGlobalItemRecommender(ItemDAO idao, GlobalItemScorer scorer) {
         itemDAO = idao;
         this.scorer = scorer;
@@ -106,31 +105,5 @@ public class TopNGlobalItemRecommender extends AbstractGlobalItemRecommender {
         }
 
         return accum.finish();
-    }
-
-    /**
-     * An intelligent provider for Top-N global recommenders. It provides a Top-N global recommender
-     * if there is an {@link GlobalItemScorer} available, and returns {@code null} otherwise.  This is
-     * the default provider for {@link GlobalItemRecommender}.
-     */
-    public static class Provider implements javax.inject.Provider<TopNGlobalItemRecommender> {
-        private final ItemDAO itemDAO;
-        private final GlobalItemScorer scorer;
-
-        @Inject
-        public Provider(ItemDAO dao,
-                        @Nullable GlobalItemScorer s) {
-            itemDAO = dao;
-            scorer = s;
-        }
-
-        @Override
-        public TopNGlobalItemRecommender get() {
-            if (scorer == null) {
-                return null;
-            } else {
-                return new TopNGlobalItemRecommender(itemDAO, scorer);
-            }
-        }
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNItemRecommender.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/basic/TopNItemRecommender.java
@@ -26,7 +26,6 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import org.apache.commons.lang3.tuple.Pair;
-import org.grouplens.lenskit.ItemRecommender;
 import org.grouplens.lenskit.ItemScorer;
 import org.grouplens.lenskit.data.dao.ItemDAO;
 import org.grouplens.lenskit.data.dao.UserEventDAO;
@@ -195,33 +194,5 @@ public class TopNItemRecommender extends AbstractItemRecommender {
      */
     protected LongSet getPredictableItems(long user) {
         return itemDAO.getItemIds();
-    }
-
-    /**
-     * An intelligent provider for Top-N recommenders. It provides a Top-N recommender
-     * if there is an {@link ItemScorer} available, and returns {@code null} otherwise.  This is
-     * the default provider for {@link ItemRecommender}.
-     */
-    public static class Provider implements javax.inject.Provider<TopNItemRecommender> {
-        private final UserEventDAO userEventDAO;
-        private final ItemDAO itemDAO;
-        private final ItemScorer scorer;
-
-        @Inject
-        public Provider(UserEventDAO uedao, ItemDAO idao,
-                        @Nullable ItemScorer s) {
-            userEventDAO = uedao;
-            itemDAO = idao;
-            scorer = s;
-        }
-
-        @Override
-        public TopNItemRecommender get() {
-            if (scorer == null) {
-                return null;
-            } else {
-                return new TopNItemRecommender(userEventDAO, itemDAO, scorer);
-            }
-        }
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommender.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/core/LenskitRecommender.java
@@ -66,7 +66,7 @@ public class LenskitRecommender implements Recommender {
      */
     public <T> T get(Class<T> cls) {
         try {
-            return injector.getInstance(cls);
+            return injector.tryGetInstance(cls);
         } catch (InjectionException e) {
             throw new RuntimeException("error instantiating component", e);
         }
@@ -85,7 +85,7 @@ public class LenskitRecommender implements Recommender {
      */
     public <T> T get(Class<? extends Annotation> qual, Class<T> cls) {
         try {
-            return injector.getInstance(qual, cls);
+            return injector.tryGetInstance(qual, cls);
         } catch (InjectionException e) {
             throw new RuntimeException("error instantiating component", e);
         }
@@ -104,7 +104,7 @@ public class LenskitRecommender implements Recommender {
      */
     public <T> T get(Annotation qual, Class<T> cls) {
         try {
-            return injector.getInstance(qual, cls);
+            return injector.tryGetInstance(qual, cls);
         } catch (InjectionException e) {
             throw new RuntimeException("error instantiating component", e);
         }

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
@@ -90,7 +90,7 @@ public class LenskitRecommender implements Recommender {
      */
     public <T> T get(Class<? extends Annotation> qual, Class<T> cls) {
         try {
-            return injector.getInstance(qual, cls);
+            return injector.tryGetInstance(qual, cls);
         } catch (InjectionException e) {
             throw new RuntimeException("error instantiating component", e);
         }

--- a/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.grouplens.lenskit.GlobalItemRecommender.properties
+++ b/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.grouplens.lenskit.GlobalItemRecommender.properties
@@ -1,1 +1,2 @@
-provider=org.grouplens.lenskit.basic.TopNGlobalItemRecommender$Provider
+implementation=org.grouplens.lenskit.basic.TopNGlobalItemRecommender
+skipIfUnusable=true

--- a/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.grouplens.lenskit.ItemRecommender.properties
+++ b/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.grouplens.lenskit.ItemRecommender.properties
@@ -1,1 +1,2 @@
-provider=org.grouplens.lenskit.basic.TopNItemRecommender$Provider
+implementation=org.grouplens.lenskit.basic.TopNItemRecommender
+skipIfUnusable=true

--- a/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.grouplens.lenskit.RatingPredictor.properties
+++ b/lenskit-core/src/main/resources/META-INF/grapht/defaults/org.grouplens.lenskit.RatingPredictor.properties
@@ -1,1 +1,2 @@
-provider=org.grouplens.lenskit.basic.SimpleRatingPredictor$Provider
+implementation=org.grouplens.lenskit.basic.SimpleRatingPredictor
+skipIfUnusable=true

--- a/lenskit-integration-tests/gradle-tests.gradle
+++ b/lenskit-integration-tests/gradle-tests.gradle
@@ -56,6 +56,7 @@ file('src/it/gradle').eachDir { testDir ->
     task("test$tname", type: GradleBuild) {
         dependsOn makeTestRepo, fetchData
         inputs.dir testDir
+        inputs.file 'src/it/gradle/common.gradle'
         inputs.dir "$buildDir/test-repo"
         outputs.dir workDir
 
@@ -75,6 +76,11 @@ file('src/it/gradle').eachDir { testDir ->
             copy {
                 from testDir
                 into workDir
+            }
+            copy {
+                from 'src/it/gradle'
+                into workDir
+                include 'common.gradle'
             }
             println "running gradle build for $testDir"
         }

--- a/lenskit-integration-tests/src/it/gradle/cli-classpath/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/cli-classpath/build.gradle
@@ -1,16 +1,5 @@
 apply plugin: 'java'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task recommend(type: JavaExec) {
     dependsOn classes

--- a/lenskit-integration-tests/src/it/gradle/cli-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/cli-crossfold/build.gradle
@@ -12,17 +12,7 @@ apply plugin: 'java'
 import static org.hamcrest.MatcherAssert.*
 import static org.hamcrest.Matchers.*
 
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task crossfold(type: JavaExec) {
     dependsOn classes

--- a/lenskit-integration-tests/src/it/gradle/cli-input-files/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/cli-input-files/build.gradle
@@ -1,16 +1,5 @@
 apply plugin: 'java'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task packWithHeader(type: JavaExec) {
     dependsOn classes

--- a/lenskit-integration-tests/src/it/gradle/common.gradle
+++ b/lenskit-integration-tests/src/it/gradle/common.gradle
@@ -1,0 +1,14 @@
+repositories {
+    maven {
+        url testRepoURI
+    }
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+    mavenCentral()
+}
+
+dependencies {
+    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
+    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
+}

--- a/lenskit-integration-tests/src/it/gradle/crossfold-from-spec/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/crossfold-from-spec/build.gradle
@@ -12,17 +12,7 @@ apply plugin: 'java'
 import static org.hamcrest.MatcherAssert.*
 import static org.hamcrest.Matchers.*
 
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task crossfold(type: JavaExec) {
     dependsOn classes

--- a/lenskit-integration-tests/src/it/gradle/gradle-crossfold-packed/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-crossfold-packed/build.gradle
@@ -19,18 +19,7 @@ import static org.hamcrest.Matchers.*
 
 apply plugin: 'java'
 apply plugin: 'lenskit'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task pack(type: PackRatings) {
     input textFile {

--- a/lenskit-integration-tests/src/it/gradle/gradle-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-crossfold/build.gradle
@@ -16,19 +16,8 @@ import static org.hamcrest.MatcherAssert.*
 import static org.hamcrest.Matchers.*
 
 apply plugin: 'java'
+apply from: 'common.gradle'
 apply plugin: 'lenskit'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
 
 task crossfold(type: Crossfold) {
     input textFile {

--- a/lenskit-integration-tests/src/it/gradle/gradle-eval/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-eval/build.gradle
@@ -12,18 +12,9 @@ buildscript {
 
 import org.grouplens.lenskit.gradle.*
 
+apply plugin: 'java'
 apply plugin: 'lenskit'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-configurations {
-    lenskit
-}
+apply from: 'common.gradle'
 
 dependencies {
     lenskit "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"

--- a/lenskit-integration-tests/src/it/gradle/gradle-log-file/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-log-file/build.gradle
@@ -17,18 +17,7 @@ import static org.hamcrest.Matchers.*
 
 apply plugin: 'java'
 apply plugin: 'lenskit'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task version(type: Version) {
     logFile "$buildDir/version.log"

--- a/lenskit-integration-tests/src/it/gradle/gradle-logback-config/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-logback-config/build.gradle
@@ -17,18 +17,7 @@ import static org.hamcrest.Matchers.*
 
 apply plugin: 'java'
 apply plugin: 'lenskit'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task version(type: Version) {
     logbackConfiguration 'logback.xml'

--- a/lenskit-integration-tests/src/it/gradle/gradle-pack/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-pack/build.gradle
@@ -17,18 +17,7 @@ import static org.hamcrest.Matchers.*
 
 apply plugin: 'java'
 apply plugin: 'lenskit'
-
-repositories {
-    maven {
-        url testRepoURI
-    }
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
-}
+apply from: 'common.gradle'
 
 task packRatings(type: PackRatings) {
     input textFile {


### PR DESCRIPTION
This has a few fixes:

- fix a file name problem
- upgrade to Grapht 0.11.0-SNAPSHOT
- use skippable defaults (grouplens/grapht#123) to simplify the default component implementations, and no longer have providers that return null