### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/lenskit-cli/src/main/java/org/lenskit/cli/util/InputData.java
+++ b/lenskit-cli/src/main/java/org/lenskit/cli/util/InputData.java
@@ -126,7 +126,7 @@ public class InputData {
     @Nullable
     public EventDAO getEventDAO() throws IOException {
         DataSource src = getSource();
-        return (src == null) ? null : src.getEventDAO();
+        return src == null ? null : src.getEventDAO();
     }
 
     @Nonnull
@@ -142,7 +142,7 @@ public class InputData {
     @Override
     public String toString() {
         DataSource src = getSource();
-        return (src == null) ? "null" : src.toString();
+        return src == null ? "null" : src.toString();
     }
 
     public static void configureArguments(ArgumentParser parser) {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/MeanVarianceNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/MeanVarianceNormalizer.java
@@ -207,7 +207,7 @@ public class MeanVarianceNormalizer extends AbstractVectorNormalizer implements 
 
         @Override
         public MutableSparseVector apply(MutableSparseVector vector) {
-            double recipSD = Scalars.isZero(stdev) ? 1 : (1 / stdev);
+            double recipSD = Scalars.isZero(stdev) ? 1 : 1 / stdev;
             for (VectorEntry rating : vector) {
                 vector.set(rating, (rating.getValue() - mean) * recipSD);
             }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/statistics/MutualInformationAccumulator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/statistics/MutualInformationAccumulator.java
@@ -120,7 +120,7 @@ public class MutualInformationAccumulator {
                 acc -= m * logP;
             }
         }
-        return (acc * RECIP_LOG_2) / n;
+        return acc * RECIP_LOG_2 / n;
     }
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/data/packed/BinaryIndexTable.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/packed/BinaryIndexTable.java
@@ -134,7 +134,7 @@ class BinaryIndexTable implements Serializable {
                 newKeys.setActive(i, false);
             } else {
                 //TODO following loop need to be replaced with binary rating search
-                for (int j= offsets[i];j<(offsets[i]+sizes[i]);j++) {
+                for (int j = offsets[i]; j< offsets[i]+sizes[i]; j++) {
                     /*
                     * find the new 'size' value; this is the number of indexes for this key that
                     * are less than the limit

--- a/lenskit-data-structures/src/test/java/org/grouplens/lenskit/vectors/ImmutableSparseVectorChannelsTest.java
+++ b/lenskit-data-structures/src/test/java/org/grouplens/lenskit/vectors/ImmutableSparseVectorChannelsTest.java
@@ -120,9 +120,9 @@ public class ImmutableSparseVectorChannelsTest {
         ImmutableSparseVector simpleImm = simple.immutable();
         Set<Symbol> channelSet = simpleImm.getChannelVectorSymbols();
         assertThat(channelSet.size(), equalTo(3));
-        assert(channelSet.contains(fooSymbol));
-        assert(channelSet.contains(barSymbol));
-        assert(channelSet.contains(foobarSymbol));
+        assert channelSet.contains(fooSymbol);
+        assert channelSet.contains(barSymbol);
+        assert channelSet.contains(foobarSymbol);
     }
 
     @Test

--- a/lenskit-data-structures/src/test/java/org/grouplens/lenskit/vectors/MutableSparseVectorChannelsTest.java
+++ b/lenskit-data-structures/src/test/java/org/grouplens/lenskit/vectors/MutableSparseVectorChannelsTest.java
@@ -107,9 +107,9 @@ public class MutableSparseVectorChannelsTest {
         simple.addChannelVector(foobarSymbol);
         
         Set<Symbol> channelSyms = simple.getChannelVectorSymbols();
-        assert(channelSyms.contains(fooSymbol));
-        assert(channelSyms.contains(barSymbol));
-        assert(channelSyms.contains(foobarSymbol));
+        assert channelSyms.contains(fooSymbol);
+        assert channelSyms.contains(barSymbol);
+        assert channelSyms.contains(foobarSymbol);
    }
 
     @Test


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.