### PR TITLE
Use more meaningful exceptions

### DIFF
--- a/lenskit-cli/src/main/java/org/lenskit/cli/util/InputData.java
+++ b/lenskit-cli/src/main/java/org/lenskit/cli/util/InputData.java
@@ -25,6 +25,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.lenskit.LenskitConfiguration;
+import org.lenskit.data.dao.DataAccessException;
 import org.lenskit.data.dao.EventDAO;
 import org.grouplens.lenskit.data.source.DataSource;
 import org.grouplens.lenskit.data.source.PackedDataSourceBuilder;
@@ -74,7 +75,7 @@ public class InputData {
                 spec = SpecUtils.load(DataSourceSpec.class, sourceFile.toPath());
             } catch (IOException e) {
                 logger.error("error loading " + sourceFile, e);
-                throw new RuntimeException("error loading " + sourceFile, e);
+                throw new DataAccessException("error loading " + sourceFile, e);
             }
             return SpecUtils.buildObject(DataSource.class, spec, cl);
         }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/source/PackedDataSource.java
@@ -21,13 +21,13 @@
 package org.grouplens.lenskit.data.source;
 
 import com.google.common.base.Supplier;
+import org.grouplens.lenskit.util.MoreSuppliers;
+import org.grouplens.lenskit.util.io.Describable;
+import org.grouplens.lenskit.util.io.DescriptionWriter;
 import org.lenskit.LenskitConfiguration;
 import org.lenskit.data.dao.*;
 import org.lenskit.data.packed.BinaryRatingDAO;
 import org.lenskit.data.ratings.PreferenceDomain;
-import org.grouplens.lenskit.util.MoreSuppliers;
-import org.grouplens.lenskit.util.io.Describable;
-import org.grouplens.lenskit.util.io.DescriptionWriter;
 import org.lenskit.specs.data.DataSourceSpec;
 import org.lenskit.specs.data.PackedDataSourceSpec;
 import org.slf4j.Logger;
@@ -183,7 +183,7 @@ public class PackedDataSource implements DataSource {
             try {
                 return BinaryRatingDAO.open(packedFile);
             } catch (IOException ex) {
-                throw new RuntimeException("error opening " + packedFile, ex);
+                throw new DataAccessException("error opening " + packedFile, ex);
             }
         }
 

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/text/DelimitedColumnEventFormat.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/text/DelimitedColumnEventFormat.java
@@ -20,7 +20,9 @@
  */
 package org.grouplens.lenskit.data.text;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.lang3.text.StrTokenizer;
 import org.grouplens.grapht.util.ClassLoaders;
 import org.lenskit.data.events.Event;
@@ -109,7 +111,7 @@ public final class DelimitedColumnEventFormat implements EventFormat, Serializab
             for (String name: dft.value()) {
                 Field field = Fields.byName(builder, name);
                 if (field == null) {
-                    throw new RuntimeException("cannot find field " + name);
+                    throw new IllegalArgumentException("class " + builder + " does not have field " + name);
                 }
                 fields.add(field);
             }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/data/text/Fields.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/data/text/Fields.java
@@ -20,6 +20,7 @@
  */
 package org.grouplens.lenskit.data.text;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -365,7 +366,7 @@ public final class Fields {
                 try {
                     setter.invoke(builder, converter.convertFromString(argType, token));
                 } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new RuntimeException(e);
+                    throw Throwables.propagate(e);
                 }
             }
         }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/ClassDirectory.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/ClassDirectory.java
