### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
@@ -33,6 +33,9 @@ import java.util.Set;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class TypeUtils {
+    private TypeUtils() {
+    }
+
     /**
      * Build the set of types implemented by the objects' classes. This includes
      * all supertypes which are themselves subclasses of <var>parent</var>.  The

--- a/lenskit-core/src/main/java/org/lenskit/LenskitInfo.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitInfo.java
@@ -40,6 +40,9 @@ public final class LenskitInfo {
     private static final Logger logger = LoggerFactory.getLogger(LenskitInfo.class);
     private static SoftReference<Set<String>> revisionSet;
 
+    private LenskitInfo() {
+    }
+
     private static Set<String> loadRevisionSet() {
         ImmutableSet.Builder<String> revisions = ImmutableSet.builder();
         InputStream input = LenskitInfo.class.getResourceAsStream("/META-INF/lenskit/git-commits.lst");

--- a/lenskit-core/src/main/java/org/lenskit/data/ratings/Ratings.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/ratings/Ratings.java
@@ -46,6 +46,9 @@ import java.util.Comparator;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public final class Ratings {
+    private Ratings() {
+    }
+
     /**
      * Construct a rating vector that contains the ratings provided by each user.
      * If all ratings in <var>ratings</var> are for the same item, then this

--- a/lenskit-core/src/main/java/org/lenskit/inject/NodeProcessors.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/NodeProcessors.java
@@ -33,6 +33,9 @@ import java.util.Map;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class NodeProcessors {
+    private NodeProcessors() {
+    }
+
     /**
      * Create a node processor that will instantiate nodes.  It will return nodes whose satisfactions
      * have been replaced with instance satisfactions containing the instance.

--- a/lenskit-eval/src/main/java/org/lenskit/util/table/writer/TableWriters.java
+++ b/lenskit-eval/src/main/java/org/lenskit/util/table/writer/TableWriters.java
@@ -31,6 +31,9 @@ import java.util.List;
  * @since 0.8
  */
 public final class TableWriters {
+    private TableWriters() {
+    }
+
     /**
      * Create a table writer that writes data with common leading columns to an
      * underlying table writer.  The underlying writer will not be closed when the prefixed writer

--- a/lenskit-groovy/src/main/java/org/lenskit/config/ConfigHelpers.java
+++ b/lenskit-groovy/src/main/java/org/lenskit/config/ConfigHelpers.java
@@ -39,6 +39,9 @@ import java.net.URL;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class ConfigHelpers {
+    private ConfigHelpers() {
+    }
+
     /**
      * Load a LensKit configuration from a Groovy closure.  This is useful for using the Groovy
      * DSL in unit tests.

--- a/lenskit-groovy/src/main/java/org/lenskit/config/GroovyUtils.java
+++ b/lenskit-groovy/src/main/java/org/lenskit/config/GroovyUtils.java
@@ -34,6 +34,9 @@ import java.util.Map;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class GroovyUtils {
+    private GroovyUtils() {
+    }
+
     /**
      * Call a configuration block with a specified delegate.
      * @param block The block to invoke.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.