### PR TITLE
Add tests verifying that #788 isn't present

### DIFF
--- a/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
@@ -63,6 +63,10 @@ task trainTest(type: TrainTest) {
         metric 'map'
         metric 'pr'
     }
+
+    doFirst {
+        delete 'cache'
+    }
 }
 
 task check(overwrite: true, type: JavaExec) {

--- a/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/verify.groovy
+++ b/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/verify.groovy
@@ -21,6 +21,7 @@
 
 import static com.xlson.groovycsv.CsvParser.parseCsv
 import org.lenskit.knn.item.model.SimilarityMatrixModel
+import org.lenskit.data.ratings.RatingSummary
 
 import java.util.zip.GZIPInputStream
 
@@ -75,5 +76,8 @@ cacheDir.eachFile { file ->
         objects[cls] = objects.get(cls, 0) + 1
     }
 }
-// FIXME Re-enable this assertion when sharing is fixed
-// assertThat objects[SimilarityMatrixModel.name], equalTo(5)
+
+assertThat objects[SimilarityMatrixModel.name], equalTo(5)
+
+// Verify that we only have 5 rating summaries (objects cached)
+assertThat objects[RatingSummary.name], equalTo(5)


### PR DESCRIPTION
Turns out that #788 wasn't really there as a bug, but rather was an artifact of testing. This fixes the test artifact & adds a test to verify that it's gone.