@@ -24,6 +24,8 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URL;
@@ -37,6 +39,8 @@ import java.util.Set;
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class ClassDirectory {
+    private static final Logger logger = LoggerFactory.getLogger(ClassDirectory.class);
+
     /**
      * Get a class directory for the current thread's class loader.
      * @return A class directory.
@@ -73,7 +77,7 @@ public class ClassDirectory {
                 }
             }
         } catch (IOException e) {
-            throw new RuntimeException("Error loading class lists", e);
+            logger.warn("Could not load class lists", e);
         }
 
         return new ClassDirectory(mapping.build());

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommender.java
@@ -69,7 +69,7 @@ public class LenskitRecommender implements Recommender {
         try {
             return injector.tryGetInstance(cls);
         } catch (InjectionException e) {
-            throw new RuntimeException("error instantiating component", e);
+            throw new RecommenderBuildException("error instantiating component", e);
         }
     }
 
@@ -88,7 +88,7 @@ public class LenskitRecommender implements Recommender {
         try {
             return injector.tryGetInstance(qual, cls);
         } catch (InjectionException e) {
-            throw new RuntimeException("error instantiating component", e);
+            throw new RecommenderBuildException("error instantiating component", e);
         }
     }
 
@@ -107,7 +107,7 @@ public class LenskitRecommender implements Recommender {
         try {
             return injector.getInstance(qual, cls);
         } catch (InjectionException e) {
-            throw new RuntimeException("error instantiating component", e);
+            throw new RecommenderBuildException("error instantiating component", e);
         }
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/data/packed/BinaryRatingDAO.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/packed/BinaryRatingDAO.java
@@ -382,7 +382,7 @@ public class BinaryRatingDAO implements EventDAO, UserEventDAO, ItemEventDAO, Us
             try {
                 return open(dataFile);
             } catch (IOException e) {
-                throw new RuntimeException("cannot open rating file", e);
+                throw new DataAccessException("cannot open rating file", e);
             }
         }
     }

--- a/lenskit-core/src/main/java/org/lenskit/data/packed/BinaryRatingPacker.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/packed/BinaryRatingPacker.java
@@ -30,6 +30,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
+import org.lenskit.data.dao.DataAccessException;
 import org.lenskit.data.events.Events;
 import org.lenskit.data.ratings.Rating;
 import org.lenskit.util.collections.LongUtils;
@@ -328,7 +329,7 @@ public class BinaryRatingPacker implements Closeable {
 
                 return Events.TIMESTAMP_COMPARATOR.compare(r1, r2);
             } catch (IOException ex) {
-                throw new RuntimeException("I/O error while sorting", ex);
+                throw new DataAccessException("I/O error while sorting", ex);
             }
         }
     }
@@ -362,7 +363,7 @@ public class BinaryRatingPacker implements Closeable {
                 inverseTranslationMap[i1] = inverseTranslationMap[i2];
                 inverseTranslationMap[i2] = j;
             } catch (IOException ex) {
-                throw new RuntimeException("I/O error while sorting", ex);
+                throw new DataAccessException("I/O error while sorting", ex);
             }
         }
     }

--- a/lenskit-core/src/main/java/org/lenskit/data/packed/RatingSnapshotDAO.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/packed/RatingSnapshotDAO.java
@@ -157,7 +157,7 @@ public class RatingSnapshotDAO implements EventDAO, UserEventDAO, ItemEventDAO, 
             try {
                 file = File.createTempFile("ratings", ".pack");
             } catch (IOException e) {
-                throw new RuntimeException("cannot create temporary file");
+                throw new DataAccessException("cannot create temporary file");
             }
             file.deleteOnExit();
             logger.debug("packing ratings to {}", file);
@@ -181,7 +181,7 @@ public class RatingSnapshotDAO implements EventDAO, UserEventDAO, ItemEventDAO, 
                 }
                 return new RatingSnapshotDAO(result);
             } catch (IOException ex) {
-                throw new RuntimeException("error packing ratings", ex);
+                throw new DataAccessException("error packing ratings", ex);
             }
         }
     }

--- a/lenskit-core/src/main/java/org/lenskit/data/ratings/PackedRatingDataBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/ratings/PackedRatingDataBuilder.java
@@ -131,7 +131,7 @@ class PackedRatingDataBuilder implements Builder<PackedRatingData> {
 
         final int idx = freeList.isEmpty() ? nprefs : freeList.dequeueInt();
         if (idx == Integer.MAX_VALUE) {
-            throw new RuntimeException("data pack full");
+            throw new IllegalStateException("data pack full");
         }
         final int ci = chunk(idx);
         final int ei = element(idx);

--- a/lenskit-core/src/main/java/org/lenskit/inject/NodeInstantiator.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/NodeInstantiator.java
@@ -24,6 +24,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import org.grouplens.grapht.*;
 import org.grouplens.grapht.graph.DAGNode;
+import org.lenskit.api.RecommenderBuildException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -68,7 +69,7 @@ public abstract class NodeInstantiator implements Function<DAGNode<Component,Dep
         try {
             return instantiate(input);
         } catch (InjectionException e) {
-            throw new RuntimeException("Instantiation error on " + input.getLabel(), e);
+            throw new RecommenderBuildException("cannot instantiate " + input.getLabel(), e);
         }
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/transform/quantize/ValueArrayQuantizer.java
+++ b/lenskit-core/src/main/java/org/lenskit/transform/quantize/ValueArrayQuantizer.java
@@ -92,7 +92,7 @@ public class ValueArrayQuantizer implements Quantizer, Serializable {
             }
         }
         if (closest < 0) {
-            throw new RuntimeException("could not quantize value");
+            throw new IllegalArgumentException("could not quantize value");
         } else {
             return closest;
         }

--- a/lenskit-core/src/main/java/org/lenskit/util/io/LineStream.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/io/LineStream.java
@@ -25,6 +25,7 @@ import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 import org.apache.commons.lang3.text.StrTokenizer;
 import org.grouplens.lenskit.util.io.CompressionMode;
+import org.lenskit.data.dao.DataAccessException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,7 +89,7 @@ public class LineStream extends AbstractObjectStream<String> {
             lineNumber++;
             return line;
         } catch (IOException e) {
-            throw new RuntimeException("error reading line", e);
+            throw new DataAccessException("error reading line", e);
         }
     }
 

--- a/lenskit-integration-tests/src/it/gradle/eval-with-offline-repo/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-offline-repo/build.gradle
@@ -55,7 +55,7 @@ task check(overwrite: true) {
 
     doLast {
         if (!file('results.csv').exists()) {
-            throw new RuntimeException("results file does not exist")
+            throw new FileNotFoundException(file('results.csv').toString())
         }
     }
 }

--- a/lenskit-integration-tests/src/it/gradle/external-algorithms/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/external-algorithms/build.gradle
@@ -51,7 +51,7 @@ task checkPythonInstall {
         }
         if (System.getenv("CI") == "true" && !isValid) {
             logger.error "Python is not present, but required for CI builds"
-            throw new RuntimeException("cannot find Python")
+            throw new IOException("cannot find Python")
         }
     }
 }

--- a/lenskit-predict/src/main/java/org/lenskit/external/ExternalProcessException.java
+++ b/lenskit-predict/src/main/java/org/lenskit/external/ExternalProcessException.java
@@ -1,0 +1,56 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.external;
+
+/**
+ * Error thrown when there is an error in an external process.
+ *
+ * @since 3.0
+ */
+public class ExternalProcessException extends RuntimeException {
+    /**
+     * Construct a new external process exception.
+     */
+    public ExternalProcessException() {
+    }
+
+    /**
+     * Construct a new external process exception with a message.
+     */
+    public ExternalProcessException(String message) {
+        super(message);
+    }
+
+
+    /**
+     * Construct a new external process exception with a message and cause.
+     */
+    public ExternalProcessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Construct a new external process exception with a cause.
+     */
+    public ExternalProcessException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/lenskit-predict/src/main/java/org/lenskit/external/ExternalProcessItemScorerBuilder.java
+++ b/lenskit-predict/src/main/java/org/lenskit/external/ExternalProcessItemScorerBuilder.java
@@ -227,7 +227,7 @@ public class ExternalProcessItemScorerBuilder implements Provider<ItemScorer> {
             proc = pb.start();
         } catch (IOException e) {
             logger.error("could not start {}: {}", executable, e);
-            throw new RuntimeException("could not start external process", e);
+            throw new ExternalProcessException("could not start external process", e);
         }
         Thread slurp = new LoggingStreamSlurper("build-" + executable, proc.getErrorStream(),
                                                 logger, "");
@@ -238,7 +238,7 @@ public class ExternalProcessItemScorerBuilder implements Provider<ItemScorer> {
              BufferedReader buf = new BufferedReader(rdr)) {
             scorer = PrecomputedItemScorer.fromCSV(buf);
         } catch (IOException e) {
-            throw new RuntimeException("cannot open output", e);
+            throw new ExternalProcessException("cannot open output", e);
         }
 
         int ec;
@@ -246,13 +246,13 @@ public class ExternalProcessItemScorerBuilder implements Provider<ItemScorer> {
             ec = proc.waitFor();
         } catch (InterruptedException e) {
             proc.destroy();
-            throw new RuntimeException("external process interrupted", e);
+            throw new ExternalProcessException("external process interrupted", e);
         }
         if (ec == 0) {
             return scorer;
         } else {
             logger.error("{} exited with code {}", executable, ec);
-            throw new RuntimeException("external process failed with code " + ec);
+            throw new ExternalProcessException("external process failed with code " + ec);
         }
     }
 
@@ -293,7 +293,7 @@ public class ExternalProcessItemScorerBuilder implements Provider<ItemScorer> {
                     writer.println();
                 }
             } catch (IOException e) {
-                throw new RuntimeException("Error creating ratings file", e);
+                throw new ExternalProcessException("Error creating ratings file", e);
             }
             return name;
         }
@@ -325,7 +325,7 @@ public class ExternalProcessItemScorerBuilder implements Provider<ItemScorer> {
                     writer.println(iter.nextLong());
                 }
             } catch (IOException e) {
-                throw new RuntimeException("Error creating ratings file", e);
+                throw new ExternalProcessException("Error creating ratings file", e);
             }
             return name;
         }


### PR DESCRIPTION
This starts replacing a bunch of `RuntimeException` to clean up Sonar errors. There are three types of solutions:

- Replace with a more meaningful exception
- Log and suppress
- use `Throwables.propagate` to propagate as a runtime exception

Sonar thinks these are high-impact issues (vulnerabilities, actually). Good exceptions are good development practice anyway.