### PR TITLE
Fix and test JVM argument passing

### DIFF
--- a/lenskit-cli/src/main/java/org/lenskit/cli/commands/RunScript.java
+++ b/lenskit-cli/src/main/java/org/lenskit/cli/commands/RunScript.java
@@ -1,0 +1,80 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.cli.commands;
+
+import com.google.auto.service.AutoService;
+import com.google.common.io.Files;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.lenskit.cli.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.SimpleBindings;
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.List;
+
+@AutoService(Command.class)
+public class RunScript implements Command {
+    private static final Logger logger = LoggerFactory.getLogger(RunScript.class);
+
+    @Override
+    public String getName() {
+        return "run-script";
+    }
+
+    @Override
+    public String getHelp() {
+        return "Run a Groovy script against a LensKit model.";
+    }
+
+    @Override
+    public void configureArguments(ArgumentParser parser) {
+        parser.addArgument("script")
+              .type(File.class)
+              .metavar("SCRIPT")
+              .help("run SCRIPT");
+        parser.addArgument("args")
+              .type(String.class)
+              .nargs("*")
+              .metavar("ARGS")
+              .help("pass ARGS to script");
+    }
+
+    @Override
+    public void execute(Namespace options) throws Exception {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        File scriptFile = options.get("script");
+        String ext = Files.getFileExtension(scriptFile.getName());
+        ScriptEngine engine = sem.getEngineByExtension(ext);
+        logger.info("running {} with engine {}", scriptFile, engine);
+        SimpleBindings bindings = new SimpleBindings();
+        bindings.put("logger", LoggerFactory.getLogger(scriptFile.getName()));
+        bindings.put("args", options.<List<String>>get("args"));
+        try (Reader reader = new FileReader(scriptFile)) {
+            engine.eval(reader, bindings);
+        }
+    }
+}

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitExtension.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitExtension.groovy
@@ -74,15 +74,15 @@ public class LenskitExtension {
     def String logFileLevel
 
     /**
-     * The list of jvm argument prroperties
-    */
+     * List of JVM arguments to use for LensKit actions.
+     */
     def List<String> jvmArgs = []
 
-    /*
-     * The method to add all the jvm paramters in the list
+    /**
+     * Add JVM arguments for LensKit tasks.
+     * @param val JVM arguments to add. They are appended to the current list of arguments.
      */
     def jvmArgs(String... val){
         jvmArgs.addAll(val)
     }
-
 }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitPlugin.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitPlugin.groovy
@@ -52,8 +52,10 @@ public class LenskitPlugin implements Plugin<Project> {
                 def val = project.getProperty(prjProp)
                 logger.info 'setting property {} to {}', prjProp, val
                 if (prop.type == List) { // if the type is list update the val using strtokenizer
-                    StrTokenizer tok = new StrTokenizer(val, StrMatcher.splitMatcher, StrMatcher.quoteMatcher());
-                    val = prop.type.metaClass.invokeConstructor(tok)
+                    StrTokenizer tok = new StrTokenizer(val as String,
+                                                        StrMatcher.splitMatcher(),
+                                                        StrMatcher.quoteMatcher());
+                    val = tok.toList()
                 } else if (prop.type != String) {
                     val = StringConvert.INSTANCE.convertFromString(prop.type, val)
                 }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitTask.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitTask.groovy
@@ -106,8 +106,8 @@ public abstract class LenskitTask extends ConventionTask {
         if (logbackConfiguration) {
             invoker.systemProperties 'logback.configurationFile': project.file(logbackConfiguration)
         }
-
-        invoker.jvmArgs.addAll(getJvmArgs()) // add all the arguments in the invoker
+        logger.info('applying JVM arguments {}', getJvmArgs())
+        invoker.jvmArgs getJvmArgs() // add all the arguments in the invoker
     }
 
     /**

--- a/lenskit-integration-tests/gradle-tests.gradle
+++ b/lenskit-integration-tests/gradle-tests.gradle
@@ -53,7 +53,8 @@ file('src/it/gradle').eachDir { testDir ->
     def tname = fname.replaceAll(/(?:^|-)(.)/) { m -> m[1].toUpperCase() }
     def workDir = file("build/gradle-tests/$fname")
 
-    task("test$tname", type: GradleBuild) {
+    task("test$tname", type: GradleBuild, group: 'test') {
+        description "Run the ${testDir.name} test."
         dependsOn makeTestRepo, fetchData
         inputs.dir testDir
         inputs.files fileTree('src/it/gradle') {

--- a/lenskit-integration-tests/src/.gitignore
+++ b/lenskit-integration-tests/src/.gitignore
@@ -1,0 +1,1 @@
+!gradle.properties

--- a/lenskit-integration-tests/src/it/gradle/jvm-args/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/jvm-args/build.gradle
@@ -1,0 +1,42 @@
+/* This script tests the JVM argument logic.  It consists of three pieces:
+ *
+ * 1. A gradle.properties file that specifies a JVM argument via the 'lenskit.jvmArgs' property.
+ * 2. A Groovy script that checks for this file's existence.
+ * 3. This file, that runs the script using LensKit's run-script CLI command.
+ */
+
+buildscript {
+    repositories {
+        maven {
+            url "$project.testRepoURI"
+        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.hamcrest:hamcrest-library:1.3'
+        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+    }
+}
+
+import org.lenskit.gradle.*
+import static org.hamcrest.MatcherAssert.*
+
+apply plugin: 'java'
+apply plugin: 'lenskit'
+apply from: 'common.gradle'
+
+task checkScript(type: LenskitExec) {
+    logFile "$buildDir/run-script.log"
+    command 'run-script'
+    args file('verify.groovy')
+    doFirst {
+        mkdir buildDir
+    }
+}
+
+check {
+    dependsOn 'checkScript'
+    doLast {
+        assertThat "log file exists", file("$buildDir/run-script.log").exists()
+    }
+}

--- a/lenskit-integration-tests/src/it/gradle/jvm-args/gradle.properties
+++ b/lenskit-integration-tests/src/it/gradle/jvm-args/gradle.properties
@@ -1,0 +1,1 @@
+lenskit.jvmArgs=-Dtest.prop=test-value

--- a/lenskit-integration-tests/src/it/gradle/jvm-args/verify.groovy
+++ b/lenskit-integration-tests/src/it/gradle/jvm-args/verify.groovy
@@ -1,0 +1,5 @@
+import static org.hamcrest.MatcherAssert.*
+import static org.hamcrest.Matchers.*
+
+logger.info('testing for the configured property')
+assertThat(System.getProperties(), hasEntry('test.prop', 'test-value'))


### PR DESCRIPTION
This corrects the previous code for #751 (#857) and adds tests for its logic.

It also adds the beginnings of a `run-script` command (#688) to make the test easier to write.