### PR TITLE
Metric cleanups

### DIFF
--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMAPMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMAPMetric.java
@@ -106,7 +106,7 @@ public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
         LongSet good = goodItems.selectItems(context.universe, context.recommender, user);
         if (good.isEmpty()) {
             logger.warn("no good items for user {}", user.getUserId());
-            return new UserResult(0, false);
+            return new UserResult(0);
         }
 
         if (recs == null || recs.isEmpty()) {
@@ -129,7 +129,7 @@ public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
 
         double aveP = ngood > 0 ? sum / ngood : 0;
 
-        UserResult result = new UserResult(aveP, ngood > 0);
+        UserResult result = new UserResult(aveP);
         context.addUser(result);
         return result.withSuffix(suffix);
     }
@@ -137,11 +137,9 @@ public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
     public static class UserResult extends TypedMetricResult {
         @MetricColumn("AvgPrec")
         public final double avgPrecision;
-        private final boolean isGood;
 
-        public UserResult(double aveP, boolean good) {
+        public UserResult(double aveP) {
             avgPrecision = aveP;
-            isGood = good;
         }
     }
 
@@ -153,15 +151,8 @@ public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
         @MetricColumn("MAP")
         public final double map;
 
-        /**
-         * The MAP over those users for whom a good item could be recommended.
-         */
-        @MetricColumn("MAP.OfGood")
-        public final double goodMAP;
-
         public AggregateResult(Context accum) {
             this.map = accum.allMean.getMean();
-            this.goodMAP = accum.goodMean.getMean();
         }
     }
 
@@ -169,7 +160,6 @@ public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
         private final LongSet universe;
         private final Recommender recommender;
         private final MeanAccumulator allMean = new MeanAccumulator();
-        private final MeanAccumulator goodMean = new MeanAccumulator();
 
         Context(LongSet universe, Recommender recommender) {
             this.universe = universe;
@@ -178,9 +168,6 @@ public class TopNMAPMetric extends ListOnlyTopNMetric<TopNMAPMetric.Context> {
 
         void addUser(UserResult ur) {
             allMean.add(ur.avgPrecision);
-            if (ur.isGood) {
-                goodMean.add(ur.avgPrecision);
-            }
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMRRMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNMRRMetric.java
@@ -142,22 +142,15 @@ public class TopNMRRMetric extends ListOnlyTopNMetric<TopNMRRMetric.Context> {
          */
         @MetricColumn("MRR")
         public final double mrr;
-        /**
-         * The MRR over those users for whom a good item could be recommended.
-         */
-        @MetricColumn("MRR.OfGood")
-        public final double goodMRR;
 
         public AggregateResult(Context accum) {
             this.mrr = accum.allMean.getMean();
-            this.goodMRR = accum.goodMean.getMean();
         }
     }
 
     public static class Context {
         private final LongSet universe;
         private final MeanAccumulator allMean = new MeanAccumulator();
-        private final MeanAccumulator goodMean = new MeanAccumulator();
         private final Recommender recommender;
 
         Context(LongSet universe, Recommender recommender) {
@@ -167,9 +160,6 @@ public class TopNMRRMetric extends ListOnlyTopNMetric<TopNMRRMetric.Context> {
 
         void addUser(UserResult ur) {
             allMean.add(ur.getRecipRank());
-            if (ur.rank != null) {
-                goodMean.add(ur.getRecipRank());
-            }
         }
     }
 }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/recommend/TopNPrecisionRecallMetric.java
@@ -106,7 +106,8 @@ public class TopNPrecisionRecallMetric extends ListOnlyTopNMetric<TopNPrecisionR
             context.addUser(precision, recall);
             return new PresRecResult(precision, recall).withSuffix(suffix);
         } else {
-            return MetricResult.empty();
+            context.addUser(0, 0);
+            return new PresRecResult(0, 0).withSuffix(suffix);
         }
     }
 

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/RecommendEvalTaskTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/RecommendEvalTaskTest.groovy
@@ -41,7 +41,7 @@ public class RecommendEvalTaskTest {
         assertThat(task.userColumns,
                    containsInAnyOrder("Rank", "RecipRank"))
         assertThat(task.globalColumns,
-                   contains("MRR", "MRR.OfGood"))
+                   contains("MRR"))
     }
 
     @Test
@@ -52,6 +52,6 @@ public class RecommendEvalTaskTest {
         assertThat(task.userColumns,
                    containsInAnyOrder("Foo.Rank", "Foo.RecipRank"))
         assertThat(task.globalColumns,
-                   contains("Foo.MRR", "Foo.MRR.OfGood"))
+                   contains("Foo.MRR"))
     }
 }

--- a/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
+++ b/lenskit-eval/src/test/groovy/org/lenskit/eval/traintest/recommend/TopNMRRMetricTest.groovy
@@ -63,7 +63,6 @@ class TopNMRRMetricTest {
         assertThat result.recipRank, equalTo(0.0d)
         def agg = metric.getAggregateMeasurements(accum)
         assertThat agg.mrr, closeTo(0.0d)
-        assertThat agg.goodMRR, closeTo(0.0d)
     }
 
     @Test
@@ -76,7 +75,6 @@ class TopNMRRMetricTest {
         assertThat result.recipRank, closeTo(1.0)
         def agg = metric.getAggregateMeasurements(accum)
         assertThat agg.mrr, closeTo(1)
-        assertThat agg.goodMRR, closeTo(1)
     }
 
     @Test
@@ -90,7 +88,6 @@ class TopNMRRMetricTest {
         assertThat result.recipRank, closeTo(0.5)
         def agg = metric.getAggregateMeasurements(accum)
         assertThat agg.mrr, closeTo(0.5)
-        assertThat agg.goodMRR, closeTo(0.5)
     }
 
     @Test
@@ -104,7 +101,6 @@ class TopNMRRMetricTest {
         assertThat result.recipRank, equalTo(0.0d)
         def agg = metric.getAggregateMeasurements(accum)
         assertThat agg.mrr, closeTo(0.0)
-        assertThat agg.goodMRR, closeTo(0.0)
     }
 
     @Test
@@ -121,7 +117,6 @@ class TopNMRRMetricTest {
         assertThat result.recipRank, closeTo(0.05)
         def agg = metric.getAggregateMeasurements(accum)
         assertThat agg.mrr, closeTo(0.05)
-        assertThat agg.goodMRR, closeTo(0.05)
     }
 
     @Test
@@ -143,7 +138,6 @@ class TopNMRRMetricTest {
         // MRR should average 0.05 and 0
         assertThat agg.mrr, closeTo(0.025)
         // Good MRR should only have 0.05
-        assertThat agg.goodMRR, closeTo(0.05)
     }
 
     @Test


### PR DESCRIPTION
This does two things:

- Define precision & recall of an empty list to be 0 (#871)
- Remove the confusing `OfGood` variants of MAP and MRR. MAP and MRR are well-defined for lists with no good items.