### PR TITLE
Add recommenders to item selectors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ apply plugin: 'base'
 
 allprojects { project ->
     group 'org.grouplens.lenskit'
-    version '3.0-T3-SNAPSHOT'
+    version '3.0-T3'
     
     ext.getConfigProperty = { name, dft ->
         if (project.hasProperty(name)) {

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ apply plugin: 'base'
 
 allprojects { project ->
     group 'org.grouplens.lenskit'
-    version '3.0-T3'
+    version '3.0-T4-SNAPSHOT'
     
     ext.getConfigProperty = { name, dft ->
         if (project.hasProperty(name)) {

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/RecommendEvalTask.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/RecommendEvalTask.java
@@ -316,7 +316,7 @@ public class RecommendEvalTask implements EvalTask {
             contexts.add(MetricContext.create(metric, algorithm, dataSet, rec));
         }
 
-        return new TopNConditionEvaluator(tlb, irec, contexts, items);
+        return new TopNConditionEvaluator(tlb, rec, irec, contexts, items);
     }
 
     static class MetricContext<X> {
@@ -349,14 +349,16 @@ public class RecommendEvalTask implements EvalTask {
 
     class TopNConditionEvaluator implements ConditionEvaluator {
         private final TableWriter writer;
-        private final ItemRecommender recommender;
+        private final Recommender recommender;
+        private final ItemRecommender itemRecommender;
         private final UserHistorySummarizer summarizer = new RatingVectorUserHistorySummarizer();
         private final List<MetricContext<?>> predictMetricContexts;
         private final LongSet allItems;
 
-        public TopNConditionEvaluator(TableWriter tw, ItemRecommender rec, List<MetricContext<?>> mcs, LongSet items) {
+        public TopNConditionEvaluator(TableWriter tw, Recommender rec, ItemRecommender irec, List<MetricContext<?>> mcs, LongSet items) {
             writer = tw;
             recommender = rec;
+            itemRecommender = irec;
             predictMetricContexts = mcs;
             allItems = items;
         }
@@ -365,10 +367,10 @@ public class RecommendEvalTask implements EvalTask {
         @Override
         public Map<String, Object> measureUser(TestUser testUser) {
             // FIXME Support item selectors
-            LongSet candidates = getCandidateSelector().selectItems(allItems, testUser);
-            LongSet excludes = getExcludeSelector().selectItems(allItems, testUser);
-            ResultList results = recommender.recommendWithDetails(testUser.getUserId(), getListSize(),
-                                                                  candidates, excludes);
+            LongSet candidates = getCandidateSelector().selectItems(allItems, recommender, testUser);
+            LongSet excludes = getExcludeSelector().selectItems(allItems, recommender, testUser);
+            ResultList results = itemRecommender.recommendWithDetails(testUser.getUserId(), getListSize(),
+                                                                      candidates, excludes);
 
             // Measure the user results
             Map<String,Object> row = new HashMap<>();

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMRRMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMRRMetric.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.apache.commons.lang3.StringUtils;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
+import org.lenskit.api.Recommender;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
@@ -87,7 +88,7 @@ public class TopNMRRMetric extends TopNMetric<TopNMRRMetric.Context> {
     @Nullable
     @Override
     public Context createContext(AlgorithmInstance algorithm, DataSet dataSet, org.lenskit.api.Recommender recommender) {
-        return new Context(dataSet.getTestData().getItemDAO().getItemIds());
+        return new Context(dataSet.getTestData().getItemDAO().getItemIds(), recommender);
     }
 
     @Nonnull
@@ -99,7 +100,7 @@ public class TopNMRRMetric extends TopNMetric<TopNMRRMetric.Context> {
     @Nonnull
     @Override
     public MetricResult measureUser(TestUser user, ResultList recommendations, Context context) {
-        LongSet good = goodItems.selectItems(context.universe, user);
+        LongSet good = goodItems.selectItems(context.universe, context.recommender, user);
         if (good.isEmpty()) {
             logger.warn("no good items for user {}", user.getUserId());
         }
@@ -156,9 +157,11 @@ public class TopNMRRMetric extends TopNMetric<TopNMRRMetric.Context> {
         private final LongSet universe;
         private final MeanAccumulator allMean = new MeanAccumulator();
         private final MeanAccumulator goodMean = new MeanAccumulator();
+        private final Recommender recommender;
 
-        Context(LongSet universe) {
+        Context(LongSet universe, Recommender recommender) {
             this.universe = universe;
+            this.recommender = recommender;
         }
 
         void addUser(UserResult ur) {

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
@@ -23,6 +23,7 @@ package org.lenskit.eval.traintest.recommend;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.apache.commons.lang3.StringUtils;
+import org.lenskit.api.Recommender;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
@@ -89,7 +90,7 @@ public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMet
     public MetricResult measureUser(TestUser user, ResultList recs, Context context) {
         int tp = 0;
 
-        LongSet items = goodItems.selectItems(context.universe, user);
+        LongSet items = goodItems.selectItems(context.universe, context.recommender, user);
 
         for(Result res: recs) {
             if(items.contains(res.getId())) {
@@ -111,7 +112,7 @@ public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMet
     @Nullable
     @Override
     public Context createContext(AlgorithmInstance algorithm, DataSet dataSet, org.lenskit.api.Recommender recommender) {
-        return new Context(dataSet.getAllItems());
+        return new Context(dataSet.getAllItems(), recommender);
     }
 
     @Nonnull
@@ -145,13 +146,15 @@ public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMet
     }
 
     public static class Context {
-        LongSet universe;
+        final LongSet universe;
+        final Recommender recommender;
         double totalPrecision = 0;
         double totalRecall = 0;
         int nusers = 0;
 
-        public Context(LongSet items) {
+        public Context(LongSet items, Recommender recommender) {
             universe = items;
+            this.recommender = recommender;
         }
 
         private void addUser(double prec, double rec) {

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
@@ -50,7 +50,7 @@ class TopNMRRMetricTest {
     public void createMetric() {
         metric = new TopNMRRMetric(ItemSelector.fixed(3, 7, 9, 42), null)
 
-        accum = new TopNMRRMetric.Context(universe)
+        accum = new TopNMRRMetric.Context(universe, recommender)
     }
 
     @Test

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
@@ -50,7 +50,7 @@ class TopNMRRMetricTest {
     public void createMetric() {
         metric = new TopNMRRMetric(ItemSelector.fixed(3, 7, 9, 42), null)
 
-        accum = new TopNMRRMetric.Context(universe, recommender)
+        accum = new TopNMRRMetric.Context(universe, null)
     }
 
     @Test

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetricTest.groovy
@@ -43,7 +43,7 @@ class TopNPrecisionRecallMetricTest {
     @Before
     public void createMetric() {
         metric = new TopNPrecisionRecallMetric(ItemSelector.compileSelector('user.testItems'), null)
-        accum = new TopNPrecisionRecallMetric.Context(universe)
+        accum = new TopNPrecisionRecallMetric.Context(universe, recommender)
         user = TestUser.newBuilder()
                        .setUserId(42)
                        .addTestEvent(Rating.create(42L, 1L, 3.5),

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetricTest.groovy
@@ -43,7 +43,7 @@ class TopNPrecisionRecallMetricTest {
     @Before
     public void createMetric() {
         metric = new TopNPrecisionRecallMetric(ItemSelector.compileSelector('user.testItems'), null)
-        accum = new TopNPrecisionRecallMetric.Context(universe, recommender)
+        accum = new TopNPrecisionRecallMetric.Context(universe, null)
         user = TestUser.newBuilder()
                        .setUserId(42)
                        .addTestEvent(Rating.create(42L, 1L, 3.5),

--- a/lenskit-eval/src/test/java/org/lenskit/eval/traintest/recommend/ItemSelectorTest.java
+++ b/lenskit-eval/src/test/java/org/lenskit/eval/traintest/recommend/ItemSelectorTest.java
@@ -33,7 +33,7 @@ public class ItemSelectorTest {
     public void testUniverse() {
         LongSet items = LongUtils.packedSet(42, 37, 39, 102);
         ItemSelector selector = ItemSelector.compileSelector("allItems");
-        LongSet selected = selector.selectItems(items, TestUser.newBuilder().setUserId(42).build());
+        LongSet selected = selector.selectItems(items, null, TestUser.newBuilder().setUserId(42).build());
         assertThat(selected, equalTo(items));
     }
 
@@ -46,7 +46,7 @@ public class ItemSelectorTest {
                                 .addTestRating(2, 4.2)
                                 .build();
         ItemSelector selector = ItemSelector.compileSelector("user.testItems");
-        LongSet selected = selector.selectItems(items, user);
+        LongSet selected = selector.selectItems(items, null, user);
         assertThat(selected, containsInAnyOrder(1L, 2L));
     }
 
@@ -59,7 +59,7 @@ public class ItemSelectorTest {
                                 .addTestRating(39, 4.2)
                                 .build();
         ItemSelector selector = ItemSelector.compileSelector("allItems - user.testItems");
-        LongSet selected = selector.selectItems(items, user);
+        LongSet selected = selector.selectItems(items, null, user);
         assertThat(selected, containsInAnyOrder(42L, 37L, 102L));
     }
 
@@ -72,7 +72,7 @@ public class ItemSelectorTest {
                                 .addTestRating(39, 4.2)
                                 .build();
         ItemSelector selector = ItemSelector.compileSelector("user.testItems + pickRandom(allItems - user.testItems, 2)");
-        LongSet selected = selector.selectItems(items, user);
+        LongSet selected = selector.selectItems(items, null, user);
         assertThat(selected, allOf(hasItem(1L), hasItem(39L)));
         assertThat(selected, hasSize(4));
     }


### PR DESCRIPTION
This makes recommenders available in item selectors, so data can be extracted from them if needed.