### PR TITLE
Fix crossfold output routing

### DIFF
--- a/lenskit-eval/src/main/java/org/lenskit/eval/crossfold/Crossfolder.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/crossfold/Crossfolder.java
@@ -336,30 +336,15 @@ public class Crossfolder {
     }
 
     List<Path> getTrainingFiles() {
-        return getFileList("part%02d.train." + getOutputSuffix());
+        return getFileList("part%02d.train." + outputFormat.getExtension());
     }
 
     List<Path> getTestFiles() {
-        return getFileList("part%02d.test." + getOutputSuffix());
+        return getFileList("part%02d.test." + outputFormat.getExtension());
     }
 
     List<Path> getSpecFiles() {
         return getFileList("part%02d.json");
-    }
-
-    String getOutputSuffix() {
-        switch (outputFormat) {
-        case CSV:
-            return "csv";
-        case CSV_GZIP:
-            return "csv.gz";
-        case CSV_XZ:
-            return "csv.xz";
-        case PACK:
-            return "pack";
-        default:
-            throw new IllegalArgumentException("invalid output format");
-        }
     }
 
     private List<Path> getFileList(String pattern) {

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
@@ -158,7 +158,7 @@ class TopNMRRMetricTest {
         def metric = SpecUtils.buildObject(TopNMetric, node)
         assertThat(metric, instanceOf(TopNMRRMetric))
         def mrr = metric as TopNMRRMetric
-        assertThat(metric.getExtension, equalTo("Good"))
+        assertThat(metric.suffix, equalTo("Good"))
         assertThat(metric.goodItems, instanceOf(ItemSelector.GroovyItemSelector))
     }
 }

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
@@ -158,7 +158,7 @@ class TopNMRRMetricTest {
         def metric = SpecUtils.buildObject(TopNMetric, node)
         assertThat(metric, instanceOf(TopNMRRMetric))
         def mrr = metric as TopNMRRMetric
-        assertThat(metric.suffix, equalTo("Good"))
+        assertThat(metric.getExtension, equalTo("Good"))
         assertThat(metric.goodItems, instanceOf(ItemSelector.GroovyItemSelector))
     }
 }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/Crossfold.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/Crossfold.groovy
