### PR TITLE
Updated Predict method in SimpleRatingPredictor

### DIFF
--- a/lenskit-core/src/main/java/org/lenskit/basic/SimpleRatingPredictor.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/SimpleRatingPredictor.java
@@ -74,6 +74,9 @@ public class SimpleRatingPredictor implements RatingPredictor {
     @Override
     public RescoredResult predict(long user, long item) {
         Result r = scorer.score(user, item);
+        if(r == null) {
+            return null;
+        }
         double val = r.getScore();
         if (preferenceDomain != null) {
             val = preferenceDomain.clampValue(val);


### PR DESCRIPTION
Updated Predict method in SimpleRatingPredictor
 - if scorer result is null then Predict method will not continue and return null