### PR TITLE
Add relative URI support to loading algorithms

### DIFF
--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/MultiAlgorithmDSL.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/MultiAlgorithmDSL.java
@@ -45,7 +45,7 @@ public class MultiAlgorithmDSL extends LenskitConfigDSL {
     private List<AlgorithmInstance> instances = new ArrayList<>();
 
     public MultiAlgorithmDSL(ConfigurationLoader loader, AlgorithmInstanceBuilder aib) {
-        super(loader, aib.getConfig());
+        super(loader, aib.getConfig(), null);
         builder = aib;
     }
 
@@ -73,6 +73,7 @@ public class MultiAlgorithmDSL extends LenskitConfigDSL {
             kid.setName(name);
         }
         MultiAlgorithmDSL dsl = new MultiAlgorithmDSL(getConfigLoader(), kid);
+        dsl.setBaseURI(getBaseURI());
         Closure<?> copy = (Closure<?>) block.clone();
         copy.setDelegate(dsl);
         copy.setResolveStrategy(Closure.DELEGATE_FIRST);

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TrainTestExperiment.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TrainTestExperiment.java
@@ -174,6 +174,7 @@ public class TrainTestExperiment {
         MultiAlgorithmDSL dsl = new MultiAlgorithmDSL(loader, aib);
         try {
             LenskitConfigScript script = loader.loadScript(file.toFile());
+            dsl.setBaseURI(script.getDelegate().getBaseURI());
             script.setDelegate(dsl);
             script.configure();
         } catch (IOException e) {

--- a/lenskit-groovy/src/main/java/org/lenskit/config/BindingDSL.java
+++ b/lenskit-groovy/src/main/java/org/lenskit/config/BindingDSL.java
@@ -34,9 +34,9 @@ import org.lenskit.inject.AbstractConfigContext;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.net.URI;
 import java.util.Map;
 
 /**
@@ -81,12 +81,12 @@ public class BindingDSL extends AbstractConfigContext {
 
     /**
      * Include another configuration file.
-     * @param file The configuration file.
+     * @param uri The URI of the configuration file.
      * @throws IOException if an error is thrown loading the script.
      * @throws RecommenderConfigurationException if there is an error running the script.
      * @throws UnsupportedOperationException if the current context does not support loading.
      */
-    public void include(File file) throws IOException, RecommenderConfigurationException {
+    public void include(URI uri) throws IOException, RecommenderConfigurationException {
         // doesn't work in nested bindings. Top-level bindings use LenskitConfigDSL, which
         // overrides it to work.
         throw new UnsupportedOperationException("cannot include a file in a nested configuration");
@@ -94,11 +94,11 @@ public class BindingDSL extends AbstractConfigContext {
 
     /**
      * Include another configuration file.
-     * @param file The configuration file.
-     * @see #include(File)
+     * @param file The configuration file name or URI.
+     * @see #include(URI)
      */
     public void include(String file) throws IOException, RecommenderConfigurationException {
-        include(new File(file));
+        include(URI.create(file));
     }
 
     /**

--- a/lenskit-groovy/src/main/java/org/lenskit/config/LenskitConfigScript.java
+++ b/lenskit-groovy/src/main/java/org/lenskit/config/LenskitConfigScript.java
@@ -96,7 +96,7 @@ public abstract class LenskitConfigScript extends Script {
      */
     public void configure(LenskitConfiguration config) throws RecommenderConfigurationException {
         LenskitConfigDSL old = getDelegate();
-        setDelegate(new LenskitConfigDSL(old.getConfigLoader(), config));
+        setDelegate(new LenskitConfigDSL(old.getConfigLoader(), config, delegate.getBaseURI()));
         try {
             run();
         } catch (MissingPropertyException e) {

--- a/lenskit-groovy/src/test/groovy/org/lenskit/config/ConfigLoadingTest.groovy
+++ b/lenskit-groovy/src/test/groovy/org/lenskit/config/ConfigLoadingTest.groovy
@@ -128,7 +128,19 @@ set ConstantItemScorer.Value to Math.PI""");
 
     @Test
     void testLoadBasicURL() {
-        LenskitConfiguration config = ConfigHelpers.load(getClass().getResource("test-config.groovy"))
+        LenskitConfiguration config = ConfigHelpers.load(getClass().getResource('test-config.groovy'))
+        config.bind(EventDAO).to(dao)
+        def engine = LenskitRecommenderEngine.build(config)
+        def rec = engine.createRecommender()
+        assertThat(rec.getItemScorer(), instanceOf(ConstantItemScorer))
+        assertThat(rec.getItemRecommender(), instanceOf(TopNItemRecommender))
+        assertThat(rec.getItemBasedItemRecommender(), nullValue());
+        assertThat(rec.itemScorer.fixedScore, equalTo(Math.PI))
+    }
+
+    @Test
+    void testLoadURLWithInclude() {
+        LenskitConfiguration config = ConfigHelpers.load(getClass().getResource('test-include.groovy'))
         config.bind(EventDAO).to(dao)
         def engine = LenskitRecommenderEngine.build(config)
         def rec = engine.createRecommender()

--- a/lenskit-groovy/src/test/java/org/lenskit/config/LenskitConfigDSLTest.java
+++ b/lenskit-groovy/src/test/java/org/lenskit/config/LenskitConfigDSLTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.config;
 
 import org.apache.commons.lang3.SystemUtils;

--- a/lenskit-groovy/src/test/java/org/lenskit/config/LenskitConfigDSLTest.java
+++ b/lenskit-groovy/src/test/java/org/lenskit/config/LenskitConfigDSLTest.java
@@ -1,0 +1,27 @@
+package org.lenskit.config;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+import org.lenskit.LenskitConfiguration;
+
+import java.io.File;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+
+public class LenskitConfigDSLTest {
+    @Test
+    public void testInitialBaseURI() {
+        LenskitConfigDSL dsl = LenskitConfigDSL.forConfig(new LenskitConfiguration());
+        assertThat(new File(dsl.getBaseURI().getPath()),
+                   equalTo(SystemUtils.getUserDir()));
+    }
+
+    @Test
+    public void testConfiguredBaseURI() {
+        LenskitConfigDSL dsl = LenskitConfigDSL.forConfig(new LenskitConfiguration());
+        dsl.setBaseURI(new File("/tmp").toURI());
+        assertThat(new File(dsl.getBaseURI().getPath()),
+                   equalTo(new File("/tmp")));
+    }
+}

--- a/lenskit-groovy/src/test/java/org/lenskit/config/LenskitConfigDSLTest.java
+++ b/lenskit-groovy/src/test/java/org/lenskit/config/LenskitConfigDSLTest.java
@@ -22,6 +22,6 @@ public class LenskitConfigDSLTest {
         LenskitConfigDSL dsl = LenskitConfigDSL.forConfig(new LenskitConfiguration());
         dsl.setBaseURI(new File("/tmp").toURI());
         assertThat(new File(dsl.getBaseURI().getPath()),
-                   equalTo(new File("/tmp")));
+                   equalTo(new File("/tmp").getAbsoluteFile()));
     }
 }

--- a/lenskit-groovy/src/test/resources/org/lenskit/config/pi-mean.groovy
+++ b/lenskit-groovy/src/test/resources/org/lenskit/config/pi-mean.groovy
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 import org.lenskit.basic.ConstantItemScorer
 
 set ConstantItemScorer.Value to Math.PI

--- a/lenskit-groovy/src/test/resources/org/lenskit/config/pi-mean.groovy
+++ b/lenskit-groovy/src/test/resources/org/lenskit/config/pi-mean.groovy
@@ -1,0 +1,3 @@
+import org.lenskit.basic.ConstantItemScorer
+
+set ConstantItemScorer.Value to Math.PI

--- a/lenskit-groovy/src/test/resources/org/lenskit/config/test-include.groovy
+++ b/lenskit-groovy/src/test/resources/org/lenskit/config/test-include.groovy
@@ -1,0 +1,27 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.config
+
+import org.lenskit.api.*
+import org.lenskit.basic.ConstantItemScorer
+
+include 'pi-mean.groovy'
+bind ItemScorer to ConstantItemScorer


### PR DESCRIPTION
This makes `include` statements in LensKit algorithm configurations relative
to the file being loaded.