### PR TITLE
Memory allocation performance improvements

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/ScoredItemAccumulator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/ScoredItemAccumulator.java
@@ -21,6 +21,7 @@
 package org.grouplens.lenskit.util;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
@@ -94,4 +95,10 @@ public interface ScoredItemAccumulator {
      * @return The set of items accumulated.
      */
     LongSet finishSet();
+
+    /**
+     * Accumulate the scored items into a list.
+     * @return The list of items accumulated, in decreasing order of score.
+     */
+    LongList finishList();
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/TopNScoredItemAccumulator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/TopNScoredItemAccumulator.java
@@ -24,10 +24,7 @@ import com.google.common.primitives.Doubles;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import it.unimi.dsi.fastutil.ints.AbstractIntComparator;
 import it.unimi.dsi.fastutil.ints.IntHeapPriorityQueue;
-import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
-import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.*;
 import org.grouplens.lenskit.collections.CompactableLongArrayList;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.grouplens.lenskit.scored.ScoredIdListBuilder;
@@ -225,6 +222,26 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
         clear();
 
         return longs;
+    }
+
+    @Override
+    public LongList finishList() {
+        assert size == heap.size();
+        int[] indices = new int[size];
+        // Copy backwards so the scored list is sorted.
+        for (int i = size - 1; i >= 0; i--) {
+            indices[i] = heap.dequeue();
+        }
+        LongList list = new LongArrayList(size);
+        for (int i : indices) {
+            list.add(items.getLong(i));
+        }
+
+        assert heap.isEmpty();
+
+        clear();
+
+        return list;
     }
 
     private void clear() {

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/TopNScoredItemAccumulator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/TopNScoredItemAccumulator.java
@@ -154,7 +154,7 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
         }
         ScoredIdListBuilder bld = ScoredIds.newListBuilder(size);
         for (int i : indices) {
-            bld.add(items.get(i), scores.get(i));
+            bld.add(items.getLong(i), scores.getDouble(i));
         }
 
         assert heap.isEmpty();
@@ -181,8 +181,8 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
         long[] keys = new long[indices.length];
         double[] values = new double[indices.length];
         for (int i = 0; i < indices.length; i++) {
-            keys[i] = items.get(indices[i]);
-            values[i] = scores.get(indices[i]);
+            keys[i] = items.getLong(indices[i]);
+            values[i] = scores.getDouble(indices[i]);
         }
         clear();
 
@@ -206,8 +206,8 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
         long[] keys = new long[indices.length];
         double[] values = new double[indices.length];
         for (int i = 0; i < indices.length; i++) {
-            keys[i] = items.get(indices[i]);
-            values[i] = scores.get(indices[i]);
+            keys[i] = items.getLong(indices[i]);
+            values[i] = scores.getDouble(indices[i]);
         }
         clear();
 
@@ -220,7 +220,7 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
 
         LongSet longs = new LongOpenHashSet(size);
         while (!heap.isEmpty()) {
-            longs.add(items.get(heap.dequeue()));
+            longs.add(items.getLong(heap.dequeue()));
         }
         clear();
 
@@ -240,7 +240,7 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
     private class SlotComparator extends AbstractIntComparator {
         @Override
         public int compare(int i, int j) {
-            return Doubles.compare(scores.get(i), scores.get(j));
+            return Doubles.compare(scores.getDouble(i), scores.getDouble(j));
         }
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/UnlimitedScoredItemAccumulator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/UnlimitedScoredItemAccumulator.java
@@ -101,4 +101,17 @@ public final class UnlimitedScoredItemAccumulator implements ScoredItemAccumulat
         }
         return set;
     }
+
+    @Override
+    public LongList finishList() {
+        if (scores == null) {
+            return LongLists.EMPTY_LIST;
+        }
+
+        LongList list = new LongArrayList(scores.size());
+        for (ScoredId id: finish()) {
+            list.add(id.getId());
+        }
+        return list;
+    }
 }

--- a/lenskit-core/src/main/java/org/lenskit/util/collections/LongUtils.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/collections/LongUtils.java
@@ -27,7 +27,8 @@ import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
 import org.lenskit.util.keys.LongSortedArraySet;
 import org.lenskit.util.keys.SortedKeyIndex;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.*;
 
 /**
@@ -37,6 +38,7 @@ import java.util.*;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @compat Public
  */
