### PR TITLE
Change LensKit group to org.lenskit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ task ciPublish {
 }
 
 allprojects { project ->
-    group 'org.grouplens.lenskit'
+    group 'org.lenskit'
     version '3.0-SNAPSHOT'
 
     ext.getConfigProperty = { name, dft ->

--- a/lenskit-gradle/src/it/gradle/config-methods/build.gradle
+++ b/lenskit-gradle/src/it/gradle/config-methods/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-gradle/src/it/gradle/configure-data-set/build.gradle
+++ b/lenskit-gradle/src/it/gradle/configure-data-set/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-gradle/src/it/gradle/crossfold-defaults/build.gradle
+++ b/lenskit-gradle/src/it/gradle/crossfold-defaults/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-gradle/src/it/gradle/default-props/build.gradle
+++ b/lenskit-gradle/src/it/gradle/default-props/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-gradle/src/it/gradle/property-config/build.gradle
+++ b/lenskit-gradle/src/it/gradle/property-config/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-gradle/src/it/gradle/task-deps/build.gradle
+++ b/lenskit-gradle/src/it/gradle/task-deps/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/cli-input-files/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/cli-input-files/build.gradle
@@ -7,7 +7,7 @@ task packWithHeader(type: JavaExec) {
     inputs.file 'header.csv'
     outputs.file "$buildDir/header.pack"
 
-    main 'org.grouplens.lenskit.cli.Main'
+    main 'org.lenskit.cli.Main'
     args 'pack-ratings'
     args '-o', "$buildDir/header.pack"
     args '--csv-file', file('header.csv')

--- a/lenskit-integration-tests/src/it/gradle/common.gradle
+++ b/lenskit-integration-tests/src/it/gradle/common.gradle
@@ -9,6 +9,6 @@ repositories {
 }
 
 dependencies {
-    compile "org.grouplens.lenskit:lenskit-all:$lenskitVersion"
-    runtime "org.grouplens.lenskit:lenskit-cli:$lenskitVersion"
+    compile "org.lenskit:lenskit-all:$lenskitVersion"
+    runtime "org.lenskit:lenskit-cli:$lenskitVersion"
 }

--- a/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-csv-crossfold/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 
@@ -18,7 +18,7 @@ apply from: 'common.gradle'
 
 dependencies {
     runtime 'org.hamcrest:hamcrest-library:1.3'
-    runtime "org.grouplens.lenskit:lenskit-test:$project.lenskitVersion"
+    runtime "org.lenskit:lenskit-test:$project.lenskitVersion"
     testRuntime 'com.xlson.groovycsv:groovycsv:1.0'
 }
 

--- a/lenskit-integration-tests/src/it/gradle/eval-with-offline-repo/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/eval-with-offline-repo/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 
@@ -20,7 +20,7 @@ repositories {
     }
 }
 dependencies {
-    runtime "org.grouplens.lenskit:lenskit-cli:$project.lenskitVersion"
+    runtime "org.lenskit:lenskit-cli:$project.lenskitVersion"
 }
 
 task crossfold(type: Crossfold) {

--- a/lenskit-integration-tests/src/it/gradle/external-algorithms/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/external-algorithms/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
         classpath 'org.hamcrest:hamcrest-library:1.3'
     }
 }

--- a/lenskit-integration-tests/src/it/gradle/gradle-crossfold-packed/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-crossfold-packed/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/gradle-crossfold/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-crossfold/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/gradle-log-file/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-log-file/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/gradle-logback-config/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-logback-config/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/gradle-pack/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-pack/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/gradle-plugin-basics/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/gradle-plugin-basics/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/item-item-identical/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/item-item-identical/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
         classpath 'org.hamcrest:hamcrest-library:1.3'
     }
 }

--- a/lenskit-integration-tests/src/it/gradle/jvm-args/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/jvm-args/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/renjin.gradle
+++ b/lenskit-integration-tests/src/it/gradle/renjin.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 dependencies {
     analyze localGroovy()
-    analyze group: 'org.grouplens.lenskit', name: 'lenskit-test', version: project.lenskitVersion
+    analyze group: 'org.lenskit', name: 'lenskit-test', version: project.lenskitVersion
     analyze group: 'org.renjin', name: 'renjin-script-engine', version: '0.8.2124'
 }
 

--- a/lenskit-integration-tests/src/it/gradle/simulate/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/simulate/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.hamcrest:hamcrest-library:1.3'
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 

--- a/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/train-test-all-output-files/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
     }
 }
 import org.lenskit.gradle.*
@@ -17,7 +17,7 @@ apply from: 'common.gradle'
 
 dependencies {
     runtime 'org.hamcrest:hamcrest-library:1.3'
-    runtime "org.grouplens.lenskit:lenskit-test:$project.lenskitVersion"
+    runtime "org.lenskit:lenskit-test:$project.lenskitVersion"
     testRuntime 'com.xlson.groovycsv:groovycsv:1.0'
 }
 

--- a/lenskit-integration-tests/src/it/gradle/user-user-identical/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/user-user-identical/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.grouplens.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
         classpath 'org.hamcrest:hamcrest-library:1.3'
     }
 }


### PR DESCRIPTION
This changes the Maven group to `org.lenskit` to break from the old code.

Doing this now, before the evaluator changes land, so that existing experiment code depending on the current evaluator will work with an old snapshot.