### PR TITLE
Update to Grapht lifecycles

### DIFF
--- a/lenskit-core/build.gradle
+++ b/lenskit-core/build.gradle
@@ -40,7 +40,7 @@ apply from: "$rootDir/gradle/test-utils.gradle"
 dependencies {
     compile project(':lenskit-api')
     compile project(':lenskit-specs')
-    compile group: 'org.grouplens.grapht', name: 'grapht', version: '0.11.0-BETA1'
+    compile group: 'org.grouplens.grapht', name: 'grapht', version: '0.11.0-SNAPSHOT'
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
     compile group: 'org.joda', name: 'joda-convert', version: '1.8.1'
     compileOnly group: 'com.google.auto.service', name: 'auto-service', version: '1.0-rc2'

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
@@ -140,7 +140,7 @@ public class LenskitRecommender implements Recommender {
 
     @Override
     public void close() {
-        // TODO Implement closing
+        injector.close();
     }
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/inject/NodeInstantiator.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/NodeInstantiator.java
@@ -27,6 +27,7 @@ import org.grouplens.grapht.graph.DAGNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.WillNotClose;
 
 /**
  * Instantiate graph nodes.
@@ -35,8 +36,21 @@ import javax.annotation.Nullable;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public abstract class NodeInstantiator implements Function<DAGNode<Component,Dependency>,Object> {
+    /**
+     * Create a node instantiator without a lifecycle manager.
+     * @return A node instantiator that does not support lifecycle management.
+     */
     public static NodeInstantiator create() {
-        return new DefaultImpl();
+        return new DefaultImpl(null);
+    }
+
+    /**
+     * Create a node instantiator with a lifecycle manager.
+     * @param mgr The lifecycle manager to use.
+     * @return A node instantiator that will register components with a lifecycle manager.
+     */
+    public static NodeInstantiator create(@WillNotClose LifecycleManager mgr) {
+        return new DefaultImpl(mgr);
     }
 
     /**
@@ -67,8 +81,8 @@ public abstract class NodeInstantiator implements Function<DAGNode<Component,Dep
     static class DefaultImpl extends NodeInstantiator {
         private final InjectionContainer container;
 
-        DefaultImpl() {
-            container = InjectionContainer.create(CachePolicy.MEMOIZE);
+        DefaultImpl(LifecycleManager mgr) {
+            container = InjectionContainer.create(CachePolicy.MEMOIZE, mgr);
         }
 
         @Override

--- a/lenskit-core/src/main/java/org/lenskit/inject/PlaceholderSatisfaction.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/PlaceholderSatisfaction.java
@@ -22,11 +22,14 @@ package org.lenskit.inject;
 
 import org.grouplens.grapht.CachePolicy;
 import org.grouplens.grapht.Instantiator;
+import org.grouplens.grapht.LifecycleManager;
 import org.grouplens.grapht.reflect.Desire;
 import org.grouplens.grapht.reflect.Satisfaction;
 import org.grouplens.grapht.reflect.SatisfactionVisitor;
 import org.grouplens.grapht.util.ClassProxy;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
@@ -85,7 +88,7 @@ public class PlaceholderSatisfaction implements Satisfaction, Serializable {
     }
 
     @Override
-    public Instantiator makeInstantiator(Map<Desire,Instantiator> dependencies) {
+    public Instantiator makeInstantiator(@Nonnull Map<Desire, Instantiator> dependencies, @Nullable LifecycleManager lm) {
         throw new UnsupportedOperationException("placeholder node cannot create instantiators");
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/inject/RecommenderInstantiator.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/RecommenderInstantiator.java
@@ -78,6 +78,7 @@ public final class RecommenderInstantiator {
     public DAGNode<Component,Dependency> instantiate() throws RecommenderBuildException {
         try (LifecycleManager lm = new LifecycleManager()) {
             NodeInstantiator instantiator = NodeInstantiator.create(lm);
+            // TODO Verify that no sharable components are lifecycle-managed
             return replaceShareableNodes(NodeProcessors.instantiate(instantiator));
         } catch (InjectionException e) {
             throw new RecommenderBuildException("Recommender instantiation failed", e);

--- a/lenskit-core/src/main/java/org/lenskit/inject/RecommenderInstantiator.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/RecommenderInstantiator.java
@@ -24,9 +24,9 @@ import org.grouplens.grapht.Component;
 import org.grouplens.grapht.Dependency;
 import org.grouplens.grapht.InjectionException;
 import org.grouplens.grapht.graph.DAGNode;
-import org.lenskit.api.RecommenderBuildException;
 import org.lenskit.LenskitConfiguration;
 import org.lenskit.RecommenderConfigurationException;
+import org.lenskit.api.RecommenderBuildException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,6 @@ public final class RecommenderInstantiator {
     private static final Logger logger = LoggerFactory.getLogger(RecommenderInstantiator.class);
     private final DAGNode<Component, Dependency> graph;
     private final NodeInstantiator instantiator;
-
 
     public static RecommenderInstantiator create(DAGNode<Component,Dependency> g) {
         return new RecommenderInstantiator(g, NodeInstantiator.create());
@@ -83,6 +82,7 @@ public final class RecommenderInstantiator {
      * @throws RecommenderBuildException If there is an error instantiating the graph.
      */
     public DAGNode<Component,Dependency> instantiate() throws RecommenderBuildException {
+        // TODO Integrate this with a lifecycle manager
         try {
             return replaceShareableNodes(NodeProcessors.instantiate(instantiator));
         } catch (InjectionException e) {

--- a/lenskit-core/src/main/java/org/lenskit/inject/StaticInjector.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/StaticInjector.java
@@ -102,4 +102,9 @@ public class StaticInjector implements Injector {
             return obj;
         }
     }
+
+    @Override
+    public void close() {
+        // TODO Close the lifecycle manager
+    }
 }


### PR DESCRIPTION
This updates LensKit to be binary-compatible with the lifecycle-based Grapht.

Still need to make use of lifecycles in LensKit.