### PR TITLE
Fix data set name & attribute support in Gradle task

### DIFF
--- a/lenskit-gradle/src/it/gradle/configure-data-set/build.gradle
+++ b/lenskit-gradle/src/it/gradle/configure-data-set/build.gradle
@@ -12,6 +12,9 @@ buildscript {
 }
 
 import org.lenskit.gradle.*
+import org.lenskit.specs.*
+import org.lenskit.specs.data.*
+import org.lenskit.specs.eval.*
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
@@ -22,12 +25,20 @@ apply plugin: 'lenskit'
 task evaluate(type: TrainTest) {
     dryRun true
     dataSet {
+        name 'Foo'
         trainSource textFile('train.csv')
         testSource textFile('test.csv')
+        attributes Partition: 1
     }
 }
 
 task check(overwrite: true, dependsOn: evaluate) << {
-    def spec = file("$buildDir/evaluate.json")
-    assertThat("spec file exists", spec.exists())
+    def specFile = file("$buildDir/evaluate.json")
+    assertThat("spec file exists", specFile.exists())
+    def exp = SpecUtils.load(TrainTestExperimentSpec, specFile.toPath())
+    assertThat(exp.dataSets, hasSize(1))
+    def spec = exp.dataSets[0]
+    assertThat(spec.name, equalTo('Foo'))
+    assertThat(spec.attributes, hasEntry('Partition', 1))
+    assertThat(spec.testSource, instanceOf(TextDataSourceSpec))
 }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/TrainTest.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/TrainTest.groovy
@@ -22,6 +22,7 @@ package org.lenskit.gradle
 
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
+import org.lenskit.gradle.delegates.DataSetSpecDelegate
 import org.lenskit.gradle.delegates.EvalTaskDelegate
 import org.lenskit.gradle.delegates.SpecDelegate
 import org.lenskit.gradle.traits.DataSources
@@ -65,8 +66,8 @@ class TrainTest extends LenskitTask {
      * Configure a train-test data set.
      * @param block A block which will be used to configureSpec a {@link DataSetSpec}.
      */
-    void dataSet(Closure block) {
-        dataSet SpecDelegate.configureSpec(project, DataSetSpec, block, DataSources)
+    void dataSet(@DelegatesTo(DataSetSpecDelegate) Closure block) {
+        dataSet SpecDelegate.configureSpec(project, DataSetSpec, DataSetSpecDelegate, block)
     }
 
     /**

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/delegates/DataSetSpecDelegate.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/delegates/DataSetSpecDelegate.groovy
@@ -1,0 +1,59 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.gradle.delegates
+
+import org.gradle.api.Project
+import org.lenskit.gradle.traits.DataSources
+import org.lenskit.specs.eval.DataSetSpec
+
+class DataSetSpecDelegate extends SpecDelegate implements DataSources {
+    DataSetSpec dss
+
+    public DataSetSpecDelegate(Project prj, DataSetSpec spec) {
+        super(prj, spec);
+        dss = spec;
+    }
+
+    /**
+     * Get the map of attributes in the spec.
+     * @return The spec's attributes
+     */
+    public Map<String,Object> getAttributes() {
+        return dss.attributes
+    }
+
+    /**
+     * Add an attribute.
+     * @param name The attribute name.
+     * @param val The attribute value.
+     */
+    public void attribute(String name, Object val) {
+        dss.attributes[name] = val
+    }
+
+    /**
+     * Add one or more attributes.
+     * @param attrs The attributes to add.
+     */
+    public void attributes(Map<String,Object> attrs) {
+        dss.attributes.putAll(attrs);
+    }
+}

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/delegates/SpecDelegate.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/delegates/SpecDelegate.groovy
@@ -43,7 +43,12 @@ class SpecDelegate {
 
     @Override
     Object getProperty(String property) {
-        return spec.metaClass.getProperty(spec, property)
+        switch (property) {
+        case 'project':
+            return getProject()
+        default:
+            return spec.metaClass.getProperty(spec, property)
+        }
     }
 
     @Override


### PR DESCRIPTION
This implements and tests support for names and attributes in the data set support in the Gradle task (#896), finishing up leftovers from #897.