+@ParametersAreNonnullByDefault
 public final class LongUtils {
     private LongUtils() {}
 
@@ -164,7 +166,7 @@ public final class LongUtils {
      * @return {@code longs} as a fastutil {@link LongSet}. If {@code longs} is already
      *         a LongSet, it is cast.
      */
-    public static LongSet asLongSet(final Set<Long> longs) {
+    public static LongSet asLongSet(@Nullable final Set<Long> longs) {
         if (longs == null) {
             return null;
         } else if (longs instanceof LongSet) {
@@ -355,7 +357,7 @@ public final class LongUtils {
      * {@code nRandom} items.
      */
     public static LongSortedSet randomSubset(LongSet set, int num, LongSet exclude,
-                                             @Nonnull Random rng) {
+                                             Random rng) {
         LongSet initial = exclude;
         LongList selected = new LongArrayList(num);
         int n = 0;

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TopNScoredItemAccumulatorTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TopNScoredItemAccumulatorTest.java
@@ -21,15 +21,14 @@
 package org.grouplens.lenskit.util;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -106,5 +105,14 @@ public class TopNScoredItemAccumulatorTest {
         assertThat(out, hasEntry(2L, 9.8));
         assertThat(out, hasEntry(5L, 4.2));
         assertThat(out, hasEntry(3L, 2.9));
+    }
+
+    @Test
+    public void testAccumList() {
+        accum.put(5, 4.2);
+        accum.put(3, 2.9);
+        accum.put(2, 9.8);
+        LongList out = accum.finishList();
+        assertThat(out, contains(2L, 5L, 3L));
     }
 }

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/UnlimitedScoredItemAccumulatorTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/UnlimitedScoredItemAccumulatorTest.java
@@ -20,12 +20,14 @@
  */
 package org.grouplens.lenskit.util;
 
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
@@ -61,5 +63,14 @@ public class UnlimitedScoredItemAccumulatorTest {
         assertThat(out.get(1).getScore(), equalTo(4.2));
         assertThat(out.get(2).getId(), equalTo(3L));
         assertThat(out.get(2).getScore(), equalTo(2.9));
+    }
+
+    @Test
+    public void testAccumList() {
+        accum.put(5, 4.2);
+        accum.put(3, 2.9);
+        accum.put(2, 9.8);
+        LongList out = accum.finishList();
+        assertThat(out, contains(2L, 5L, 3L));
     }
 }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/ListOnlyTopNMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/ListOnlyTopNMetric.java
@@ -1,0 +1,72 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.eval.traintest.recommend;
+
+import it.unimi.dsi.fastutil.longs.LongList;
+import org.lenskit.api.ResultList;
+import org.lenskit.eval.traintest.TestUser;
+import org.lenskit.eval.traintest.metrics.MetricResult;
+import org.lenskit.eval.traintest.metrics.TypedMetricResult;
+import org.lenskit.util.collections.LongUtils;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Intermediate class for top-N metrics that only depend on the list of recommended items, not their details.
+ * Metrics extending this class will implement the {@link #measureUser(TestUser, int, LongList, Object)} method
+ * instead of {@link #measureUser(TestUser, int, ResultList, Object)}.  The recommend eval task uses this
+ * subclass to improve efficiency when results are not used in the evaluation.
+ *
+ * @param <X> The accumulator type.
+ */
+public abstract class ListOnlyTopNMetric<X> extends TopNMetric<X> {
+    protected ListOnlyTopNMetric(List<String> labels, List<String> aggLabels) {
+        super(labels, aggLabels);
+    }
+
+    protected ListOnlyTopNMetric(Class<? extends TypedMetricResult> resType, Class<? extends TypedMetricResult> aggType) {
+        super(resType, aggType);
+    }
+
+    protected ListOnlyTopNMetric(Class<? extends TypedMetricResult> resType, Class<? extends TypedMetricResult> aggType, String suffix) {
+        super(resType, aggType, suffix);
+    }
+
+    @Nonnull
+    @Override
+    public final MetricResult measureUser(TestUser user, int targetLength, ResultList recommendations, X context) {
+        return measureUser(user, targetLength,
+                           LongUtils.asLongList(recommendations.idList()),
+                           context);
+    }
+
+    /**
+     * Measurement method that only uses the recommend list.
+     * @param user The user.
+     * @param targetLength The target list length.
+     * @param recommendations The list of recommendations.
+     * @param context The context.
+     * @return The results of measuring this user.
+     */
+    @Nonnull
+    public abstract MetricResult measureUser(TestUser user, int targetLength, LongList recommendations, X context);
+}

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/RecommendEvalTask.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/RecommendEvalTask.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.grouplens.lenskit.data.history.RatingVectorUserHistorySummarizer;
 import org.grouplens.lenskit.data.history.UserHistorySummarizer;
@@ -39,6 +40,7 @@ import org.lenskit.eval.traintest.metrics.MetricResult;
 import org.lenskit.specs.DynamicSpec;
 import org.lenskit.specs.SpecUtils;
 import org.lenskit.specs.eval.RecommendEvalTaskSpec;
+import org.lenskit.util.collections.LongUtils;
 import org.lenskit.util.table.TableLayout;
 import org.lenskit.util.table.TableLayoutBuilder;
 import org.lenskit.util.table.writer.CSVWriter;
@@ -303,13 +305,17 @@ public class RecommendEvalTask implements EvalTask {
             return null;
         }
 
+        boolean useDetails = tlb != null; // writing requires details
         List<MetricContext<?>> contexts = new ArrayList<>(topNMetrics.size());
         for (TopNMetric<?> metric: topNMetrics) {
             logger.debug("setting up metric {}", metric);
-            contexts.add(MetricContext.create(metric, algorithm, dataSet, rec));
+            MetricContext<?> mc = MetricContext.create(metric, algorithm, dataSet, rec);
+            contexts.add(mc);
+            // does this metric require details?
+            useDetails |= mc.usesDetails();
         }
 
-        return new TopNConditionEvaluator(tlb, rec, irec, contexts, items);
+        return new TopNConditionEvaluator(tlb, rec, irec, contexts, items, useDetails);
     }
 
     static class MetricContext<X> {
@@ -321,9 +327,18 @@ public class RecommendEvalTask implements EvalTask {
             context = ctx;
         }
 
+        public boolean usesDetails() {
+            return !(metric instanceof ListOnlyTopNMetric);
+        }
+
         @Nonnull
         public MetricResult measureUser(TestUser user, int n, ResultList recommendations) {
             return metric.measureUser(user, n, recommendations, context);
+        }
+
+        @Nonnull
+        public MetricResult measureUser(TestUser user, int n, LongList recommendations) {
+            return ((ListOnlyTopNMetric<X>) metric).measureUser(user, n, recommendations, context);
         }
 
         @Nonnull
@@ -347,13 +362,16 @@ public class RecommendEvalTask implements EvalTask {
         private final UserHistorySummarizer summarizer = new RatingVectorUserHistorySummarizer();
         private final List<MetricContext<?>> predictMetricContexts;
         private final LongSet allItems;
+        private final boolean useDetails;
 
-        public TopNConditionEvaluator(TableWriter tw, Recommender rec, ItemRecommender irec, List<MetricContext<?>> mcs, LongSet items) {
+        public TopNConditionEvaluator(TableWriter tw, Recommender rec, ItemRecommender irec,
+                                      List<MetricContext<?>> mcs, LongSet items, boolean details) {
             writer = tw;
             recommender = rec;
             itemRecommender = irec;
             predictMetricContexts = mcs;
             allItems = items;
+            useDetails = details;
         }
 
         @Nonnull
@@ -362,27 +380,41 @@ public class RecommendEvalTask implements EvalTask {
             LongSet candidates = getCandidateSelector().selectItems(allItems, recommender, testUser);
             LongSet excludes = getExcludeSelector().selectItems(allItems, recommender, testUser);
             int n = getListSize();
-            ResultList results = itemRecommender.recommendWithDetails(testUser.getUserId(), n,
-                                                                      candidates, excludes);
+            ResultList results = null;
+            LongList items = null;
+            if (useDetails) {
+                results = itemRecommender.recommendWithDetails(testUser.getUserId(), n,
+                                                               candidates, excludes);
+            } else {
+                // no one needs details, save time collecting them
+                items = LongUtils.asLongList(itemRecommender.recommend(testUser.getUserId(), n,
+                                                                       candidates, excludes));
+            }
 
             // Measure the user results
             Map<String,Object> row = new HashMap<>();
             for (MetricContext<?> mc: predictMetricContexts) {
-                row.putAll(mc.measureUser(testUser, n, results)
-                             .withPrefix(getLabelPrefix())
-                             .getValues());
+                MetricResult res;
+                if (useDetails) {
+                    res = mc.measureUser(testUser, n, results);
+                } else {
+                    res = mc.measureUser(testUser, n, items);
+                }
+                row.putAll(res.withPrefix(getLabelPrefix())
+                              .getValues());
             }
 
             // Write all attempted predictions
-            int rank = 0;
-            for (Result rec: results) {
-                try {
-                    rank += 1;
-                    if (writer != null) {
+            if (writer != null) {
+                assert results != null; // we use details when writer is nonnull
+                int rank = 0;
+                for (Result rec : results) {
+                    try {
+                        rank += 1;
                         writer.writeRow(testUser.getUserId(), rank, rec.getId(), rec.getScore());
+                    } catch (IOException ex) {
+                        throw new EvaluationException("error writing prediction row", ex);
                     }
-                } catch (IOException ex) {
-                    throw new EvaluationException("error writing prediction row", ex);
                 }
             }
 

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNEntropyMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNEntropyMetric.java
@@ -22,8 +22,8 @@ package org.lenskit.eval.traintest.recommend;
 
 import it.unimi.dsi.fastutil.longs.Long2IntMap;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
-import org.lenskit.api.Result;
-import org.lenskit.api.ResultList;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
@@ -50,7 +50,7 @@ import javax.annotation.Nullable;
  *
  * This metric is registered with the type name `entropy`.
  */
-public class TopNEntropyMetric extends TopNMetric<TopNEntropyMetric.Context> {
+public class TopNEntropyMetric extends ListOnlyTopNMetric<TopNEntropyMetric.Context> {
     /**
      * Construct a new length metric.
      */
@@ -60,7 +60,7 @@ public class TopNEntropyMetric extends TopNMetric<TopNEntropyMetric.Context> {
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recommendations, Context context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recommendations, Context context) {
         context.addUser(recommendations);
         return MetricResult.empty();
     }
@@ -89,9 +89,11 @@ public class TopNEntropyMetric extends TopNMetric<TopNEntropyMetric.Context> {
         private Long2IntMap counts = new Long2IntOpenHashMap();
         private int recCount = 0;
 
-        private void addUser(ResultList recs) {
-            for (Result s: recs) {
-                counts.put(s.getId(), counts.get(s.getId()) +1);
+        private void addUser(LongList recs) {
+            LongIterator iter = recs.iterator();
+            while (iter.hasNext()) {
+                long item = iter.nextLong();
+                counts.put(item, counts.get(item) +1);
                 recCount +=1;
             }
         }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNLengthMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNLengthMetric.java
@@ -20,9 +20,9 @@
  */
 package org.lenskit.eval.traintest.recommend;
 
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
 import org.lenskit.api.Recommender;
-import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
  *
  * This metric is registered with the type name `length`.
  */
-public class TopNLengthMetric extends TopNMetric<MeanAccumulator> {
+public class TopNLengthMetric extends ListOnlyTopNMetric<MeanAccumulator> {
     /**
      * Construct a new length metric.
      */
@@ -48,7 +48,7 @@ public class TopNLengthMetric extends TopNMetric<MeanAccumulator> {
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recommendations, MeanAccumulator context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recommendations, MeanAccumulator context) {
         int n = recommendations.size();
         context.add(n);
         return new LengthResult(n);

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMAPMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMAPMetric.java
@@ -21,12 +21,12 @@
 package org.lenskit.eval.traintest.recommend;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.apache.commons.lang3.StringUtils;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
 import org.lenskit.api.Recommender;
-import org.lenskit.api.Result;
-import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
@@ -53,7 +53,7 @@ import javax.annotation.Nullable;
  * `goodItems`
  * :   an item selector expression. The default is the user's test items.
  */
-public class TopNMAPMetric extends TopNMetric<TopNMAPMetric.Context> {
+public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
     private static final Logger logger = LoggerFactory.getLogger(TopNMAPMetric.class);
 
     private final String suffix;
@@ -102,7 +102,7 @@ public class TopNMAPMetric extends TopNMetric<TopNMAPMetric.Context> {
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recs, Context context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recs, Context context) {
         LongSet good = goodItems.selectItems(context.universe, context.recommender, user);
         if (good.isEmpty()) {
             logger.warn("no good items for user {}", user.getUserId());
@@ -116,9 +116,10 @@ public class TopNMAPMetric extends TopNMetric<TopNMAPMetric.Context> {
         int n = 0;
         double ngood = 0;
         double sum = 0;
-        for(Result res : recs) {
+        LongIterator iter = recs.iterator();
+        while (iter.hasNext()) {
             n += 1;
-            if(good.contains(res.getId())) {
+            if(good.contains(iter.nextLong())) {
                 // it is good
                 ngood += 1;
                 // add to MAP sum

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMRRMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMRRMetric.java
@@ -21,12 +21,12 @@
 package org.lenskit.eval.traintest.recommend;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.apache.commons.lang3.StringUtils;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
 import org.lenskit.api.Recommender;
-import org.lenskit.api.Result;
-import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
@@ -50,7 +50,7 @@ import javax.annotation.Nullable;
  * `goodItems`
  * :   an item selector expression. The default is the user's test items.
  */
-public class TopNMRRMetric extends TopNMetric<TopNMRRMetric.Context> {
+public class TopNMRRMetric extends ListOnlyTopNMetric<TopNMRRMetric.Context> {
     private static final Logger logger = LoggerFactory.getLogger(TopNMRRMetric.class);
 
     private final ItemSelector goodItems;
@@ -99,7 +99,7 @@ public class TopNMRRMetric extends TopNMetric<TopNMRRMetric.Context> {
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recommendations, Context context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recommendations, Context context) {
         LongSet good = goodItems.selectItems(context.universe, context.recommender, user);
         if (good.isEmpty()) {
             logger.warn("no good items for user {}", user.getUserId());
@@ -107,9 +107,10 @@ public class TopNMRRMetric extends TopNMetric<TopNMRRMetric.Context> {
 
         Integer rank = null;
         int i = 0;
-        for(Result res: recommendations) {
+        LongIterator iter = recommendations.iterator();
+        while (iter.hasNext()) {
             i++;
-            if(good.contains(res.getId())) {
+            if(good.contains(iter.nextLong())) {
                 rank = i;
                 break;
             }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNNDCGMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNNDCGMetric.java
@@ -22,14 +22,10 @@ package org.lenskit.eval.traintest.recommend;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import it.unimi.dsi.fastutil.longs.Long2DoubleFunction;
-import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
-import it.unimi.dsi.fastutil.longs.LongArrays;
-import it.unimi.dsi.fastutil.longs.LongComparators;
+import it.unimi.dsi.fastutil.longs.*;
 import org.apache.commons.lang3.StringUtils;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
 import org.lenskit.api.Recommender;
-import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
@@ -51,7 +47,7 @@ import java.util.Collections;
  *
  * This metric is registered with the type name `ndcg`.
  */
-public class TopNNDCGMetric extends TopNMetric<MeanAccumulator> {
+public class TopNNDCGMetric extends ListOnlyTopNMetric<MeanAccumulator> {
     private static final Logger logger = LoggerFactory.getLogger(TopNNDCGMetric.class);
     public static final String DEFAULT_COLUMN = "TopN.nDCG";
     private final String columnName;
@@ -107,7 +103,7 @@ public class TopNNDCGMetric extends TopNMetric<MeanAccumulator> {
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recommendations, MeanAccumulator context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recommendations, MeanAccumulator context) {
         if (recommendations == null) {
             return MetricResult.empty();
         }
@@ -120,7 +116,7 @@ public class TopNNDCGMetric extends TopNMetric<MeanAccumulator> {
         }
         double idealGain = computeDCG(ideal, ratings);
 
-        long[] actual = LongUtils.asLongCollection(recommendations.idList()).toLongArray();
+        long[] actual = recommendations.toLongArray();
         double gain = computeDCG(actual, ratings);
 
         double score = gain / idealGain;

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNNDPMMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNNDPMMetric.java
@@ -22,16 +22,16 @@ package org.lenskit.eval.traintest.recommend;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.longs.Long2DoubleFunction;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.apache.commons.lang3.StringUtils;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
-import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
 import org.lenskit.eval.traintest.metrics.MetricResult;
 import org.lenskit.specs.AbstractSpec;
-import org.lenskit.util.collections.LongUtils;
 import org.lenskit.util.math.Scalars;
 
 import javax.annotation.Nonnull;
@@ -43,7 +43,7 @@ import java.util.Collections;
  * This metric is registered with the type name `ndpm`.
  * The paper used as a reference for this implementation is http://www2.cs.uregina.ca/~yyao/PAPERS/jasis_ndpm.pdf.
  */
-public class TopNNDPMMetric extends TopNMetric<MeanAccumulator> {
+public class TopNNDPMMetric extends ListOnlyTopNMetric<MeanAccumulator> {
     public static final String DEFAULT_COLUMN = "TopN.nDPM";
 
     /**
@@ -76,14 +76,14 @@ public class TopNNDPMMetric extends TopNMetric<MeanAccumulator> {
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recommendations, MeanAccumulator context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recommendations, MeanAccumulator context) {
         if (recommendations == null) {
             return MetricResult.empty();
         }
 
         Long2DoubleMap ratings = user.getTestRatings();
 
-        long[] actual = LongUtils.asLongCollection(recommendations.idList()).toLongArray();
+        long[] actual = recommendations.toLongArray();
 
         double dpm = computeDPM(actual, ratings);
 

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPopularityMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPopularityMetric.java
@@ -20,11 +20,11 @@
  */
 package org.lenskit.eval.traintest.recommend;
 
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.util.statistics.MeanAccumulator;
 import org.lenskit.LenskitRecommender;
 import org.lenskit.api.Recommender;
-import org.lenskit.api.Result;
-import org.lenskit.api.ResultList;
 import org.lenskit.data.ratings.RatingSummary;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
@@ -43,7 +43,7 @@ import java.util.Set;
  *
  * This metric is registered with the type name `popularity`.
  */
-public class TopNPopularityMetric extends TopNMetric<TopNPopularityMetric.Context> {
+public class TopNPopularityMetric extends ListOnlyTopNMetric<TopNPopularityMetric.Context> {
     public TopNPopularityMetric() {
         super(PopResult.class, PopResult.class);
     }
@@ -64,13 +64,14 @@ public class TopNPopularityMetric extends TopNMetric<TopNPopularityMetric.Contex
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recs, Context context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recs, Context context) {
         if (recs == null || recs.isEmpty()) {
             return MetricResult.empty();
         }
         double pop = 0;
-        for (Result r: recs) {
-            pop += context.summary.getItemRatingCount(r.getId());
+        LongIterator iter = recs.iterator();
+        while (iter.hasNext()) {
+            pop += context.summary.getItemRatingCount(iter.nextLong());
         }
         pop = pop / recs.size();
 

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
@@ -21,11 +21,11 @@
 package org.lenskit.eval.traintest.recommend;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import org.apache.commons.lang3.StringUtils;
 import org.lenskit.api.Recommender;
-import org.lenskit.api.Result;
-import org.lenskit.api.ResultList;
 import org.lenskit.eval.traintest.AlgorithmInstance;
 import org.lenskit.eval.traintest.DataSet;
 import org.lenskit.eval.traintest.TestUser;
@@ -53,7 +53,7 @@ import javax.annotation.Nullable;
  * `goodItems`
  * :   an item selector expression. The default is the user's test items.
  */
-public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMetric.Context> {
+public class TopNPrecisionRecallMetric extends ListOnlyTopNMetric<TopNPrecisionRecallMetric.Context> {
     private final String suffix;
     private final ItemSelector goodItems;
 
@@ -87,13 +87,14 @@ public class TopNPrecisionRecallMetric extends TopNMetric<TopNPrecisionRecallMet
 
     @Nonnull
     @Override
-    public MetricResult measureUser(TestUser user, int targetLength, ResultList recs, Context context) {
+    public MetricResult measureUser(TestUser user, int targetLength, LongList recs, Context context) {
         int tp = 0;
 
         LongSet items = goodItems.selectItems(context.universe, context.recommender, user);
 
-        for(Result res: recs) {
-            if(items.contains(res.getId())) {
+        LongIterator iter = recs.iterator();
+        while (iter.hasNext()) {
+            if(items.contains(iter.nextLong())) {
                 tp += 1;
             }
         }

--- a/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemAccuracyTest.groovy
@@ -31,6 +31,10 @@ import org.lenskit.baseline.ItemMeanRatingItemScorer
 import org.lenskit.baseline.UserMeanBaseline
 import org.lenskit.baseline.UserMeanItemScorer
 import org.lenskit.config.ConfigHelpers
+import org.lenskit.eval.traintest.SimpleEvaluator
+import org.lenskit.eval.traintest.TrainTestExperiment
+import org.lenskit.eval.traintest.recommend.RecommendEvalTask
+import org.lenskit.eval.traintest.recommend.TopNMAPMetric
 import org.lenskit.knn.NeighborhoodSize
 import org.lenskit.util.table.Table
 
@@ -43,6 +47,14 @@ import static org.junit.Assert.assertThat
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class ItemItemAccuracyTest extends CrossfoldTestSuite {
+    @Override
+    void addExtraConfig(SimpleEvaluator eval) {
+        def rec = new RecommendEvalTask()
+        rec.listSize = 50
+        rec.addMetric(new TopNMAPMetric())
+        eval.experiment.addTask(rec)
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     protected void configureAlgorithm(LenskitConfiguration config) {

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemItemBasedItemScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemItemBasedItemScorer.java
@@ -20,16 +20,12 @@
  */
 package org.lenskit.knn.item;
 
-import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
-import it.unimi.dsi.fastutil.longs.LongIterator;
-import it.unimi.dsi.fastutil.longs.LongIterators;
-import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.*;
 import org.grouplens.lenskit.util.ScoredItemAccumulator;
 import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
 import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
 import org.grouplens.lenskit.vectors.SparseVector;
 import org.grouplens.lenskit.vectors.VectorEntry;
-import org.lenskit.api.Result;
 import org.lenskit.api.ResultMap;
 import org.lenskit.basic.AbstractItemBasedItemScorer;
 import org.lenskit.knn.NeighborhoodSize;
@@ -42,6 +38,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Score items based on the basket of items using an item-item CF model.
@@ -63,23 +60,51 @@ public class ItemItemItemBasedItemScorer extends AbstractItemBasedItemScorer {
         neighborhoodSize = nnbrs;
     }
 
+    @Nonnull
+    @Override
+    public Map<Long, Double> scoreRelatedItems(@Nonnull Collection<Long> basket, @Nonnull Collection<Long> items) {
+        Long2DoubleMap results = new Long2DoubleOpenHashMap();
+        ItemItemScoreAccumulator accum = ItemItemScoreAccumulator.basic(results);
+
+        scoreItems(basket, items, accum);
+
+        return results;
+    }
+
     @Override
     public ResultMap scoreRelatedItemsWithDetails(@Nonnull Collection<Long> basket, Collection<Long> items) {
-        LongSet bset = LongUtils.packedSet(basket);
-        Long2DoubleMap basketScores = LongUtils.constantDoubleMap(bset, 1.0);
-        List<Result> results = new ArrayList<>();
-        LongIterator iter = LongIterators.asLongIterator(items.iterator());
-        while (iter.hasNext()) {
-            long item = iter.nextLong();
-            ItemItemResult result = scoreItem(basketScores, item);
-            if (result != null) {
-                results.add(result);
-            }
-        }
+        List<ItemItemResult> results = new ArrayList<>();
+        ItemItemScoreAccumulator accum = ItemItemScoreAccumulator.detailed(results);
+
+        scoreItems(basket, items, accum);
+
         return Results.newResultMap(results);
     }
 
-    protected ItemItemResult scoreItem(Long2DoubleMap scores, long item) {
+    /**
+     * Score items into an accumulator.
+     * @param basket The basket of reference items.
+     * @param items The item scores.
+     * @param accum The accumulator.
+     */
+    private void scoreItems(@Nonnull Collection<Long> basket, Collection<Long> items, ItemItemScoreAccumulator accum) {
+        LongSet bset = LongUtils.packedSet(basket);
+        Long2DoubleMap basketScores = LongUtils.constantDoubleMap(bset, 1.0);
+
+        LongIterator iter = LongIterators.asLongIterator(items.iterator());
+        while (iter.hasNext()) {
+            long item = iter.nextLong();
+            scoreItem(basketScores, item, accum);
+        }
+    }
+
+    /**
+     * Score a single item into an accumulator.
+     * @param scores The reference scores.
+     * @param item The item to score.
+     * @param accum The accumulator.
+     */
+    protected void scoreItem(Long2DoubleMap scores, long item, ItemItemScoreAccumulator accum) {
         SparseVector allNeighbors = model.getNeighbors(item);
         ScoredItemAccumulator acc;
         if (neighborhoodSize > 0) {
@@ -96,6 +121,6 @@ public class ItemItemItemBasedItemScorer extends AbstractItemBasedItemScorer {
         }
 
         Long2DoubleMap neighborhood = acc.finishMap();
-        return scorer.score(item, neighborhood, scores);
+        scorer.score(item, neighborhood, scores, accum);
     }
 }

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemResult.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemResult.java
@@ -57,6 +57,15 @@ public class ItemItemResult extends AbstractResult {
         return neighborWeight;
     }
 
+    /**
+     * Rescore this item-item result.
+     * @param score The new score.
+     * @return The rescored result.
+     */
+    ItemItemResult rescore(double score) {
+        return new ItemItemResult(getId(), score, getNeighborhoodSize(), getNeighborWeight());
+    }
+
     @Override
     public String toString() {
         return "ItemItemResult{" +

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemScoreAccumulator.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemScoreAccumulator.java
@@ -1,0 +1,112 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.knn.item;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import org.grouplens.lenskit.transform.normalize.VectorTransformation;
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+
+import java.util.List;
+
+/**
+ * Score accumulator for item-item recommendation.  It is used to record the results of the item-item CF
+ * scoring of one or more items.
+ *
+ * Accumulating results here allows us to avoid memory allocations when detailed results are not required.
+ */
+public abstract class ItemItemScoreAccumulator {
+    private ItemItemScoreAccumulator() {}
+
+    /**
+     * Add a score to the accumulator.
+     * @param item The item to score.
+     * @param score The score.
+     * @param nnbrs The number of neighbors used.
+     * @param weight The total neighbor weight.
+     */
+    public abstract void add(long item, double score, int nnbrs, double weight);
+
+    /**
+     * Apply the reverse of a transform to the results.
+     * @param transform The transform to apply.
+     */
+    public abstract void applyReversedTransform(VectorTransformation transform);
+
+    /**
+     * Construct an accumulator that will store items and scores in a map.
+     * @param receiver The map to receive the results.
+     * @return The accumulator.
+     */
+    static ItemItemScoreAccumulator basic(Long2DoubleMap receiver) {
+        return new BasicAccumulator(receiver);
+    }
+
+    /**
+     * Construct an accumulator that will store full detailed results in a map.
+     * @param receiver The map to receive the results.
+     * @return The accumulator.
+     */
+    static ItemItemScoreAccumulator detailed(List<ItemItemResult> receiver) {
+        return new DetailedAccumulator(receiver);
+    }
+
+    private static class BasicAccumulator extends ItemItemScoreAccumulator {
+        private final Long2DoubleMap receiver;
+
+        BasicAccumulator(Long2DoubleMap recv) {
+            receiver = recv;
+        }
+
+        @Override
+        public void add(long item, double score, int nnbrs, double weight) {
+            receiver.put(item, score);
+        }
+
+        @Override
+        public void applyReversedTransform(VectorTransformation transform) {
+            MutableSparseVector vec = MutableSparseVector.create(receiver);
+            transform.unapply(vec);
+            receiver.putAll(vec.asMap());
+        }
+    }
+
+    private static class DetailedAccumulator extends ItemItemScoreAccumulator {
+        private final List<ItemItemResult> receiver;
+
+        DetailedAccumulator(List<ItemItemResult> recv) {
+            receiver = recv;
+        }
+
+        @Override
+        public void add(long item, double score, int nnbrs, double weight) {
+            receiver.add(new ItemItemResult(item, score, nnbrs, weight));
+        }
+
+        @Override
+        public void applyReversedTransform(VectorTransformation transform) {
+            int n = receiver.size();
+            for (int i = 0; i < n; i++) {
+                ItemItemResult res = receiver.get(i);
+                receiver.set(i, res.rescore(transform.unapply(res.getId(), res.getScore())));
+            }
+        }
+    }
+}

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/NeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/NeighborhoodScorer.java
@@ -22,8 +22,6 @@ package org.lenskit.knn.item;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import org.grouplens.grapht.annotation.DefaultImplementation;
-import org.grouplens.lenskit.scored.ScoredId;
-import org.grouplens.lenskit.vectors.SparseVector;
 
 /**
  * Compute scores from neighborhoods and score vectors.
@@ -42,14 +40,11 @@ public interface NeighborhoodScorer {
      * Compute a score based on similar neighbors and their corresponding
      * scores.
      *
-     *
-     *
-     * @param item
+     * @param item      The item ID to score.
      * @param neighbors A vector of neighbors with similarity measures.
      * @param scores    A vector of item scores. It should contain a score for
      *                  every item in <var>neighbors</var>.
-     * @return An accumulated score from the neighbors, or {@code null} if
-     *         no score could be computed.
+     * @param accum     An accumulator to receive the score computed by this method.
      */
-    ItemItemResult score(long item, Long2DoubleMap neighbors, Long2DoubleMap scores);
+    void score(long item, Long2DoubleMap neighbors, Long2DoubleMap scores, ItemItemScoreAccumulator accum);
 }

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/SimilaritySumNeighborhoodScorer.java
@@ -36,12 +36,10 @@ public class SimilaritySumNeighborhoodScorer implements NeighborhoodScorer, Seri
     private static final long serialVersionUID = 1L;
 
     @Override
-    public ItemItemResult score(long item, Long2DoubleMap neighbors, Long2DoubleMap scores) {
-        if (neighbors.size() == 0) {
-            return null;
-        } else {
+    public void score(long item, Long2DoubleMap neighbors, Long2DoubleMap scores, ItemItemScoreAccumulator accum) {
+        if (neighbors.size() > 0) {
             double sum = Vectors.sum(neighbors);
-            return new ItemItemResult(item, sum, neighbors.size(), sum);
+            accum.add(item, sum, neighbors.size(), sum);
         }
     }
 

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/WeightedAverageNeighborhoodScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/WeightedAverageNeighborhoodScorer.java
@@ -21,11 +21,9 @@
 package org.lenskit.knn.item;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
-import org.lenskit.inject.Shareable;
 import org.grouplens.lenskit.symbols.Symbol;
+import org.lenskit.inject.Shareable;
 import org.lenskit.util.math.Vectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 
@@ -41,13 +39,11 @@ public class WeightedAverageNeighborhoodScorer implements NeighborhoodScorer, Se
             Symbol.of("org.grouplens.lenskit.knn.item.neighborhoodWeight");
 
     @Override
-    public ItemItemResult score(long item, Long2DoubleMap neighbors, Long2DoubleMap scores) {
+    public void score(long item, Long2DoubleMap neighbors, Long2DoubleMap scores, ItemItemScoreAccumulator accum) {
         double weight = Vectors.sumAbs(neighbors);
         if (weight > 0) {
             double weightedSum = Vectors.dotProduct(neighbors, scores);
-            return new ItemItemResult(item, weightedSum / weight, neighbors.size(), weight);
-        } else {
-            return null;
+            accum.add(item, weightedSum / weight, neighbors.size(), weight);
         }
     }
 

--- a/lenskit-knn/src/test/java/org/lenskit/knn/item/SimilaritySumNeighborhoodScorerTest.java
+++ b/lenskit-knn/src/test/java/org/lenskit/knn/item/SimilaritySumNeighborhoodScorerTest.java
@@ -47,21 +47,21 @@ public class SimilaritySumNeighborhoodScorerTest {
     public void testEmpty() {
         Long2DoubleMap nbrs = Long2DoubleMaps.EMPTY_MAP;
         Long2DoubleMap scores = Long2DoubleMaps.EMPTY_MAP;
-        assertThat(scorer.score(42, nbrs, scores), nullValue());
+        assertThat(scorer.score(42, nbrs, scores, accum), nullValue());
     }
 
     @Test
     public void testEmptyNbrs() {
         Long2DoubleMap nbrs = Long2DoubleMaps.EMPTY_MAP;
         Long2DoubleMap scores = Long2DoubleMaps.singleton(5, 3.7);
-        assertThat(scorer.score(42, nbrs, scores), nullValue());
+        assertThat(scorer.score(42, nbrs, scores, accum), nullValue());
     }
 
     @Test
     public void testOneNbr() {
         Long2DoubleMap nbrs = Long2DoubleMaps.singleton(5, 1.0);
         Long2DoubleMap scores = Long2DoubleMaps.singleton(5, 3.7);
-        assertThat(scorer.score(42, nbrs, scores).getScore(), closeTo(1.0));
+        assertThat(scorer.score(42, nbrs, scores, accum).getScore(), closeTo(1.0));
     }
 
     @Test
@@ -76,6 +76,6 @@ public class SimilaritySumNeighborhoodScorerTest {
         scores.put(3, 4.2);
         scores.put(5, 1.2);
         scores.put(7, 7.8);
-        assertThat(scorer.score(42, nbrs, scores).getScore(), closeTo(2.42));
+        assertThat(scorer.score(42, nbrs, scores, accum).getScore(), closeTo(2.42));
     }
 }

--- a/lenskit-knn/src/test/java/org/lenskit/knn/item/SimilaritySumNeighborhoodScorerTest.java
+++ b/lenskit-knn/src/test/java/org/lenskit/knn/item/SimilaritySumNeighborhoodScorerTest.java
@@ -28,6 +28,9 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -47,21 +50,36 @@ public class SimilaritySumNeighborhoodScorerTest {
     public void testEmpty() {
         Long2DoubleMap nbrs = Long2DoubleMaps.EMPTY_MAP;
         Long2DoubleMap scores = Long2DoubleMaps.EMPTY_MAP;
-        assertThat(scorer.score(42, nbrs, scores, accum), nullValue());
+        List<ItemItemResult> results = new ArrayList<>();
+        ItemItemScoreAccumulator accum = ItemItemScoreAccumulator.detailed(results);
+
+        scorer.score(42, nbrs, scores, accum);
+
+        assertThat(results, hasSize(0));
     }
 
     @Test
     public void testEmptyNbrs() {
         Long2DoubleMap nbrs = Long2DoubleMaps.EMPTY_MAP;
         Long2DoubleMap scores = Long2DoubleMaps.singleton(5, 3.7);
-        assertThat(scorer.score(42, nbrs, scores, accum), nullValue());
+        List<ItemItemResult> results = new ArrayList<>();
+        ItemItemScoreAccumulator accum = ItemItemScoreAccumulator.detailed(results);
+
+        scorer.score(42, nbrs, scores, accum);
+
+        assertThat(results, hasSize(0));
     }
 
     @Test
     public void testOneNbr() {
         Long2DoubleMap nbrs = Long2DoubleMaps.singleton(5, 1.0);
         Long2DoubleMap scores = Long2DoubleMaps.singleton(5, 3.7);
-        assertThat(scorer.score(42, nbrs, scores, accum).getScore(), closeTo(1.0));
+        List<ItemItemResult> results = new ArrayList<>();
+        ItemItemScoreAccumulator accum = ItemItemScoreAccumulator.detailed(results);
+
+        scorer.score(42, nbrs, scores, accum);
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getScore(), closeTo(1.0));
     }
 
     @Test
@@ -76,6 +94,12 @@ public class SimilaritySumNeighborhoodScorerTest {
         scores.put(3, 4.2);
         scores.put(5, 1.2);
         scores.put(7, 7.8);
-        assertThat(scorer.score(42, nbrs, scores, accum).getScore(), closeTo(2.42));
+
+        List<ItemItemResult> results = new ArrayList<>();
+        ItemItemScoreAccumulator accum = ItemItemScoreAccumulator.detailed(results);
+
+        scorer.score(42, nbrs, scores, accum);
+        assertThat(results, hasSize(1));
+        assertThat(results.get(0).getScore(), closeTo(2.42));
     }
 }


### PR DESCRIPTION
This set of changes improves the performance of recommendation and evaluation, particularly in item-item CF, with the following changes:

- Improve top-*N* scored item accumulator to remove spurious boxing of IDs and scores
- Compute top-N recommendations without creating result objects when no details are required
- Allow top-N metrics to be *list-only*, meaning that they do not require the actual result objects
- Improve the `recommend` eval task to only compute detailed recommendations if at least one metric requires `Result` objects
- Improve the item-item recommender to be able to compute non-detailed recommendations without allocating `Result` objects