### PR TITLE
Fix non-string Gradle properties (3.0-T version)

### DIFF
--- a/lenskit-gradle/build.gradle
+++ b/lenskit-gradle/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile localGroovy()
 
     compile project(':lenskit-specs')
+    compile 'org.joda:joda-convert:1.8.1'
 }
 
 apply from: 'integration-tests.gradle'

--- a/lenskit-gradle/src/it/gradle/.gitignore
+++ b/lenskit-gradle/src/it/gradle/.gitignore
@@ -1,0 +1,1 @@
+!gradle.properties

--- a/lenskit-gradle/src/it/gradle/property-config/build.gradle
+++ b/lenskit-gradle/src/it/gradle/property-config/build.gradle
@@ -1,0 +1,24 @@
+buildscript {
+    repositories {
+        maven {
+            url "$project.testRepoURI"
+        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.hamcrest:hamcrest-library:1.3'
+        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+    }
+}
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+apply plugin: 'lenskit'
+
+task check {
+    doLast {
+        assertThat(lenskit.maxMemory, equalTo('16g'))
+        assertThat(lenskit.threadCount, equalTo(5))
+    }
+}

--- a/lenskit-gradle/src/it/gradle/property-config/gradle.properties
+++ b/lenskit-gradle/src/it/gradle/property-config/gradle.properties
@@ -1,0 +1,2 @@
+lenskit.threadCount=5
+lenskit.maxMemory=16g

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitPlugin.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitPlugin.groovy
@@ -22,6 +22,7 @@ package org.lenskit.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.joda.convert.StringConvert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -46,11 +47,12 @@ public class LenskitPlugin implements Plugin<Project> {
         for (prop in lenskit.metaClass.properties) {
             def prjProp = "lenskit.$prop.name"
             if (project.hasProperty(prjProp)) {
-                def val = project.getProperty(prjProp)
-                logger.info 'setting property {} to {}', prjProp, val
+                String valStr = project.getProperty(prjProp)
+                def val = valStr
                 if (prop.type != String) {
-                    val = prop.type.metaClass.invokeConstructor(val)
+                    val = StringConvert.INSTANCE.convertFromString(prop.type, valStr)
                 }
+                logger.info 'setting property {} to {}', prjProp, val
                 prop.setProperty(lenskit, val)
             }
         }


### PR DESCRIPTION
These changes fix the handling of non-string Gradle properties using joda-convert, addressing #824.