### PR TITLE
 Resources should be closed

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/Functional.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/Functional.java
@@ -83,13 +83,8 @@ public final class Functional {
 
         @Override
         public void funnel(Object from, PrimitiveSink into) {
-            try {
-                ObjectOutputStream out = new ObjectOutputStream(Funnels.asOutputStream(into));
-                try {
-                    out.writeObject(from);
-                } finally {
-                    out.close();
-                }
+            try (ObjectOutputStream out = new ObjectOutputStream(Funnels.asOutputStream(into))) {
+                out.writeObject(from);
             } catch (IOException ex) {
                 throw Throwables.propagate(ex);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “ Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.