### PR TITLE
Recommend task exclude routing

### DIFF
--- a/lenskit-core/src/main/java/org/lenskit/util/UncheckedInterruptException.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/UncheckedInterruptException.java
@@ -1,0 +1,43 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.util;
+
+/**
+ * Unchecked exception thrown to propagate an interrupt up the stack.
+ */
+public class UncheckedInterruptException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public UncheckedInterruptException() {
+    }
+
+    public UncheckedInterruptException(String message) {
+        super(message);
+    }
+
+    public UncheckedInterruptException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UncheckedInterruptException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/ExperimentJob.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/ExperimentJob.java
@@ -38,6 +38,7 @@ import org.lenskit.data.history.UserHistory;
 import org.lenskit.inject.GraphtUtils;
 import org.lenskit.inject.NodeProcessors;
 import org.lenskit.inject.RecommenderInstantiator;
+import org.lenskit.util.UncheckedInterruptException;
 import org.lenskit.util.table.RowBuilder;
 import org.lenskit.util.table.writer.TableWriter;
 import org.lenskit.LenskitRecommender;
@@ -170,9 +171,15 @@ class ExperimentJob implements Runnable {
             logger.info("Tested {} in {}", algorithm.getName(), testTimer);
             outputRow.add("BuildTime", buildTimer.elapsed(TimeUnit.MILLISECONDS) * 0.001);
             outputRow.add("TestTime", testTimer.elapsed(TimeUnit.MILLISECONDS) * 0.001);
-            for (ConditionEvaluator eval: accumulators) {
+            for (ConditionEvaluator eval : accumulators) {
                 outputRow.addAll(eval.finish());
             }
+        } catch (UncheckedInterruptException ex) {
+            logger.info("evaluation interrupted");
+            throw ex;
+        } catch (Throwable th) {
+            logger.error("Error occured in eval job", th);
+            throw th;
         }
 
         try {

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/metrics/MetricResult.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/metrics/MetricResult.java
@@ -20,6 +20,8 @@
  */
 package org.lenskit.eval.traintest.metrics;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,13 +34,15 @@ public abstract class MetricResult {
      * Get the column values for this metric result.
      * @return The values for the result.
      */
+    @Nonnull
     public abstract Map<String,Object> getValues();
 
     /**
-     * Add a suffix to this metric result's column names.
+     * Add a suffix to this metric result's column names.  The resulting keys are of the form "key.sfx".
      * @param sfx The suffix to add, or `null` for no change.
      * @return The converted metric.
      */
+    @Nonnull
     public MetricResult withSuffix(String sfx) {
         if (sfx == null) {
             return this;
@@ -51,18 +55,49 @@ public abstract class MetricResult {
         return fromMap(newData);
     }
 
+
     /**
-     * Create an empty metric result.
-     * @return An empty metric result.
+     * Add a prefix to this metric result's column names.  The resulting keys are of the form "pfx.key".
+     * @param pfx The prefix to add, or `null` for no change.
+     * @return The converted metric.
      */
-    public static MetricResult empty() {
-        return fromMap(Collections.<String, Object>emptyMap());
+    @Nonnull
+    public MetricResult withPrefix(String pfx) {
+        if (pfx == null) {
+            return this;
+        }
+
+        Map<String,Object> newData = new HashMap<>();
+        for (Map.Entry<String,Object> e: getValues().entrySet()) {
+            newData.put(pfx + "." + e.getKey(), e.getValue());
+        }
+        return fromMap(newData);
     }
 
     /**
      * Create an empty metric result.
      * @return An empty metric result.
      */
+    @Nonnull
+    public static MetricResult empty() {
+        return fromMap(Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * Convert a null result to an empty result.
+     * @param result The result.
+     * @return The result, or {@link #empty()} if it is null.
+     */
+    @Nonnull
+    public static MetricResult fromNullable(@Nullable MetricResult result) {
+        return result != null ? result : empty();
+    }
+
+    /**
+     * Create an empty metric result.
+     * @return An empty metric result.
+     */
+    @Nonnull
     public static MetricResult fromMap(Map<String,?> values) {
         return new MapMetricResult(values);
     }
@@ -73,6 +108,7 @@ public abstract class MetricResult {
      * @param value The column value.
      * @return The map result.
      */
+    @Nonnull
     public static MetricResult singleton(String name, Object value) {
         return fromMap(Collections.singletonMap(name, value));
     }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNEntropyMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNEntropyMetric.java
@@ -74,7 +74,7 @@ public class TopNEntropyMetric extends TopNMetric<TopNEntropyMetric.Context> {
     @Nonnull
     @Override
     public MetricResult getAggregateMeasurements(Context context) {
-        return context.finish();
+        return MetricResult.fromNullable(context.finish());
     }
 
     public static class EntropyResult extends TypedMetricResult {
@@ -96,6 +96,7 @@ public class TopNEntropyMetric extends TopNMetric<TopNEntropyMetric.Context> {
             }
         }
 
+        @Nullable
         public EntropyResult finish() {
             if (recCount > 0) {
                 double entropy = 0;

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
@@ -117,7 +117,8 @@ public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMet
     @Nonnull
     @Override
     public MetricResult getAggregateMeasurements(Context context) {
-        return context.finish().withSuffix(suffix);
+        return MetricResult.fromNullable(context.finish())
+                           .withSuffix(suffix);
     }
 
     public static class PresRecResult extends TypedMetricResult {
@@ -159,6 +160,7 @@ public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMet
             nusers += 1;
         }
 
+        @Nullable
         public PresRecResult finish() {
             if (nusers > 0) {
                 return new PresRecResult(totalPrecision / nusers, totalRecall / nusers);

--- a/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
@@ -41,7 +41,6 @@ task trainTest(type: TrainTest) {
     userOutputFile 'users.csv'
     algorithm 'Baseline', 'baseline.groovy'
     predict {
-        outputFile 'predictions.csv'
         metric 'coverage'
         metric 'rmse'
         metric('ndcg') {
@@ -50,9 +49,6 @@ task trainTest(type: TrainTest) {
     }
     recommend {
         listSize 10
-        outputFile 'recommendations.csv.gz'
-        candidateItems 'allItems'
-        excludeItems 'user.trainItems'
         metric 'length'
         metric 'entropy'
         metric('ndcg') {

--- a/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
@@ -35,6 +35,8 @@ task crossfold(type: Crossfold) {
 
 task trainTest(type: TrainTest) {
     maxMemory '256m'
+    logFile "train-test.log"
+    logFileLevel 'DEBUG'
     dataSet crossfold
     cacheDirectory 'cache'
     outputFile 'results.csv'

--- a/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
@@ -52,6 +52,7 @@ task trainTest(type: TrainTest) {
         listSize 10
         outputFile 'recommendations.csv.gz'
         candidateItems 'allItems'
+        excludeItems 'user.trainItems'
         metric 'length'
         metric 'entropy'
         metric('ndcg') {

--- a/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/verify.groovy
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/verify.groovy
@@ -35,18 +35,12 @@ import static org.hamcrest.Matchers.equalTo
 
 File resultsFile = new File("results.csv")
 File userFile = new File("users.csv")
-File predictFile = new File("predictions.csv")
-File recommendFile = new File("recommendations.csv.gz")
 
 assertThat("output file exists",
            resultsFile, allOf(existingFile(),
                               hasLineCount(equalTo(6))));
 assertThat("output file exists",
            userFile, existingFile());
-assertThat("output file exists",
-           predictFile, existingFile());
-assertThat("output file exists",
-           recommendFile, existingFile());
 resultsFile.withReader { rdr ->
     def results = parseCsv(rdr)
     for (row in results) {

--- a/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
@@ -35,6 +35,8 @@ task crossfold(type: Crossfold) {
 
 task trainTest(type: TrainTest) {
     maxMemory '256m'
+    logFile "train-test.log"
+    logFileLevel 'DEBUG'
     dataSet crossfold
     cacheDirectory 'cache'
     outputFile 'results.csv'
@@ -54,6 +56,22 @@ task trainTest(type: TrainTest) {
         outputFile 'recommendations.csv.gz'
         candidateItems 'allItems'
         excludeItems 'user.trainItems'
+        metric 'length'
+        metric 'entropy'
+        metric('ndcg') {
+            columnName 'nDCG'
+        }
+        metric 'popularity'
+        metric 'mrr'
+        metric 'map'
+        metric 'pr'
+    }
+    // test the top-N metrics for handling a full run with no recommendations
+    recommend {
+        candidateItems 'allItems'
+        excludeItems 'allItems'
+        listSize 10
+        labelPrefix 'NoRecs'
         metric 'length'
         metric 'entropy'
         metric('ndcg') {

--- a/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
@@ -53,6 +53,7 @@ task trainTest(type: TrainTest) {
         listSize 10
         outputFile 'recommendations.csv.gz'
         candidateItems 'allItems'
+        excludeItems 'user.trainItems'
         metric 'length'
         metric 'entropy'
         metric('ndcg') {

--- a/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/verify.groovy
+++ b/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/verify.groovy
@@ -42,11 +42,13 @@ File recommendFile = new File("recommendations.csv.gz")
 assertThat("output file exists",
            resultsFile, allOf(existingFile(),
                               hasLineCount(equalTo(11))));
-assertThat("output file exists",
+assertThat("log file file exists",
+           new File("train-test.log"), existingFile());
+assertThat("user file exists",
            userFile, existingFile());
-assertThat("output file exists",
+assertThat("prediction file exists",
            predictFile, existingFile());
-assertThat("output file exists",
+assertThat("recommendation file exists",
            recommendFile, existingFile());
 resultsFile.withReader { rdr ->
     def results = parseCsv(rdr)

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/RecommendEvalTaskSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/RecommendEvalTaskSpec.java
@@ -31,9 +31,27 @@ import java.util.Set;
  */
 public class RecommendEvalTaskSpec extends EvalTaskSpec {
     private Path outputFile;
+    private String labelPrefix;
     private int listSize;
     private String candidateItems;
     private String excludeItems;
+
+    /**
+     * Get the prefix applied to column labels.
+     * @return The column label prefix.
+     */
+    public String getLabelPrefix() {
+        return labelPrefix;
+    }
+
+    /**
+     * Set the prefix applied to column labels.  If provided, it will be prepended to column labels from this task,
+     * along with a ".".
+     * @param prefix The label prefix.
+     */
+    public void setLabelPrefix(String prefix) {
+        labelPrefix = prefix;
+    }
 
     /**
      * Get the recommendation output file.

--- a/lenskit-specs/src/main/java/org/lenskit/specs/eval/RecommendEvalTaskSpec.java
+++ b/lenskit-specs/src/main/java/org/lenskit/specs/eval/RecommendEvalTaskSpec.java
@@ -33,6 +33,7 @@ public class RecommendEvalTaskSpec extends EvalTaskSpec {
     private Path outputFile;
     private int listSize;
     private String candidateItems;
+    private String excludeItems;
 
     /**
      * Get the recommendation output file.
@@ -90,5 +91,21 @@ public class RecommendEvalTaskSpec extends EvalTaskSpec {
      */
     public void setCandidateItems(String candidates) {
         candidateItems = candidates;
+    }
+
+    /**
+     * Get the candidate item selector.
+     * @return The selector expression for exclude items.
+     */
+    public String getExcludeItems() {
+        return excludeItems;
+    }
+
+    /**
+     * Get the exclude item selector.
+     * @param excludeItems The selector expression for exclude items.
+     */
+    public void setExcludeItems(String excludeItems) {
+        this.excludeItems = excludeItems;
     }
 }


### PR DESCRIPTION
This has several fixes for recommend evaluation, including:

- actually route exclude items
- battle-test edge cases in top-*N* metrics
- improve eval job error logging