### PR TITLE
Deprecation cleanups

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/truncate/TopNTruncator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/truncate/TopNTruncator.java
@@ -22,7 +22,7 @@ package org.grouplens.lenskit.transform.truncate;
 
 import org.lenskit.inject.Shareable;
 import org.grouplens.lenskit.transform.threshold.Threshold;
-import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
+import org.lenskit.util.TopNScoredIdAccumulator;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.VectorEntry;
 
@@ -58,7 +58,7 @@ public class TopNTruncator implements VectorTruncator, Serializable {
             threshold.truncate(v);
         }
 
-        TopNScoredItemAccumulator accumulator = new TopNScoredItemAccumulator(n);
+        TopNScoredIdAccumulator accumulator = new TopNScoredIdAccumulator(n);
         for (VectorEntry e : v.view(VectorEntry.State.SET)) {
             accumulator.put(e.getKey(), e.getValue());
         }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/UnlimitedScoredItemAccumulator.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/UnlimitedScoredItemAccumulator.java
@@ -81,6 +81,9 @@ public final class UnlimitedScoredItemAccumulator implements ScoredItemAccumulat
 
     @Override
     public Long2DoubleMap finishMap() {
+        if (scores == null) {
+            return Long2DoubleMaps.EMPTY_MAP;
+        }
         // FIXME Make this efficient
         Long2DoubleMap set = new Long2DoubleOpenHashMap(scores.size());
         for (ScoredId id: finish()) {

--- a/lenskit-core/src/main/java/org/lenskit/basic/TopNItemRecommender.java
+++ b/lenskit-core/src/main/java/org/lenskit/basic/TopNItemRecommender.java
@@ -23,9 +23,9 @@ package org.lenskit.basic;
 
 import com.google.common.collect.Ordering;
 import it.unimi.dsi.fastutil.longs.*;
-import org.grouplens.lenskit.util.ScoredItemAccumulator;
-import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
-import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
+import org.lenskit.util.ScoredIdAccumulator;
+import org.lenskit.util.TopNScoredIdAccumulator;
+import org.lenskit.util.UnlimitedScoredIdAccumulator;
 import org.lenskit.api.ItemScorer;
 import org.lenskit.api.Result;
 import org.lenskit.api.ResultList;
@@ -85,11 +85,11 @@ public class TopNItemRecommender extends AbstractItemRecommender {
                      n, user, candidates.size());
 
         Map<Long, Double> scores = scorer.score(user, candidates);
-        ScoredItemAccumulator accum;
+        ScoredIdAccumulator accum;
         if (n >= 0) {
-            accum = new TopNScoredItemAccumulator(n);
+            accum = new TopNScoredIdAccumulator(n);
         } else {
-            accum = new UnlimitedScoredItemAccumulator();
+            accum = new UnlimitedScoredIdAccumulator();
         }
 
         Long2DoubleFunction map = LongUtils.asLong2DoubleFunction(scores);

--- a/lenskit-core/src/main/java/org/lenskit/util/ScoredIdAccumulator.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/ScoredIdAccumulator.java
@@ -18,7 +18,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit.util;
+package org.lenskit.util;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongList;
@@ -29,11 +29,9 @@ import org.grouplens.lenskit.vectors.MutableSparseVector;
 import java.util.List;
 
 /**
- * Accumulate a sorted list of scored items.
- *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * Accumulate a sorted list of scored IDs.
  */
-public interface ScoredItemAccumulator {
+public interface ScoredIdAccumulator {
     /**
      * Query whether the accumulator is empty.
      *

--- a/lenskit-core/src/main/java/org/lenskit/util/TopNScoredIdAccumulator.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/TopNScoredIdAccumulator.java
@@ -18,7 +18,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit.util;
+package org.lenskit.util;
 
 import com.google.common.primitives.Doubles;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
@@ -37,10 +37,8 @@ import java.util.List;
 /**
  * Accumulate the top <i>N</i> scored IDs.  IDs are sorted by their associated
  * scores.
- *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
-public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
+public final class TopNScoredIdAccumulator implements ScoredIdAccumulator {
     private final int count;
     private DoubleArrayList scores;
     private CompactableLongArrayList items;
@@ -57,7 +55,7 @@ public final class TopNScoredItemAccumulator implements ScoredItemAccumulator {
      *
      * @param n The number of IDs to retain.
      */
-    public TopNScoredItemAccumulator(int n) {
+    public TopNScoredIdAccumulator(int n) {
         this.count = n;
 
         slot = 0;

--- a/lenskit-core/src/main/java/org/lenskit/util/UnlimitedScoredIdAccumulator.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/UnlimitedScoredIdAccumulator.java
@@ -18,7 +18,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit.util;
+package org.lenskit.util;
 
 import it.unimi.dsi.fastutil.longs.*;
 import org.grouplens.lenskit.scored.ScoredId;
@@ -31,13 +31,11 @@ import java.util.List;
 
 /**
  * Scored item accumulator with no upper bound.
- *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
-public final class UnlimitedScoredItemAccumulator implements ScoredItemAccumulator {
+public final class UnlimitedScoredIdAccumulator implements ScoredIdAccumulator {
     private ScoredIdListBuilder scores;
 
-    public UnlimitedScoredItemAccumulator() {}
+    public UnlimitedScoredIdAccumulator() {}
 
     @Override
     public boolean isEmpty() {

--- a/lenskit-core/src/test/java/org/lenskit/util/TopNScoredIdAccumulatorTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/util/TopNScoredIdAccumulatorTest.java
@@ -18,8 +18,9 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit.util;
+package org.lenskit.util;
 
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.junit.Before;
@@ -27,21 +28,15 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
-/**
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
- */
-public class UnlimitedScoredItemAccumulatorTest {
-    ScoredItemAccumulator accum;
+public class TopNScoredIdAccumulatorTest {
+    ScoredIdAccumulator accum;
 
     @Before
     public void createAccumulator() {
-        accum = new UnlimitedScoredItemAccumulator();
+        accum = new TopNScoredIdAccumulator(3);
     }
 
     @Test
@@ -63,6 +58,49 @@ public class UnlimitedScoredItemAccumulatorTest {
         assertThat(out.get(1).getScore(), equalTo(4.2));
         assertThat(out.get(2).getId(), equalTo(3L));
         assertThat(out.get(2).getScore(), equalTo(2.9));
+    }
+
+    @Test
+    public void testAccumLimit() {
+        accum.put(7, 1.0);
+        accum.put(5, 4.2);
+        accum.put(3, 2.9);
+        accum.put(2, 9.8);
+        accum.put(8, 2.1);
+        List<ScoredId> out = accum.finish();
+        assertThat(out, hasSize(3));
+        assertThat(out.get(0).getId(), equalTo(2L));
+        assertThat(out.get(0).getScore(), equalTo(9.8));
+        assertThat(out.get(1).getId(), equalTo(5L));
+        assertThat(out.get(1).getScore(), equalTo(4.2));
+        assertThat(out.get(2).getId(), equalTo(3L));
+        assertThat(out.get(2).getScore(), equalTo(2.9));
+    }
+
+    @Test
+    public void testAccumMap() {
+        accum.put(5, 4.2);
+        accum.put(3, 2.9);
+        accum.put(2, 9.8);
+        Long2DoubleMap out = accum.finishMap();
+        assertThat(out.size(), equalTo(3));
+        assertThat(out, hasEntry(2L, 9.8));
+        assertThat(out, hasEntry(5L, 4.2));
+        assertThat(out, hasEntry(3L, 2.9));
+    }
+
+    @Test
+    public void testAccumMapLimit() {
+        accum.put(7, 1.0);
+        accum.put(5, 4.2);
+        accum.put(3, 2.9);
+        accum.put(2, 9.8);
+        accum.put(8, 2.1);
+        Long2DoubleMap out = accum.finishMap();
+        assertThat(out.size(), equalTo(3));
+        assertThat(out, hasEntry(2L, 9.8));
+        assertThat(out, hasEntry(5L, 4.2));
+        assertThat(out, hasEntry(3L, 2.9));
     }
 
     @Test

--- a/lenskit-core/src/test/java/org/lenskit/util/UnlimitedScoredIdAccumulatorTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/util/UnlimitedScoredIdAccumulatorTest.java
@@ -18,9 +18,8 @@
  * this program; if not, write to the Free Software Foundation, Inc., 51
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-package org.grouplens.lenskit.util;
+package org.lenskit.util;
 
-import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.grouplens.lenskit.scored.ScoredId;
 import org.junit.Before;
@@ -28,19 +27,21 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
-public class TopNScoredItemAccumulatorTest {
-    ScoredItemAccumulator accum;
+public class UnlimitedScoredIdAccumulatorTest {
+    ScoredIdAccumulator accum;
 
     @Before
     public void createAccumulator() {
-        accum = new TopNScoredItemAccumulator(3);
+        accum = new UnlimitedScoredIdAccumulator();
     }
 
     @Test
@@ -62,49 +63,6 @@ public class TopNScoredItemAccumulatorTest {
         assertThat(out.get(1).getScore(), equalTo(4.2));
         assertThat(out.get(2).getId(), equalTo(3L));
         assertThat(out.get(2).getScore(), equalTo(2.9));
-    }
-
-    @Test
-    public void testAccumLimit() {
-        accum.put(7, 1.0);
-        accum.put(5, 4.2);
-        accum.put(3, 2.9);
-        accum.put(2, 9.8);
-        accum.put(8, 2.1);
-        List<ScoredId> out = accum.finish();
-        assertThat(out, hasSize(3));
-        assertThat(out.get(0).getId(), equalTo(2L));
-        assertThat(out.get(0).getScore(), equalTo(9.8));
-        assertThat(out.get(1).getId(), equalTo(5L));
-        assertThat(out.get(1).getScore(), equalTo(4.2));
-        assertThat(out.get(2).getId(), equalTo(3L));
-        assertThat(out.get(2).getScore(), equalTo(2.9));
-    }
-
-    @Test
-    public void testAccumMap() {
-        accum.put(5, 4.2);
-        accum.put(3, 2.9);
-        accum.put(2, 9.8);
-        Long2DoubleMap out = accum.finishMap();
-        assertThat(out.size(), equalTo(3));
-        assertThat(out, hasEntry(2L, 9.8));
-        assertThat(out, hasEntry(5L, 4.2));
-        assertThat(out, hasEntry(3L, 2.9));
-    }
-
-    @Test
-    public void testAccumMapLimit() {
-        accum.put(7, 1.0);
-        accum.put(5, 4.2);
-        accum.put(3, 2.9);
-        accum.put(2, 9.8);
-        accum.put(8, 2.1);
-        Long2DoubleMap out = accum.finishMap();
-        assertThat(out.size(), equalTo(3));
-        assertThat(out, hasEntry(2L, 9.8));
-        assertThat(out, hasEntry(5L, 4.2));
-        assertThat(out, hasEntry(3L, 2.9));
     }
 
     @Test

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemItemBasedItemScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemItemBasedItemScorer.java
@@ -24,8 +24,6 @@ import it.unimi.dsi.fastutil.longs.*;
 import org.grouplens.lenskit.util.ScoredItemAccumulator;
 import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
 import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
-import org.grouplens.lenskit.vectors.SparseVector;
-import org.grouplens.lenskit.vectors.VectorEntry;
 import org.lenskit.api.ResultMap;
 import org.lenskit.basic.AbstractItemBasedItemScorer;
 import org.lenskit.knn.NeighborhoodSize;
@@ -105,7 +103,7 @@ public class ItemItemItemBasedItemScorer extends AbstractItemBasedItemScorer {
      * @param accum The accumulator.
      */
     protected void scoreItem(Long2DoubleMap scores, long item, ItemItemScoreAccumulator accum) {
-        SparseVector allNeighbors = model.getNeighbors(item);
+        Long2DoubleMap allNeighbors = model.getNeighbors(item);
         ScoredItemAccumulator acc;
         if (neighborhoodSize > 0) {
             // FIXME Abstract accumulator selection logic
@@ -114,9 +112,9 @@ public class ItemItemItemBasedItemScorer extends AbstractItemBasedItemScorer {
             acc = new UnlimitedScoredItemAccumulator();
         }
 
-        for (VectorEntry e: allNeighbors) {
-            if (scores.containsKey(e.getKey())) {
-                acc.put(e.getKey(), e.getValue());
+        for (Long2DoubleMap.Entry nbr: allNeighbors.long2DoubleEntrySet()) {
+            if (scores.containsKey(nbr.getLongKey())) {
+                acc.put(nbr.getLongKey(), nbr.getDoubleValue());
             }
         }
 

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemItemBasedItemScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemItemBasedItemScorer.java
@@ -21,9 +21,9 @@
 package org.lenskit.knn.item;
 
 import it.unimi.dsi.fastutil.longs.*;
-import org.grouplens.lenskit.util.ScoredItemAccumulator;
-import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
-import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
+import org.lenskit.util.ScoredIdAccumulator;
+import org.lenskit.util.TopNScoredIdAccumulator;
+import org.lenskit.util.UnlimitedScoredIdAccumulator;
 import org.lenskit.api.ResultMap;
 import org.lenskit.basic.AbstractItemBasedItemScorer;
 import org.lenskit.knn.NeighborhoodSize;
@@ -104,12 +104,12 @@ public class ItemItemItemBasedItemScorer extends AbstractItemBasedItemScorer {
      */
     protected void scoreItem(Long2DoubleMap scores, long item, ItemItemScoreAccumulator accum) {
         Long2DoubleMap allNeighbors = model.getNeighbors(item);
-        ScoredItemAccumulator acc;
+        ScoredIdAccumulator acc;
         if (neighborhoodSize > 0) {
             // FIXME Abstract accumulator selection logic
-            acc = new TopNScoredItemAccumulator(neighborhoodSize);
+            acc = new TopNScoredIdAccumulator(neighborhoodSize);
         } else {
-            acc = new UnlimitedScoredItemAccumulator();
+            acc = new UnlimitedScoredIdAccumulator();
         }
 
         for (Long2DoubleMap.Entry nbr: allNeighbors.long2DoubleEntrySet()) {

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemScorer.java
@@ -33,7 +33,6 @@ import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
 import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
-import org.grouplens.lenskit.vectors.VectorEntry;
 import org.lenskit.api.ResultMap;
 import org.lenskit.basic.AbstractItemScorer;
 import org.lenskit.data.ratings.RatingVectorPDAO;
@@ -151,7 +150,7 @@ public class ItemItemScorer extends AbstractItemScorer {
     }
 
     protected void scoreItem(Long2DoubleMap userData, long item, ItemItemScoreAccumulator accum) {
-        SparseVector allNeighbors = model.getNeighbors(item);
+        Long2DoubleMap allNeighbors = model.getNeighbors(item);
         ScoredItemAccumulator acc;
         if (neighborhoodSize > 0) {
             // FIXME Abstract accumulator selection logic
@@ -160,9 +159,9 @@ public class ItemItemScorer extends AbstractItemScorer {
             acc = new UnlimitedScoredItemAccumulator();
         }
 
-        for (VectorEntry e: allNeighbors) {
-            if (userData.containsKey(e.getKey())) {
-                acc.put(e.getKey(), e.getValue());
+        for (Long2DoubleMap.Entry nbr: allNeighbors.long2DoubleEntrySet()) {
+            if (userData.containsKey(nbr.getLongKey())) {
+                acc.put(nbr.getLongKey(), nbr.getDoubleValue());
             }
         }
 

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemScorer.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/ItemItemScorer.java
@@ -27,9 +27,9 @@ import it.unimi.dsi.fastutil.longs.LongIterators;
 import org.grouplens.lenskit.symbols.Symbol;
 import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer;
 import org.grouplens.lenskit.transform.normalize.VectorTransformation;
-import org.grouplens.lenskit.util.ScoredItemAccumulator;
-import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
-import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
+import org.lenskit.util.ScoredIdAccumulator;
+import org.lenskit.util.TopNScoredIdAccumulator;
+import org.lenskit.util.UnlimitedScoredIdAccumulator;
 import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
@@ -151,12 +151,12 @@ public class ItemItemScorer extends AbstractItemScorer {
 
     protected void scoreItem(Long2DoubleMap userData, long item, ItemItemScoreAccumulator accum) {
         Long2DoubleMap allNeighbors = model.getNeighbors(item);
-        ScoredItemAccumulator acc;
+        ScoredIdAccumulator acc;
         if (neighborhoodSize > 0) {
             // FIXME Abstract accumulator selection logic
-            acc = new TopNScoredItemAccumulator(neighborhoodSize);
+            acc = new TopNScoredIdAccumulator(neighborhoodSize);
         } else {
-            acc = new UnlimitedScoredItemAccumulator();
+            acc = new UnlimitedScoredIdAccumulator();
         }
 
         for (Long2DoubleMap.Entry nbr: allNeighbors.long2DoubleEntrySet()) {

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/model/ItemItemModel.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/model/ItemItemModel.java
@@ -20,9 +20,9 @@
  */
 package org.lenskit.knn.item.model;
 
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
 import org.grouplens.grapht.annotation.DefaultImplementation;
-import org.grouplens.lenskit.vectors.SparseVector;
 
 import javax.annotation.Nonnull;
 
@@ -48,12 +48,12 @@ public interface ItemItemModel {
 
     /**
      * Get the neighbors of an item scored by similarity. This is the corresponding
-     * <em>row</em> of the item-item similarity matrix (see {@link org.grouplens.lenskit.knn.item}).
+     * <em>row</em> of the item-item similarity matrix (see {@link org.lenskit.knn.item}).
      *
      * @param item The item to get the neighborhood for.
      * @return The row of the similarity matrix. If the item is unknown, an empty
      *         vector is returned.
      */
     @Nonnull
-    SparseVector getNeighbors(long item);
+    Long2DoubleMap getNeighbors(long item);
 }

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/model/ItemItemModelProvider.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/model/ItemItemModelProvider.java
@@ -25,7 +25,6 @@ import org.grouplens.lenskit.transform.threshold.Threshold;
 import org.grouplens.lenskit.util.ScoredItemAccumulator;
 import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
 import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
-import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
 import org.lenskit.inject.Transient;
 import org.lenskit.knn.item.ItemSimilarity;
@@ -164,10 +163,10 @@ public class ItemItemModelProvider implements Provider<ItemItemModel> {
         return rows;
     }
 
-    private Long2ObjectMap<ImmutableSparseVector> finishRows(Long2ObjectMap<ScoredItemAccumulator> rows) {
-        Long2ObjectMap<ImmutableSparseVector> results = new Long2ObjectOpenHashMap<>(rows.size());
+    private Long2ObjectMap<Long2DoubleMap> finishRows(Long2ObjectMap<ScoredItemAccumulator> rows) {
+        Long2ObjectMap<Long2DoubleMap> results = new Long2ObjectOpenHashMap<>(rows.size());
         for (Long2ObjectMap.Entry<ScoredItemAccumulator> e: rows.long2ObjectEntrySet()) {
-            results.put(e.getLongKey(), e.getValue().finishVector().freeze());
+            results.put(e.getLongKey(), e.getValue().finishMap());
         }
         return results;
     }

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/model/ItemItemModelProvider.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/model/ItemItemModelProvider.java
@@ -22,9 +22,9 @@ package org.lenskit.knn.item.model;
 
 import it.unimi.dsi.fastutil.longs.*;
 import org.grouplens.lenskit.transform.threshold.Threshold;
-import org.grouplens.lenskit.util.ScoredItemAccumulator;
-import org.grouplens.lenskit.util.TopNScoredItemAccumulator;
-import org.grouplens.lenskit.util.UnlimitedScoredItemAccumulator;
+import org.lenskit.util.ScoredIdAccumulator;
+import org.lenskit.util.TopNScoredIdAccumulator;
+import org.lenskit.util.UnlimitedScoredIdAccumulator;
 import org.grouplens.lenskit.vectors.SparseVector;
 import org.lenskit.inject.Transient;
 import org.lenskit.knn.item.ItemSimilarity;
@@ -84,7 +84,7 @@ public class ItemItemModelProvider implements Provider<ItemItemModel> {
 
         LongSortedSet allItems = buildContext.getItems();
 
-        Long2ObjectMap<ScoredItemAccumulator> rows = makeAccumulators(allItems);
+        Long2ObjectMap<ScoredIdAccumulator> rows = makeAccumulators(allItems);
 
         final int nitems = allItems.size();
         LongIterator outer = allItems.iterator();
@@ -116,7 +116,7 @@ public class ItemItemModelProvider implements Provider<ItemItemModel> {
             LongIterator itemIter = neighborStrategy.neighborIterator(buildContext, itemId1,
                                                                       itemSimilarity.isSymmetric());
 
-            ScoredItemAccumulator row = rows.get(itemId1);
+            ScoredIdAccumulator row = rows.get(itemId1);
             INNER: while (itemIter.hasNext()) {
                 long itemId2 = itemIter.nextLong();
                 if (itemId1 != itemId2) {
@@ -147,25 +147,25 @@ public class ItemItemModelProvider implements Provider<ItemItemModel> {
         return new SimilarityMatrixModel(finishRows(rows));
     }
 
-    private Long2ObjectMap<ScoredItemAccumulator> makeAccumulators(LongSet items) {
-        Long2ObjectMap<ScoredItemAccumulator> rows = new Long2ObjectOpenHashMap<>(items.size());
+    private Long2ObjectMap<ScoredIdAccumulator> makeAccumulators(LongSet items) {
+        Long2ObjectMap<ScoredIdAccumulator> rows = new Long2ObjectOpenHashMap<>(items.size());
         LongIterator iter = items.iterator();
         while (iter.hasNext()) {
             long item = iter.nextLong();
-            ScoredItemAccumulator accum;
+            ScoredIdAccumulator accum;
             if (modelSize == 0) {
-                accum = new UnlimitedScoredItemAccumulator();
+                accum = new UnlimitedScoredIdAccumulator();
             } else {
-                accum = new TopNScoredItemAccumulator(modelSize);
+                accum = new TopNScoredIdAccumulator(modelSize);
             }
             rows.put(item, accum);
         }
         return rows;
     }
 
-    private Long2ObjectMap<Long2DoubleMap> finishRows(Long2ObjectMap<ScoredItemAccumulator> rows) {
+    private Long2ObjectMap<Long2DoubleMap> finishRows(Long2ObjectMap<ScoredIdAccumulator> rows) {
         Long2ObjectMap<Long2DoubleMap> results = new Long2ObjectOpenHashMap<>(rows.size());
-        for (Long2ObjectMap.Entry<ScoredItemAccumulator> e: rows.long2ObjectEntrySet()) {
+        for (Long2ObjectMap.Entry<ScoredIdAccumulator> e: rows.long2ObjectEntrySet()) {
             results.put(e.getLongKey(), e.getValue().finishMap());
         }
         return results;

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/model/NormalizingItemItemModelProvider.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/model/NormalizingItemItemModelProvider.java
@@ -23,15 +23,16 @@ package org.lenskit.knn.item.model;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
-import org.lenskit.inject.Transient;
-import org.lenskit.knn.item.ItemSimilarity;
 import org.grouplens.lenskit.transform.normalize.ItemVectorNormalizer;
 import org.grouplens.lenskit.transform.truncate.VectorTruncator;
-import org.grouplens.lenskit.vectors.ImmutableSparseVector;
 import org.grouplens.lenskit.vectors.MutableSparseVector;
 import org.grouplens.lenskit.vectors.SparseVector;
+import org.lenskit.inject.Transient;
+import org.lenskit.knn.item.ItemSimilarity;
+import org.lenskit.util.collections.LongUtils;
 import org.lenskit.util.keys.SortedKeyIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,7 @@ public class NormalizingItemItemModelProvider implements Provider<ItemItemModel>
 
         SortedKeyIndex itemDomain = SortedKeyIndex.fromCollection(itemUniverse);
         assert itemDomain.size() == nitems;
-        List<ImmutableSparseVector> matrix = Lists.newArrayListWithCapacity(itemDomain.size());
+        List<Long2DoubleMap> matrix = Lists.newArrayListWithCapacity(itemDomain.size());
 
         // working space for accumulating each row (reuse between rows)
         MutableSparseVector currentRow = MutableSparseVector.create(itemUniverse);
@@ -120,7 +121,7 @@ public class NormalizingItemItemModelProvider implements Provider<ItemItemModel>
             MutableSparseVector normalized = rowNormalizer.normalize(rowItem, currentRow, null);
             truncator.truncate(normalized);
 
-            matrix.add(normalized.immutable());
+            matrix.add(LongUtils.frozenMap(normalized.asMap()));
         }
 
         timer.stop();

--- a/lenskit-knn/src/main/java/org/lenskit/knn/item/model/SimilarityMatrixModel.java
+++ b/lenskit-knn/src/main/java/org/lenskit/knn/item/model/SimilarityMatrixModel.java
@@ -21,11 +21,14 @@
 package org.lenskit.knn.item.model;
 
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
 import org.grouplens.grapht.annotation.DefaultProvider;
+import org.lenskit.api.ResultList;
 import org.lenskit.inject.Shareable;
-import org.grouplens.lenskit.vectors.ImmutableSparseVector;
-import org.grouplens.lenskit.vectors.SparseVector;
+import org.lenskit.results.Results;
+import org.lenskit.util.collections.LongUtils;
 import org.lenskit.util.keys.SortedKeyIndex;
 
 import javax.annotation.Nonnull;
@@ -50,7 +53,7 @@ public class SimilarityMatrixModel implements Serializable, ItemItemModel {
     private static final long serialVersionUID = 3L;
 
     private final SortedKeyIndex itemDomain;
-    private final ImmutableList<ImmutableSparseVector> neighborhoods;
+    private final ImmutableList<Long2DoubleMap> neighborhoods;
     private transient volatile String stringValue;
 
     /**
@@ -61,7 +64,7 @@ public class SimilarityMatrixModel implements Serializable, ItemItemModel {
      * @deprecated This is deprecated for public usage.  It is better to use the other constructor.
      */
     @Deprecated
-    public SimilarityMatrixModel(SortedKeyIndex items, List<ImmutableSparseVector> nbrs) {
+    public SimilarityMatrixModel(SortedKeyIndex items, List<Long2DoubleMap> nbrs) {
         itemDomain = items;
         neighborhoods = ImmutableList.copyOf(nbrs);
     }
@@ -71,13 +74,13 @@ public class SimilarityMatrixModel implements Serializable, ItemItemModel {
      *
      * @param nbrs  The item neighborhoods.  The item neighborhood lists are not copied.
      */
-    public SimilarityMatrixModel(Map<Long,ImmutableSparseVector> nbrs) {
+    public SimilarityMatrixModel(Map<Long,Long2DoubleMap> nbrs) {
         itemDomain = SortedKeyIndex.fromCollection(nbrs.keySet());
         int n = itemDomain.size();
         assert n == nbrs.size();
-        ImmutableList.Builder<ImmutableSparseVector> neighbors = ImmutableList.builder();
+        ImmutableList.Builder<Long2DoubleMap> neighbors = ImmutableList.builder();
         for (int i = 0; i < n; i++) {
-            neighbors.add(nbrs.get(itemDomain.getKey(i)));
+            neighbors.add(LongUtils.frozenMap(nbrs.get(itemDomain.getKey(i))));
         }
         neighborhoods = neighbors.build();
     }
@@ -89,10 +92,10 @@ public class SimilarityMatrixModel implements Serializable, ItemItemModel {
 
     @Override
     @Nonnull
-    public SparseVector getNeighbors(long item) {
+    public Long2DoubleMap getNeighbors(long item) {
         int idx = itemDomain.tryGetIndex(item);
         if (idx < 0) {
-            return ImmutableSparseVector.empty();
+            return Long2DoubleMaps.EMPTY_MAP;
         } else {
             return neighborhoods.get(idx);
         }
@@ -103,7 +106,7 @@ public class SimilarityMatrixModel implements Serializable, ItemItemModel {
         String val = stringValue;
         if (val == null) {
             int nsims = 0;
-            for (SparseVector nbrs: neighborhoods) {
+            for (Long2DoubleMap nbrs: neighborhoods) {
                 nsims += nbrs.size();
             }
             val = String.format("matrix of %d similarities for %d items", nsims, neighborhoods.size());


### PR DESCRIPTION
This does some deprecation cleanups so teaching code can avoid using non-updated classes.

- Stop using sparse vectors in the item-item model