@@ -134,7 +134,9 @@ class Crossfold extends LenskitTask implements DataSources {
     }
 
     List<DataSetSpec> getDataSets() {
-        return SpecUtils.loadList(DataSetSpec, project.file(getOutputDir()).toPath().resolve("all-partitions.json"))
+        def copy = SpecUtils.copySpec(spec)
+        copy.setOutputDir(project.file(getOutputDir()).toPath())
+        return copy.dataSets
     }
 
     /**

--- a/lenskit-specs/src/main/java/org/lenskit/specs/data/DataSourceSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/data/DataSourceSpec.java
@@ -53,4 +53,6 @@ public abstract class DataSourceSpec extends AbstractSpec {
     public Set<Path> getInputFiles() {
         return Collections.emptySet();
     }
+
+    public abstract PrefDomainSpec getDomain();
 }

--- a/lenskit-specs/src/main/java/org/lenskit/specs/data/PackedDataSourceSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/data/PackedDataSourceSpec.java
@@ -31,6 +31,16 @@ public class PackedDataSourceSpec extends DataSourceSpec {
     private Path file;
     private PrefDomainSpec domain;
 
+    @Override
+    public String getName() {
+        String name = super.getName();
+        if (name == null && file != null) {
+            return file.getFileName().toString();
+        } else {
+            return name;
+        }
+    }
+
     public Path getFile() {
         return file;
     }
@@ -39,6 +49,7 @@ public class PackedDataSourceSpec extends DataSourceSpec {
         this.file = file;
     }
 
+    @Override
     public PrefDomainSpec getDomain() {
         return domain;
     }

--- a/lenskit-specs/src/main/java/org/lenskit/specs/data/TextDataSourceSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/data/TextDataSourceSpec.java
@@ -38,6 +38,16 @@ public class TextDataSourceSpec extends DataSourceSpec {
     private Path itemFile;
     private Path itemNameFile;
 
+    @Override
+    public String getName() {
+        String name = super.getName();
+        if (name == null && file != null) {
+            return file.getFileName().toString();
+        } else {
+            return name;
+        }
+    }
+
     public Path getFile() {
         return file;
     }
@@ -102,6 +112,7 @@ public class TextDataSourceSpec extends DataSourceSpec {
         itemNameFile = file;
     }
 
+    @Override
     public PrefDomainSpec getDomain() {
         return domain;
     }

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
@@ -156,6 +156,7 @@ public class CrossfoldSpec extends AbstractSpec {
         List<DataSetSpec> specs = new ArrayList<>(partitionCount);
         for (int i = 1; i <= partitionCount; i++) {
             DataSetSpec dss = new DataSetSpec();
+            dss.setName(getName() + "." + i);
             dss.setTrainSource(makeDataSource(String.format("part%02d.train", i)));
             dss.setTestSource(makeDataSource(String.format("part%02d.test", i)));
             dss.setAttribute("DataSet", getName());

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
@@ -66,10 +66,12 @@ public class CrossfoldSpec extends AbstractSpec {
 
     public String getName() {
         if (name == null && source != null) {
-            return source.get().getName();
-        } else {
-            return name;
+            DataSourceSpec ss = source.get();
+            if (ss != null) {
+                return ss.getName();
+            }
         }
+        return name;
     }
 
     public void setName(String name) {

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/CrossfoldSpec.java
@@ -51,7 +51,7 @@ public class CrossfoldSpec extends AbstractSpec {
     private PartitionMethodSpec userPartitionMethod;
     private Integer sampleSize;
 
-    private boolean includeTimestamps = false;
+    private boolean includeTimestamps = true;
 
     private OutputFormat outputFormat = OutputFormat.CSV;
     private Path outputDir;

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/OutputFormat.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/OutputFormat.java
@@ -21,5 +21,19 @@
 package org.lenskit.specs.eval;
 
 public enum OutputFormat {
-    CSV, CSV_GZIP, CSV_XZ, PACK
+    CSV("csv"), CSV_GZIP("csv.gz"), CSV_XZ("csv.xz"), PACK("pack");
+
+    private String extension;
+
+    OutputFormat(String ext) {
+        extension = ext;
+    }
+
+    /**
+     * Get the file extension for the output format.
+     * @return The extension.
+     */
+    public String getExtension() {
+        return extension;
+    }
 }

--- a/lenskit-specs/src/test/java/org/lenskit/specs/eval/CrossfoldSpecTest.java
+++ b/lenskit-specs/src/test/java/org/lenskit/specs/eval/CrossfoldSpecTest.java
@@ -1,0 +1,104 @@
+package org.lenskit.specs.eval;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lenskit.specs.data.PackedDataSourceSpec;
+import org.lenskit.specs.data.PrefDomainSpec;
+import org.lenskit.specs.data.TextDataSourceSpec;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class CrossfoldSpecTest {
+    TextDataSourceSpec input;
+
+    @Before
+    public void createDataSource() {
+        input = new TextDataSourceSpec();
+        input.setFile(Paths.get("ratings.csv"));
+        input.setName("TestData");
+    }
+
+    @Test
+    public void testDefaults() {
+        CrossfoldSpec spec = new CrossfoldSpec();
+        spec.setName("TestData");
+        spec.setSource(input);
+        spec.setOutputDir(Paths.get("crossfold.out"));
+
+        assertThat(spec.getPartitionCount(), equalTo(5));
+        assertThat(spec.getOutputFormat(), equalTo(OutputFormat.CSV));
+        assertThat(spec.getOutputDir(), equalTo(Paths.get("crossfold.out")));
+        assertThat(spec.getIncludeTimestamps(), equalTo(true));
+        assertThat(spec.getMethod(), equalTo(CrossfoldMethod.PARTITION_USERS));
+        assertThat(spec.getUserPartitionMethod(),
+                   instanceOf(PartitionMethodSpec.Holdout.class));
+        PartitionMethodSpec.Holdout holdout = (PartitionMethodSpec.Holdout) spec.getUserPartitionMethod();
+        assertThat(holdout.getCount(), equalTo(10));
+        assertThat(holdout.getOrder(), equalTo("random"));
+    }
+
+    @Test
+    public void testBasicDataSets() {
+        CrossfoldSpec spec = new CrossfoldSpec();
+        spec.setName("TestData");
+        spec.setSource(input);
+        input.setDomain(PrefDomainSpec.fromString("[1,5]/1.0"));
+        spec.setOutputDir(Paths.get("crossfold.out"));
+        List<DataSetSpec> sets = spec.getDataSets();
+        assertThat(sets, hasSize(5));
+        for (int i = 0; i < 5; i++) {
+            DataSetSpec set = sets.get(i);
+            assertThat(set.getName(), equalTo("TestData." + i+1));
+            assertThat(set.getAttributes(), hasEntry("DataSet", (Object) "TestData"));
+            assertThat(set.getAttributes(), hasEntry("Partition", (Object) (i+1)));
+
+            assertThat(set.getTrainSource(), instanceOf(TextDataSourceSpec.class));
+            TextDataSourceSpec tds = (TextDataSourceSpec) set.getTrainSource();
+            assertThat(tds.getFile(), equalTo(spec.getOutputDir().resolve(String.format("part%02d.train.csv", i+1))));
+            assertThat(tds.getDomain(),
+                       equalTo(PrefDomainSpec.fromString("[1,5]/1.0")));
+            assertThat(tds.getDelimiter(), equalTo(","));
+
+            assertThat(set.getTestSource(), instanceOf(TextDataSourceSpec.class));
+            tds = (TextDataSourceSpec) set.getTestSource();
+            assertThat(tds.getFile(), equalTo(spec.getOutputDir().resolve(String.format("part%02d.test.csv", i+1))));
+            assertThat(tds.getDomain(),
+                       equalTo(PrefDomainSpec.fromString("[1,5]/1.0")));
+            assertThat(tds.getDelimiter(), equalTo(","));
+        }
+    }
+
+    @Test
+    public void testPackDataSets() {
+        CrossfoldSpec spec = new CrossfoldSpec();
+        spec.setName("TestData");
+        spec.setSource(input);
+        input.setDomain(PrefDomainSpec.fromString("[1,5]/1.0"));
+        spec.setOutputDir(Paths.get("crossfold.out"));
+        spec.setOutputFormat(OutputFormat.PACK);
+        List<DataSetSpec> sets = spec.getDataSets();
+        assertThat(sets, hasSize(5));
+        for (int i = 0; i < 5; i++) {
+            DataSetSpec set = sets.get(i);
+            assertThat(set.getName(), equalTo("TestData." + i+1));
+            assertThat(set.getAttributes(), hasEntry("DataSet", (Object) "TestData"));
+            assertThat(set.getAttributes(), hasEntry("Partition", (Object) (i+1)));
+
+            assertThat(set.getTrainSource(), instanceOf(PackedDataSourceSpec.class));
+            PackedDataSourceSpec tds = (PackedDataSourceSpec) set.getTrainSource();
+            assertThat(tds.getFile(), equalTo(spec.getOutputDir().resolve(String.format("part%02d.train.pack", i+1))));
+            assertThat(tds.getDomain(),
+                       equalTo(PrefDomainSpec.fromString("[1,5]/1.0")));
+
+            assertThat(set.getTestSource(), instanceOf(PackedDataSourceSpec.class));
+            tds = (PackedDataSourceSpec) set.getTestSource();
+            assertThat(tds.getFile(), equalTo(spec.getOutputDir().resolve(String.format("part%02d.test.pack", i+1))));
+            assertThat(tds.getDomain(),
+                       equalTo(PrefDomainSpec.fromString("[1,5]/1.0")));
+        }
+    }
+}

--- a/lenskit-specs/src/test/java/org/lenskit/specs/eval/CrossfoldSpecTest.java
+++ b/lenskit-specs/src/test/java/org/lenskit/specs/eval/CrossfoldSpecTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.specs.eval;
 
 import org.junit.Before;

--- a/lenskit-specs/src/test/java/org/lenskit/specs/eval/CrossfoldSpecTest.java
+++ b/lenskit-specs/src/test/java/org/lenskit/specs/eval/CrossfoldSpecTest.java
@@ -72,7 +72,7 @@ public class CrossfoldSpecTest {
         assertThat(sets, hasSize(5));
         for (int i = 0; i < 5; i++) {
             DataSetSpec set = sets.get(i);
-            assertThat(set.getName(), equalTo("TestData." + i+1));
+            assertThat(set.getName(), equalTo("TestData." + (i+1)));
             assertThat(set.getAttributes(), hasEntry("DataSet", (Object) "TestData"));
             assertThat(set.getAttributes(), hasEntry("Partition", (Object) (i+1)));
 
@@ -104,7 +104,7 @@ public class CrossfoldSpecTest {
         assertThat(sets, hasSize(5));
         for (int i = 0; i < 5; i++) {
             DataSetSpec set = sets.get(i);
-            assertThat(set.getName(), equalTo("TestData." + i+1));
+            assertThat(set.getName(), equalTo("TestData." + (i+1)));
             assertThat(set.getAttributes(), hasEntry("DataSet", (Object) "TestData"));
             assertThat(set.getAttributes(), hasEntry("Partition", (Object) (i+1)));
 

--- a/lenskit-test/src/main/java/org/grouplens/lenskit/util/test/LineCountMatcher.java
+++ b/lenskit-test/src/main/java/org/grouplens/lenskit/util/test/LineCountMatcher.java
@@ -38,21 +38,21 @@ public class LineCountMatcher extends BaseMatcher<File> {
 
     @Override
     public boolean matches(Object o) {
-        if (!(o instanceof File)) {
-            return false;
-        }
+        return o instanceof File && lineCount.matches(getLineCount((File) o));
+    }
 
-        try (Reader reader = new FileReader((File) o);
+    private int getLineCount(File file) {
+        try (Reader reader = new FileReader(file);
              BufferedReader lines = new BufferedReader(reader)) {
             int n = 0;
             while (lines.readLine() != null) {
                 n++;
             }
-            return lineCount.matches(n);
+            return n;
         } catch (FileNotFoundException ex) {
-            return false;
+            throw new RuntimeException("file " + file + " not found", ex);
         } catch (IOException ex) {
-            throw new RuntimeException("error reading file " + o, ex);
+            throw new RuntimeException("error reading file " + file, ex);
         }
     }
 
@@ -60,5 +60,15 @@ public class LineCountMatcher extends BaseMatcher<File> {
     public void describeTo(Description description) {
         description.appendText("file with line count ")
                    .appendDescriptionOf(lineCount);
+    }
+
+    @Override
+    public void describeMismatch(Object item, Description description) {
+        if (item instanceof File) {
+            int lines = getLineCount((File) item);
+            description.appendText("had " + lines + " lines");
+        } else {
+            description.appendText("was non-file object " + item);
+        }
     }
 }


### PR DESCRIPTION
This adds output file support to the crossfold spec so that we can get that information before running the crossfolder.

This means that the crossfold spec knows a lot about how the crossfolder produces output. This should be capitalized on in the crossfolder itself so that we don't duplicate that logic.