### PR TITLE
User-item bias model

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/AbstractItemVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/AbstractItemVectorNormalizer.java
@@ -1,0 +1,50 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.transform.normalize;
+
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.grouplens.lenskit.vectors.SparseVector;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Abstract item vector normalizer implementation.
+ */
+public abstract class AbstractItemVectorNormalizer implements ItemVectorNormalizer {
+
+    /**
+     * {@inheritDoc}
+     * <p>Delegates to {@link #makeTransformation(long, SparseVector)}
+     * and the resulting {@link VectorTransformation}.
+     */
+    @Override
+    public MutableSparseVector normalize(long item, @Nonnull SparseVector vector,
+                                         @Nullable MutableSparseVector target) {
+        MutableSparseVector v = target;
+        if (v == null) {
+            v = vector.mutableCopy();
+        }
+
+        VectorTransformation tform = makeTransformation(item, vector);
+        return tform.apply(v);
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasItemVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasItemVectorNormalizer.java
@@ -1,0 +1,84 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.transform.normalize;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.grouplens.lenskit.vectors.SparseVector;
+import org.grouplens.lenskit.vectors.VectorEntry;
+import org.lenskit.bias.BiasModel;
+
+import javax.inject.Inject;
+
+/**
+ * Item vector normalizer that subtracts user-item biases.
+ */
+public class BiasItemVectorNormalizer extends AbstractItemVectorNormalizer {
+    private final BiasModel model;
+
+    @Inject
+    public BiasItemVectorNormalizer(BiasModel bias) {
+        model = bias;
+    }
+
+    @Override
+    public VectorTransformation makeTransformation(long itemId, SparseVector vector) {
+        return new Transform(itemId);
+    }
+
+    private class Transform implements VectorTransformation {
+        private final long item;
+        private final double itemBias;
+
+        public Transform(long iid) {
+            item = iid;
+            itemBias = model.getIntercept() + model.getItemBias(item);
+        }
+
+        @Override
+        public MutableSparseVector apply(MutableSparseVector vector) {
+            Long2DoubleMap users = model.getUserBiases(vector.keySet());
+            for (VectorEntry e: vector) {
+                vector.set(e, e.getValue() - itemBias - users.get(e.getKey()));
+            }
+            return vector;
+        }
+
+        @Override
+        public MutableSparseVector unapply(MutableSparseVector vector) {
+            Long2DoubleMap users = model.getUserBiases(vector.keySet());
+            for (VectorEntry e: vector) {
+                vector.set(e, e.getValue() + itemBias + users.get(e.getKey()));
+            }
+            return vector;
+        }
+
+        @Override
+        public double apply(long key, double value) {
+            return value - itemBias - model.getUserBias(key);
+        }
+
+        @Override
+        public double unapply(long key, double value) {
+            return value + itemBias + model.getUserBias(key);
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasItemVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasItemVectorNormalizer.java
@@ -34,6 +34,10 @@ import javax.inject.Inject;
 public class BiasItemVectorNormalizer extends AbstractItemVectorNormalizer {
     private final BiasModel model;
 
+    /**
+     * Construct a new normalizer.
+     * @param bias The bias model to subtract from item vector values.
+     */
     @Inject
     public BiasItemVectorNormalizer(BiasModel bias) {
         model = bias;
@@ -48,7 +52,7 @@ public class BiasItemVectorNormalizer extends AbstractItemVectorNormalizer {
         private final long item;
         private final double itemBias;
 
-        public Transform(long iid) {
+        Transform(long iid) {
             item = iid;
             itemBias = model.getIntercept() + model.getItemBias(item);
         }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasUserVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasUserVectorNormalizer.java
@@ -1,0 +1,84 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.transform.normalize;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.grouplens.lenskit.vectors.SparseVector;
+import org.grouplens.lenskit.vectors.VectorEntry;
+import org.lenskit.bias.BiasModel;
+
+import javax.inject.Inject;
+
+/**
+ * Item vector normalizer that subtracts user-item biases.
+ */
+public class BiasUserVectorNormalizer extends AbstractUserVectorNormalizer {
+    private final BiasModel model;
+
+    @Inject
+    public BiasUserVectorNormalizer(BiasModel bias) {
+        model = bias;
+    }
+
+    @Override
+    public VectorTransformation makeTransformation(long userId, SparseVector vector) {
+        return new Transform(userId);
+    }
+
+    private class Transform implements VectorTransformation {
+        private final long user;
+        private final double userBias;
+
+        public Transform(long uid) {
+            user = uid;
+            userBias = model.getIntercept() + model.getUserBias(user);
+        }
+
+        @Override
+        public MutableSparseVector apply(MutableSparseVector vector) {
+            Long2DoubleMap users = model.getItemBiases(vector.keySet());
+            for (VectorEntry e: vector) {
+                vector.set(e, e.getValue() - userBias - users.get(e.getKey()));
+            }
+            return vector;
+        }
+
+        @Override
+        public MutableSparseVector unapply(MutableSparseVector vector) {
+            Long2DoubleMap users = model.getItemBiases(vector.keySet());
+            for (VectorEntry e: vector) {
+                vector.set(e, e.getValue() + userBias + users.get(e.getKey()));
+            }
+            return vector;
+        }
+
+        @Override
+        public double apply(long key, double value) {
+            return value - userBias - model.getItemBias(key);
+        }
+
+        @Override
+        public double unapply(long key, double value) {
+            return value + userBias + model.getItemBias(key);
+        }
+    }
+}

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasUserVectorNormalizer.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/transform/normalize/BiasUserVectorNormalizer.java
@@ -29,11 +29,15 @@ import org.lenskit.bias.BiasModel;
 import javax.inject.Inject;
 
 /**
- * Item vector normalizer that subtracts user-item biases.
+ * User vector normalizer that subtracts user-item biases.
  */
 public class BiasUserVectorNormalizer extends AbstractUserVectorNormalizer {
     private final BiasModel model;
 
+    /**
+     * Construct a new normalizer.
+     * @param bias The bias model to subtract from user vector values.
+     */
     @Inject
     public BiasUserVectorNormalizer(BiasModel bias) {
         model = bias;
@@ -48,7 +52,7 @@ public class BiasUserVectorNormalizer extends AbstractUserVectorNormalizer {
         private final long user;
         private final double userBias;
 
-        public Transform(long uid) {
+        Transform(long uid) {
             user = uid;
             userBias = model.getIntercept() + model.getUserBias(user);
         }

--- a/lenskit-core/src/main/java/org/lenskit/bias/BiasItemScorer.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/BiasItemScorer.java
@@ -41,6 +41,10 @@ import java.util.List;
 public class BiasItemScorer extends AbstractItemScorer {
     private final BiasModel model;
 
+    /**
+     * Construct a new scorer.
+     * @param bias The bias model to use.
+     */
     @Inject
     public BiasItemScorer(BiasModel bias) {
         model = bias;

--- a/lenskit-core/src/main/java/org/lenskit/bias/BiasItemScorer.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/BiasItemScorer.java
@@ -1,0 +1,67 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongIterators;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+import org.lenskit.basic.AbstractItemScorer;
+import org.lenskit.results.Results;
+import org.lenskit.util.collections.LongUtils;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Score items using a user-item bias model.  This scorer is good as a baseline scorer for many situations.
+ */
+public class BiasItemScorer extends AbstractItemScorer {
+    private final BiasModel model;
+
+    @Inject
+    public BiasItemScorer(BiasModel bias) {
+        model = bias;
+    }
+
+    @Override
+    public Result score(long user, long item) {
+        return Results.create(item, model.getIntercept() + model.getUserBias(user) + model.getItemBias(item));
+    }
+
+    @Nonnull
+    @Override
+    public ResultMap scoreWithDetails(long user, @Nonnull Collection<Long> items) {
+        Long2DoubleMap scores = model.getItemBiases(LongUtils.asLongSet(items));
+        List<Result> results = new ArrayList<>();
+        double base = model.getIntercept() + model.getUserBias(user);
+        LongIterator iter = LongIterators.asLongIterator(items.iterator());
+        while (iter.hasNext()) {
+            long item = iter.nextLong();
+            results.add(Results.create(item, base + scores.get(item)));
+        }
+        return Results.newResultMap(results);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
@@ -20,6 +20,9 @@
  */
 package org.lenskit.bias;
 
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
 /**
  * Interface for bias models that can be based on the user, item, or both.
  */
@@ -38,9 +41,25 @@ public interface BiasModel {
     double getUserBias(long user);
 
     /**
+     * Get a set of user biases.
+     * @param users The users whose biases are to be returned.
+     * @return A mapping from user IDs to biases. It is not guaranteed to contain all user IDs in its key set, but its
+     * {@link Long2DoubleMap#defaultReturnValue()} will be 0.
+     */
+    Long2DoubleMap getUserBiases(LongSet users);
+
+    /**
      * Get the item bias.
      * @param item The item ID.
      * @return The bias for the specified ite, or 0 if the item's bias is unknown.
      */
     double getItemBias(long item);
+
+    /**
+     * Get a set of item biases.
+     * @param items The itemms whose biases are to be returned.
+     * @return A mapping from item IDs to biases. It is not guaranteed to contain all item IDs in its key set, but its
+     * {@link Long2DoubleMap#defaultReturnValue()} will be 0.
+     */
+    Long2DoubleMap getItemBiases(LongSet items);
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
@@ -22,6 +22,7 @@ package org.lenskit.bias;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import org.grouplens.grapht.annotation.DefaultImplementation;
 
 /**
  * Interface for bias models that can be based on the user, item, or both.

--- a/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
@@ -1,0 +1,46 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+/**
+ * Interface for bias models that can be based on the user, item, or both.
+ */
+public interface BiasModel {
+    /**
+     * Get the global bias (intercept).
+     * @return The global bias.
+     */
+    double getIntercept();
+
+    /**
+     * Get the user bias.
+     * @param user The user ID.
+     * @return The bias for the specified user, or 0 if the user's bias is unknown.
+     */
+    double getUserBias(long user);
+
+    /**
+     * Get the item bias.
+     * @param item The item ID.
+     * @return The bias for the specified ite, or 0 if the item's bias is unknown.
+     */
+    double getItemBias(long item);
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/BiasModel.java
@@ -22,7 +22,6 @@ package org.lenskit.bias;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongSet;
-import org.grouplens.grapht.annotation.DefaultImplementation;
 
 /**
  * Interface for bias models that can be based on the user, item, or both.
@@ -58,7 +57,7 @@ public interface BiasModel {
 
     /**
      * Get a set of item biases.
-     * @param items The itemms whose biases are to be returned.
+     * @param items The items whose biases are to be returned.
      * @return A mapping from item IDs to biases. It is not guaranteed to contain all item IDs in its key set, but its
      * {@link Long2DoubleMap#defaultReturnValue()} will be 0.
      */

--- a/lenskit-core/src/main/java/org/lenskit/bias/GlobalAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/GlobalAverageRatingBiasModelProvider.java
@@ -1,0 +1,55 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import org.lenskit.data.dao.DataAccessObject;
+import org.lenskit.data.ratings.Rating;
+import org.lenskit.inject.Transient;
+import org.lenskit.util.io.ObjectStream;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/**
+ * Compute a bias model with the global average rating.
+ */
+public class GlobalAverageRatingBiasModelProvider implements Provider<GlobalBiasModel> {
+    private final DataAccessObject dao;
+
+    @Inject
+    public GlobalAverageRatingBiasModelProvider(@Transient DataAccessObject dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public GlobalBiasModel get() {
+        double sum = 0;
+        int n = 0;
+        try (ObjectStream<Rating> ratings = dao.query(Rating.class).stream()) {
+            for (Rating r: ratings) {
+                sum += r.getValue();
+                n += 1;
+            }
+        }
+        double mean = n > 0 ? sum / n : 0;
+        return new GlobalBiasModel(mean);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
@@ -36,7 +36,7 @@ public class GlobalBiasModel implements BiasModel {
 
     @Override
     public double getIntercept() {
-        return 0;
+        return intercept;
     }
 
     @Override

--- a/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
@@ -20,10 +20,21 @@
  */
 package org.lenskit.bias;
 
+import org.grouplens.grapht.annotation.DefaultProvider;
+import org.lenskit.inject.Shareable;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
+
 /**
  * Bias model that only uses a global bias.
  */
-public class GlobalBiasModel implements BiasModel {
+@Shareable
+@Immutable
+@DefaultProvider(GlobalAverageRatingBiasModelProvider.class)
+public class GlobalBiasModel implements BiasModel, Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final double intercept;
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
@@ -1,0 +1,51 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+/**
+ * Bias model that only uses a global bias.
+ */
+public class GlobalBiasModel implements BiasModel {
+    private final double intercept;
+
+    /**
+     * Construct a new global bias model.
+     * @param bias The global bias.
+     */
+    public GlobalBiasModel(double bias) {
+        intercept = bias;
+    }
+
+    @Override
+    public double getIntercept() {
+        return 0;
+    }
+
+    @Override
+    public double getUserBias(long user) {
+        return 0;
+    }
+
+    @Override
+    public double getItemBias(long item) {
+        return 0;
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/GlobalBiasModel.java
@@ -20,6 +20,9 @@
  */
 package org.lenskit.bias;
 
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import org.grouplens.grapht.annotation.DefaultProvider;
 import org.lenskit.inject.Shareable;
 
@@ -58,5 +61,15 @@ public class GlobalBiasModel implements BiasModel, Serializable {
     @Override
     public double getItemBias(long item) {
         return 0;
+    }
+
+    @Override
+    public Long2DoubleMap getUserBiases(LongSet users) {
+        return Long2DoubleMaps.EMPTY_MAP;
+    }
+
+    @Override
+    public Long2DoubleMap getItemBiases(LongSet items) {
+        return Long2DoubleMaps.EMPTY_MAP;
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/ItemAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/ItemAverageRatingBiasModelProvider.java
@@ -21,9 +21,6 @@
 package org.lenskit.bias;
 
 import org.lenskit.data.ratings.RatingSummary;
-import org.lenskit.inject.Transient;
-import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
-import org.lenskit.util.keys.SortedKeyIndex;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -35,19 +32,12 @@ public class ItemAverageRatingBiasModelProvider implements Provider<ItemBiasMode
     private final RatingSummary summary;
 
     @Inject
-    public ItemAverageRatingBiasModelProvider(@Transient RatingSummary rs) {
+    public ItemAverageRatingBiasModelProvider(RatingSummary rs) {
         summary = rs;
     }
 
     @Override
     public ItemBiasModel get() {
-        SortedKeyIndex keys = SortedKeyIndex.fromCollection(summary.getItems());
-        final int n = keys.size();
-        double[] values = new double[n];
-        for (int i = 0; i < n; i++) {
-            values[i] = summary.getItemOffset(keys.getKey(i));
-        }
-
-        return new ItemBiasModel(summary.getGlobalMean(), Long2DoubleSortedArrayMap.wrap(keys, values));
+        return new ItemBiasModel(summary.getGlobalMean(), summary.getItemOffets());
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/ItemAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/ItemAverageRatingBiasModelProvider.java
@@ -1,0 +1,53 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import org.lenskit.data.ratings.RatingSummary;
+import org.lenskit.inject.Transient;
+import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+import org.lenskit.util.keys.SortedKeyIndex;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/**
+ * Compute a bias model with the global average rating.
+ */
+public class ItemAverageRatingBiasModelProvider implements Provider<ItemBiasModel> {
+    private final RatingSummary summary;
+
+    @Inject
+    public ItemAverageRatingBiasModelProvider(@Transient RatingSummary rs) {
+        summary = rs;
+    }
+
+    @Override
+    public ItemBiasModel get() {
+        SortedKeyIndex keys = SortedKeyIndex.fromCollection(summary.getItems());
+        final int n = keys.size();
+        double[] values = new double[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = summary.getItemOffset(keys.getKey(i));
+        }
+
+        return new ItemBiasModel(summary.getGlobalMean(), Long2DoubleSortedArrayMap.wrap(keys, values));
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/ItemAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/ItemAverageRatingBiasModelProvider.java
@@ -26,7 +26,8 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 /**
- * Compute a bias model with the global average rating.
+ * Compute a bias model that returns items' average ratings.  For an item \\(i\\), the global bias \\(b\\) plus the
+ * item bias \\(b_i\\) will equal the item's average rating.  User biases are all zero.
  */
 public class ItemAverageRatingBiasModelProvider implements Provider<ItemBiasModel> {
     private final RatingSummary summary;

--- a/lenskit-core/src/main/java/org/lenskit/bias/ItemBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/ItemBiasModel.java
@@ -21,12 +21,11 @@
 package org.lenskit.bias;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
 import org.grouplens.grapht.annotation.DefaultProvider;
 import org.lenskit.inject.Shareable;
-import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
 
 import javax.annotation.concurrent.Immutable;
-import java.io.Serializable;
 
 /**
  * Bias model that provides global and item biases. The item biases are precomputed and are *not* updated based on
@@ -35,11 +34,8 @@ import java.io.Serializable;
 @Shareable
 @Immutable
 @DefaultProvider(ItemAverageRatingBiasModelProvider.class)
-public class ItemBiasModel implements BiasModel, Serializable {
+public class ItemBiasModel extends UserItemBiasModel {
     private static final long serialVersionUID = 1L;
-
-    private final double intercept;
-    private final Long2DoubleSortedArrayMap itemBiases;
 
     /**
      * Construct a new item bias model.
@@ -47,22 +43,6 @@ public class ItemBiasModel implements BiasModel, Serializable {
      * @param items The item biases.
      */
     public ItemBiasModel(double global, Long2DoubleMap items) {
-        intercept = global;
-        itemBiases = Long2DoubleSortedArrayMap.create(items);
-    }
-
-    @Override
-    public double getIntercept() {
-        return intercept;
-    }
-
-    @Override
-    public double getUserBias(long user) {
-        return 0;
-    }
-
-    @Override
-    public double getItemBias(long item) {
-        return itemBiases.get(item);
+        super(global, Long2DoubleMaps.EMPTY_MAP, items);
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/ItemBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/ItemBiasModel.java
@@ -1,0 +1,67 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import org.grouplens.grapht.annotation.DefaultProvider;
+import org.lenskit.inject.Shareable;
+import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
+
+/**
+ * Bias model that provides global and item biases.
+ */
+@Shareable
+@Immutable
+@DefaultProvider(ItemAverageRatingBiasModelProvider.class)
+public class ItemBiasModel implements BiasModel, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final double intercept;
+    private final Long2DoubleSortedArrayMap itemBiases;
+
+    /**
+     * Construct a new item bias model.
+     * @param global The global bias.
+     * @param items The item biases.
+     */
+    public ItemBiasModel(double global, Long2DoubleMap items) {
+        intercept = global;
+        itemBiases = Long2DoubleSortedArrayMap.create(items);
+    }
+
+    @Override
+    public double getIntercept() {
+        return intercept;
+    }
+
+    @Override
+    public double getUserBias(long user) {
+        return 0;
+    }
+
+    @Override
+    public double getItemBias(long item) {
+        return itemBiases.get(item);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/LiveUserItemBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/LiveUserItemBiasModel.java
@@ -21,7 +21,10 @@
 package org.lenskit.bias;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import org.lenskit.data.ratings.RatingVectorPDAO;
+import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+import org.lenskit.util.keys.SortedKeyIndex;
 
 import javax.inject.Inject;
 
@@ -68,5 +71,23 @@ public final class LiveUserItemBiasModel implements BiasModel{
     @Override
     public double getItemBias(long item) {
         return delegate.getItemBias(item);
+    }
+
+    @Override
+    public Long2DoubleMap getUserBiases(LongSet users) {
+        SortedKeyIndex index = SortedKeyIndex.fromCollection(users);
+        final int n = index.size();
+        double[] values = new double[n];
+
+        for (int i = 0; i < n; i++) {
+            values[i] = getUserBias(index.getKey(i));
+        }
+
+        return Long2DoubleSortedArrayMap.wrap(index, values);
+    }
+
+    @Override
+    public Long2DoubleMap getItemBiases(LongSet items) {
+        return delegate.getItemBiases(items);
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/LiveUserItemBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/LiveUserItemBiasModel.java
@@ -31,14 +31,14 @@ import javax.inject.Inject;
 /**
  * Bias model that provides global, user, and item biases.  The global and item biases are precomputed and are *not*
  * refreshed based on user data added since the model build, but the user bias (mean rating from the rating DAO) is
- * recomputed live.
+ * recomputed live based on a {@link RatingVectorPDAO}.
  */
 public final class LiveUserItemBiasModel implements BiasModel{
     private final ItemBiasModel delegate;
     private final RatingVectorPDAO dao;
 
     /**
-     * Construct a new user bias model.
+     * Construct a new bias model.
      * @param base An item bias model to use as the base model.
      * @param dao The rating vector DAO to fetch user data.
      */

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserAverageRatingBiasModelProvider.java
@@ -36,7 +36,8 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 /**
- * Compute a bias model with users' average ratings.
+ * Compute a bias model that returns users' average ratings.  For a user \\(u\\), the global bias \\(b\\) plus the
+ * user bias \\(b_u\\) will equal the user's average rating.  Item biases are all zero.
  */
 public class UserAverageRatingBiasModelProvider implements Provider<UserBiasModel> {
     private final RatingVectorPDAO dao;

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserAverageRatingBiasModelProvider.java
@@ -1,0 +1,70 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap;
+import org.lenskit.data.dao.DataAccessObject;
+import org.lenskit.data.ratings.RatingSummary;
+import org.lenskit.data.ratings.RatingVectorPDAO;
+import org.lenskit.inject.Transient;
+import org.lenskit.util.IdBox;
+import org.lenskit.util.io.ObjectStream;
+import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+import org.lenskit.util.keys.SortedKeyIndex;
+import org.lenskit.util.math.Vectors;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/**
+ * Compute a bias model with users' average ratings.
+ */
+public class UserAverageRatingBiasModelProvider implements Provider<UserBiasModel> {
+    private final RatingVectorPDAO dao;
+
+    @Inject
+    public UserAverageRatingBiasModelProvider(@Transient RatingVectorPDAO dao) {
+        this.dao = dao;
+    }
+
+    @Override
+    public UserBiasModel get() {
+        double sum = 0;
+        int n = 0;
+        Long2DoubleMap map = new Long2DoubleOpenHashMap();
+        try (ObjectStream<IdBox<Long2DoubleMap>> stream = dao.streamUsers()) {
+            for (IdBox<Long2DoubleMap> user : stream) {
+                Long2DoubleMap uvec = user.getValue();
+                double usum = Vectors.sum(uvec);
+                int ucount = uvec.size();
+
+                sum += usum;
+                n += ucount;
+
+                map.put(user.getId(), usum / ucount);
+            }
+        }
+
+        double mean = sum / n;
+        return new UserBiasModel(mean, Vectors.addScalar(map, -mean));
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserBiasModel.java
@@ -21,12 +21,11 @@
 package org.lenskit.bias;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
 import org.grouplens.grapht.annotation.DefaultProvider;
 import org.lenskit.inject.Shareable;
-import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
 
 import javax.annotation.concurrent.Immutable;
-import java.io.Serializable;
 
 /**
  * Bias model that provides global and user biases.  The user biases are precomputed and are *not* refreshed based
@@ -35,11 +34,8 @@ import java.io.Serializable;
 @Shareable
 @Immutable
 @DefaultProvider(UserAverageRatingBiasModelProvider.class)
-public class UserBiasModel implements BiasModel, Serializable {
+public class UserBiasModel extends UserItemBiasModel {
     private static final long serialVersionUID = 1L;
-
-    private final double intercept;
-    private final Long2DoubleSortedArrayMap userBiases;
 
     /**
      * Construct a new user bias model.
@@ -47,22 +43,6 @@ public class UserBiasModel implements BiasModel, Serializable {
      * @param users The user biases.
      */
     public UserBiasModel(double global, Long2DoubleMap users) {
-        intercept = global;
-        userBiases = Long2DoubleSortedArrayMap.create(users);
-    }
-
-    @Override
-    public double getIntercept() {
-        return intercept;
-    }
-
-    @Override
-    public double getUserBias(long user) {
-        return userBiases.get(user);
-    }
-
-    @Override
-    public double getItemBias(long item) {
-        return 0;
+        super(global, users, Long2DoubleMaps.EMPTY_MAP);
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserBiasModel.java
@@ -1,0 +1,68 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import org.grouplens.grapht.annotation.DefaultProvider;
+import org.lenskit.inject.Shareable;
+import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+
+import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
+
+/**
+ * Bias model that provides global and user biases.  The user biases are precomputed and are *not* refreshed based
+ * on user data added since the model build.
+ */
+@Shareable
+@Immutable
+@DefaultProvider(UserAverageRatingBiasModelProvider.class)
+public class UserBiasModel implements BiasModel, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final double intercept;
+    private final Long2DoubleSortedArrayMap userBiases;
+
+    /**
+     * Construct a new user bias model.
+     * @param global The global bias.
+     * @param users The user biases.
+     */
+    public UserBiasModel(double global, Long2DoubleMap users) {
+        intercept = global;
+        userBiases = Long2DoubleSortedArrayMap.create(users);
+    }
+
+    @Override
+    public double getIntercept() {
+        return intercept;
+    }
+
+    @Override
+    public double getUserBias(long user) {
+        return userBiases.get(user);
+    }
+
+    @Override
+    public double getItemBias(long item) {
+        return 0;
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserItemAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserItemAverageRatingBiasModelProvider.java
@@ -27,9 +27,6 @@ import org.lenskit.data.ratings.RatingVectorPDAO;
 import org.lenskit.inject.Transient;
 import org.lenskit.util.IdBox;
 import org.lenskit.util.io.ObjectStream;
-import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
-import org.lenskit.util.keys.SortedKeyIndex;
-import org.lenskit.util.math.Vectors;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -42,7 +39,7 @@ public class UserItemAverageRatingBiasModelProvider implements Provider<UserItem
     private final RatingVectorPDAO dao;
 
     @Inject
-    public UserItemAverageRatingBiasModelProvider(@Transient RatingSummary rs, @Transient RatingVectorPDAO dao) {
+    public UserItemAverageRatingBiasModelProvider(RatingSummary rs, @Transient RatingVectorPDAO dao) {
         summary = rs;
         this.dao = dao;
     }
@@ -51,14 +48,7 @@ public class UserItemAverageRatingBiasModelProvider implements Provider<UserItem
     public UserItemBiasModel get() {
         double intercept = summary.getGlobalMean();
 
-        SortedKeyIndex items = SortedKeyIndex.fromCollection(summary.getItems());
-        final int ni = items.size();
-        double[] ivalues = new double[ni];
-        for (int i = 0; i < ni; i++) {
-            ivalues[i] = summary.getItemOffset(items.getKey(i));
-        }
-
-        Long2DoubleMap itemOff = Long2DoubleSortedArrayMap.wrap(items, ivalues);
+        Long2DoubleMap itemOff = summary.getItemOffets();
 
         Long2DoubleMap map = new Long2DoubleOpenHashMap();
         try (ObjectStream<IdBox<Long2DoubleMap>> stream = dao.streamUsers()) {

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserItemAverageRatingBiasModelProvider.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserItemAverageRatingBiasModelProvider.java
@@ -1,0 +1,80 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap;
+import org.lenskit.data.ratings.RatingSummary;
+import org.lenskit.data.ratings.RatingVectorPDAO;
+import org.lenskit.inject.Transient;
+import org.lenskit.util.IdBox;
+import org.lenskit.util.io.ObjectStream;
+import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+import org.lenskit.util.keys.SortedKeyIndex;
+import org.lenskit.util.math.Vectors;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+/**
+ * Compute a bias model with users' average ratings.
+ */
+public class UserItemAverageRatingBiasModelProvider implements Provider<UserItemBiasModel> {
+    private final RatingSummary summary;
+    private final RatingVectorPDAO dao;
+
+    @Inject
+    public UserItemAverageRatingBiasModelProvider(@Transient RatingSummary rs, @Transient RatingVectorPDAO dao) {
+        summary = rs;
+        this.dao = dao;
+    }
+
+    @Override
+    public UserItemBiasModel get() {
+        double intercept = summary.getGlobalMean();
+
+        SortedKeyIndex items = SortedKeyIndex.fromCollection(summary.getItems());
+        final int ni = items.size();
+        double[] ivalues = new double[ni];
+        for (int i = 0; i < ni; i++) {
+            ivalues[i] = summary.getItemOffset(items.getKey(i));
+        }
+
+        Long2DoubleMap itemOff = Long2DoubleSortedArrayMap.wrap(items, ivalues);
+
+        Long2DoubleMap map = new Long2DoubleOpenHashMap();
+        try (ObjectStream<IdBox<Long2DoubleMap>> stream = dao.streamUsers()) {
+            for (IdBox<Long2DoubleMap> user : stream) {
+                Long2DoubleMap uvec = user.getValue();
+
+                double usum = 0;
+
+                for (Long2DoubleMap.Entry e: uvec.long2DoubleEntrySet()) {
+                    usum += e.getDoubleValue() - intercept - itemOff.get(e.getLongKey());
+                }
+
+                map.put(user.getId(), usum / uvec.size());
+            }
+        }
+
+        return new UserItemBiasModel(intercept, map, itemOff);
+    }
+}

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserItemBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserItemBiasModel.java
@@ -20,13 +20,17 @@
  */
 package org.lenskit.bias;
 
-import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.*;
 import org.grouplens.grapht.annotation.DefaultProvider;
 import org.lenskit.inject.Shareable;
+import org.lenskit.util.collections.LongUtils;
 import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+import org.lenskit.util.keys.SortedKeyIndex;
+import org.lenskit.util.math.Scalars;
 
 import javax.annotation.concurrent.Immutable;
 import java.io.Serializable;
+import java.util.Iterator;
 
 /**
  * Bias model that provides global, user, and item biases.  The user and item biases are precomputed and are *not*
@@ -39,8 +43,8 @@ public class UserItemBiasModel implements BiasModel, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final double intercept;
-    private final Long2DoubleMap userBiases;
-    private final Long2DoubleMap itemBiases;
+    private final Long2DoubleSortedArrayMap userBiases;
+    private final Long2DoubleSortedArrayMap itemBiases;
 
     /**
      * Construct a new user bias model.
@@ -65,7 +69,17 @@ public class UserItemBiasModel implements BiasModel, Serializable {
     }
 
     @Override
+    public Long2DoubleMap getUserBiases(LongSet users) {
+        return userBiases.subMap(users);
+    }
+
+    @Override
     public double getItemBias(long item) {
         return itemBiases.get(item);
+    }
+
+    @Override
+    public Long2DoubleMap getItemBiases(LongSet items) {
+        return itemBiases.subMap(items);
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/bias/UserItemBiasModel.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/UserItemBiasModel.java
@@ -29,25 +29,28 @@ import javax.annotation.concurrent.Immutable;
 import java.io.Serializable;
 
 /**
- * Bias model that provides global and item biases. The item biases are precomputed and are *not* updated based on
- * new data added since the model builds
+ * Bias model that provides global, user, and item biases.  The user and item biases are precomputed and are *not*
+ * refreshed based on user data added since the model build.
  */
 @Shareable
 @Immutable
-@DefaultProvider(ItemAverageRatingBiasModelProvider.class)
-public class ItemBiasModel implements BiasModel, Serializable {
+@DefaultProvider(UserAverageRatingBiasModelProvider.class)
+public class UserItemBiasModel implements BiasModel, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final double intercept;
-    private final Long2DoubleSortedArrayMap itemBiases;
+    private final Long2DoubleMap userBiases;
+    private final Long2DoubleMap itemBiases;
 
     /**
-     * Construct a new item bias model.
+     * Construct a new user bias model.
      * @param global The global bias.
+     * @param users The user biases.
      * @param items The item biases.
      */
-    public ItemBiasModel(double global, Long2DoubleMap items) {
+    public UserItemBiasModel(double global, Long2DoubleMap users, Long2DoubleMap items) {
         intercept = global;
+        userBiases = Long2DoubleSortedArrayMap.create(users);
         itemBiases = Long2DoubleSortedArrayMap.create(items);
     }
 
@@ -58,7 +61,7 @@ public class ItemBiasModel implements BiasModel, Serializable {
 
     @Override
     public double getUserBias(long user) {
-        return 0;
+        return userBiases.get(user);
     }
 
     @Override

--- a/lenskit-core/src/main/java/org/lenskit/bias/package-info.java
+++ b/lenskit-core/src/main/java/org/lenskit/bias/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+/**
+ * User-item bias models, suitable for use in baseline scorers and normalizers.
+ */
+package org.lenskit.bias;

--- a/lenskit-core/src/main/java/org/lenskit/data/dao/EntityCollectionDAO.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/dao/EntityCollectionDAO.java
@@ -63,7 +63,7 @@ public class EntityCollectionDAO extends AbstractDataAccessObject {
      * @param data The data to store in the DAO.
      * @return The DAO.
      */
-    public static EntityCollectionDAO create(Collection<Entity> data) {
+    public static EntityCollectionDAO create(Collection<? extends Entity> data) {
         return newBuilder().addEntities(data).build();
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/data/dao/EntityCollectionDAOBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/dao/EntityCollectionDAOBuilder.java
@@ -116,7 +116,7 @@ public class EntityCollectionDAOBuilder {
      * @param entities The entity list.
      * @return The builder (for chaining).
      */
-    public EntityCollectionDAOBuilder addEntities(Iterable<Entity> entities) {
+    public EntityCollectionDAOBuilder addEntities(Iterable<? extends Entity> entities) {
         for (Entity e: entities) {
             addEntity(e);
         }

--- a/lenskit-core/src/main/java/org/lenskit/util/collections/LongUtils.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/collections/LongUtils.java
@@ -177,6 +177,23 @@ public final class LongUtils {
     }
 
     /**
+     * Get a Fastutil {@link LongSet} from a {@link java.util.Collection} of longs.
+     *
+     * @param longs The set of longs.
+     * @return {@code longs} as a fastutil {@link LongSet}. If {@code longs} is already
+     *         a LongSet, it is cast.
+     */
+    public static LongSet asLongSet(@Nullable final Collection<Long> longs) {
+        if (longs == null) {
+            return null;
+        } else if (longs instanceof Set) {
+            return asLongSet((Set<Long>) longs);
+        } else {
+            return SortedKeyIndex.fromCollection(longs).keySet();
+        }
+    }
+
+    /**
      * Compute the ranks for a list of longs.
      * @param results The list of longs.
      * @return The map of ranks; its default return value will be -1.

--- a/lenskit-core/src/main/java/org/lenskit/util/collections/LongUtils.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/collections/LongUtils.java
@@ -292,6 +292,23 @@ public final class LongUtils {
      * @param b The second set.
      * @return The elements of <var>items</var> that are not in <var>exclude</var>.
      */
+    public static LongSortedSet setUnion(LongSet a, LongSet b) {
+        if (a instanceof LongSortedSet && b instanceof LongSortedSet) {
+            return setUnion((LongSortedSet) a, (LongSortedSet) b);
+        } else {
+            LongSet set = new LongOpenHashSet(a);
+            set.addAll(b);
+            return packedSet(set);
+        }
+    }
+
+    /**
+     * Compute the union of two sets.
+     *
+     * @param a The first set.
+     * @param b The second set.
+     * @return The elements of <var>items</var> that are not in <var>exclude</var>.
+     */
     public static LongSortedSet setUnion(LongSortedSet a, LongSortedSet b) {
         long[] data = new long[unionSize(a, b)];
 
@@ -327,6 +344,71 @@ public final class LongUtils {
         assert i == data.length;
 
         return SortedKeyIndex.wrap(data, data.length).keySet();
+    }
+
+    /**
+     * Compute the intersection of two sets.
+     *
+     * @param a The first set.
+     * @param b The second set.
+     * @return The elements present in both sets.
+     */
+    public static LongSortedSet setIntersect(LongSet a, LongSet b) {
+        if (a instanceof LongSortedSet && b instanceof LongSortedSet) {
+            return setIntersect((LongSortedSet) a, (LongSortedSet) b);
+        } else if (a.size() <= b.size()) {
+            LongArrayList longs = new LongArrayList(Math.min(a.size(), b.size()));
+            LongIterator iter = a.iterator();
+            while (iter.hasNext()) {
+                long key = iter.nextLong();
+                if (b.contains(key)) {
+                    longs.add(key);
+                }
+            }
+            return LongUtils.packedSet(longs);
+        } else {
+            return setIntersect(b, a);
+        }
+    }
+
+    /**
+     * Compute the intersection of two sets.
+     *
+     * @param a The first set.
+     * @param b The second set.
+     * @return The elements present in both sets.
+     */
+    public static LongSortedSet setIntersect(LongSortedSet a, LongSortedSet b) {
+        long[] data = new long[Math.min(a.size(), b.size())];
+
+        LongIterator ait = a.iterator();
+        LongIterator bit = b.iterator();
+        boolean hasA = ait.hasNext();
+        boolean hasB = bit.hasNext();
+        long nextA = hasA ? ait.nextLong() : Long.MAX_VALUE;
+        long nextB = hasB ? bit.nextLong() : Long.MAX_VALUE;
+        int i = 0;
+        while (hasA && hasB) {
+            if (nextA < nextB) {
+                hasA = ait.hasNext();
+                nextA = hasA ? ait.nextLong() : Long.MAX_VALUE;
+            } else if (nextB < nextA) {
+                hasB = bit.hasNext();
+                nextB = hasB ? bit.nextLong() : Long.MAX_VALUE;
+            } else {
+                // they're both present and equal, use A but advance both
+                data[i++] = nextA;
+                hasA = ait.hasNext();
+                nextA = hasA ? ait.nextLong() : Long.MAX_VALUE;
+                hasB = bit.hasNext();
+                nextB = hasB ? bit.nextLong() : Long.MAX_VALUE;
+            }
+        }
+        if (data.length > i + i / 2) {
+            data = Arrays.copyOf(data, i);
+        }
+
+        return SortedKeyIndex.wrap(data, i).keySet();
     }
 
     /**

--- a/lenskit-core/src/main/java/org/lenskit/util/keys/Long2DoubleSortedArrayMap.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/keys/Long2DoubleSortedArrayMap.java
@@ -55,6 +55,11 @@ public final class Long2DoubleSortedArrayMap extends AbstractLong2DoubleSortedMa
         values = vs;
     }
 
+    /**
+     * Create a new map with existing data.
+     * @param data Use {@link #create(Map)} instead, as it can avoid copying maps that are already packed.
+     */
+    @Deprecated
     public Long2DoubleSortedArrayMap(Map<Long,Double> data) {
         Long2DoubleFunction vf = LongUtils.asLong2DoubleFunction(data);
         keys = SortedKeyIndex.fromCollection(data.keySet());
@@ -129,6 +134,20 @@ public final class Long2DoubleSortedArrayMap extends AbstractLong2DoubleSortedMa
             nvs[i] = values.get(origIndex);
         }
         return wrap(index, nvs);
+    }
+
+    /**
+     * Create a new sorted array map from input data.
+     * @param data The input data.
+     * @return The sorted array map.
+     */
+    @SuppressWarnings("deprecation")
+    public static Long2DoubleSortedArrayMap create(Map<Long,Double> data) {
+        if (data instanceof Long2DoubleSortedArrayMap) {
+            return (Long2DoubleSortedArrayMap) data;
+        } else {
+            return new Long2DoubleSortedArrayMap(data);
+        }
     }
 
     @Override

--- a/lenskit-core/src/main/java/org/lenskit/util/keys/SortedKeyIndex.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/keys/SortedKeyIndex.java
@@ -61,7 +61,7 @@ public abstract class SortedKeyIndex implements KeyIndex, Serializable {
      */
     public static SortedKeyIndex fromCollection(Collection<Long> keys) {
         if (keys instanceof LongSortedArraySet) {
-            return ((LongSortedArraySet) keys).getDomain();
+            return ((LongSortedArraySet) keys).getIndex();
         } else {
             return fromIterator(keys.size(), keys.iterator());
         }

--- a/lenskit-core/src/main/java/org/lenskit/util/math/Vectors.java
+++ b/lenskit-core/src/main/java/org/lenskit/util/math/Vectors.java
@@ -25,6 +25,7 @@ import it.unimi.dsi.fastutil.longs.Long2DoubleFunction;
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.lenskit.util.keys.Long2DoubleSortedArrayMap;
+import org.lenskit.util.keys.SortedKeyIndex;
 
 import java.util.Iterator;
 
@@ -172,6 +173,31 @@ public final class Vectors {
      */
     public static double mean(Long2DoubleMap vec) {
         return sum(vec) / vec.size();
+    }
+
+    /**
+     * Add a scalar to each element of a vector.
+     * @param vec The vector to rescale.
+     * @param val The value to add.
+     * @return A new map with every value in {@code vec} increased by {@code val}.
+     */
+    public static Long2DoubleMap addScalar(Long2DoubleMap vec, double val) {
+        SortedKeyIndex keys = SortedKeyIndex.fromCollection(vec.keySet());
+        final int n = keys.size();
+        double[] values = new double[n];
+        if (vec instanceof Long2DoubleSortedArrayMap) {
+            Long2DoubleSortedArrayMap sorted = (Long2DoubleSortedArrayMap) vec;
+            for (int i = 0; i < n; i++) {
+                assert sorted.getKeyByIndex(i) == keys.getKey(i);
+                values[i] = sorted.getValueByIndex(i) + val;
+            }
+        } else {
+            for (int i = 0; i < n; i++) {
+                values[i] = vec.get(keys.getKey(i)) + val;
+            }
+        }
+
+        return Long2DoubleSortedArrayMap.wrap(keys, values);
     }
 
     private static class DftAdaptingL2DFunction implements Long2DoubleFunction {

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/transform/normalize/BiasItemVectorNormalizerTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/transform/normalize/BiasItemVectorNormalizerTest.java
@@ -1,0 +1,98 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.transform.normalize;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap;
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.junit.Before;
+import org.junit.Test;
+import org.lenskit.bias.BiasModel;
+import org.lenskit.bias.UserItemBiasModel;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class BiasItemVectorNormalizerTest {
+    ItemVectorNormalizer normalizer;
+
+    @Before
+    public void createNormalizer() {
+        Long2DoubleMap items = new Long2DoubleOpenHashMap();
+        items.put(42L, 0.5);
+        items.put(37L, -0.2);
+        Long2DoubleMap users = new Long2DoubleOpenHashMap();
+        users.put(1L, 0.2);
+        users.put(2L, -0.1);
+
+        BiasModel model = new UserItemBiasModel(3.0, users, items);
+        normalizer = new BiasItemVectorNormalizer(model);
+    }
+
+    @Test
+    public void testNormalizeVectorForItem() {
+        VectorTransformation tx = normalizer.makeTransformation(42L, null);
+
+        MutableSparseVector vec = MutableSparseVector.create(1L, 2L, 3L);
+        vec.set(1L, 3.0);
+        vec.set(2L, 3.5);
+        vec.set(3L, 4.0);
+        assertThat(tx.apply(vec), sameInstance(vec));
+        assertThat(vec.get(1L), closeTo(3.0 - 3.0 - 0.5 - 0.2, 0.0001));
+        assertThat(vec.get(2L), closeTo(3.5 - 3.0 - 0.5 + 0.1, 0.0001));
+        assertThat(vec.get(3L), closeTo(4.0 - 3.0 - 0.5, 0.0001));
+    }
+
+    @Test
+    public void testDenormalizeVectorForItem() {
+        VectorTransformation tx = normalizer.makeTransformation(42L, null);
+
+        MutableSparseVector vec = MutableSparseVector.create(1L, 2L, 3L);
+        vec.set(1L, -1.0);
+        vec.set(2L, -0.5);
+        vec.set(3L, 0.2);
+        assertThat(tx.unapply(vec), sameInstance(vec));
+        assertThat(vec.get(1L), closeTo(-1.0 + 3.0 + 0.5 + 0.2, 0.0001));
+        assertThat(vec.get(2L), closeTo(-0.5 + 3.0 + 0.5 - 0.1, 0.0001));
+        assertThat(vec.get(3L), closeTo(0.2 + 3.0 + 0.5, 0.0001));
+    }
+
+    @Test
+    public void testNormalizeValueForItem() {
+        VectorTransformation tx = normalizer.makeTransformation(42L, null);
+        assertThat(tx.apply(1L, 3.7), closeTo(0, 0.0001));
+        assertThat(tx.apply(3L, 3.7), closeTo(0.2, 0.0001));
+    }
+
+    @Test
+    public void testDeormalizeForItem() {
+        VectorTransformation tx = normalizer.makeTransformation(37L, null);
+        assertThat(tx.unapply(1L, 0), closeTo(3.0, 0.0001));
+        assertThat(tx.unapply(3L, 0), closeTo(2.8, 0.0001));
+    }
+
+    @Test
+    public void testForUnknownUser() {
+        VectorTransformation tx = normalizer.makeTransformation(92L, null);
+        assertThat(tx.apply(1L, 4), closeTo(0.8, 0.0001));
+        assertThat(tx.unapply(3L, 1.2), closeTo(4.2, 0.0001));
+    }
+}

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/transform/normalize/BiasUserVectorNormalizerTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/transform/normalize/BiasUserVectorNormalizerTest.java
@@ -1,0 +1,98 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.grouplens.lenskit.transform.normalize;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap;
+import org.grouplens.lenskit.vectors.MutableSparseVector;
+import org.junit.Before;
+import org.junit.Test;
+import org.lenskit.bias.BiasModel;
+import org.lenskit.bias.UserItemBiasModel;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class BiasUserVectorNormalizerTest {
+    UserVectorNormalizer normalizer;
+
+    @Before
+    public void createNormalizer() {
+        Long2DoubleMap users = new Long2DoubleOpenHashMap();
+        users.put(42L, 0.5);
+        users.put(37L, -0.2);
+        Long2DoubleMap items = new Long2DoubleOpenHashMap();
+        items.put(1L, 0.2);
+        items.put(2L, -0.1);
+
+        BiasModel model = new UserItemBiasModel(3.0, users, items);
+        normalizer = new BiasUserVectorNormalizer(model);
+    }
+
+    @Test
+    public void testNormalizeVectorForUser() {
+        VectorTransformation tx = normalizer.makeTransformation(42L, null);
+
+        MutableSparseVector vec = MutableSparseVector.create(1L, 2L, 3L);
+        vec.set(1L, 3.0);
+        vec.set(2L, 3.5);
+        vec.set(3L, 4.0);
+        assertThat(tx.apply(vec), sameInstance(vec));
+        assertThat(vec.get(1L), closeTo(3.0 - 3.0 - 0.5 - 0.2, 0.0001));
+        assertThat(vec.get(2L), closeTo(3.5 - 3.0 - 0.5 + 0.1, 0.0001));
+        assertThat(vec.get(3L), closeTo(4.0 - 3.0 - 0.5, 0.0001));
+    }
+
+    @Test
+    public void testDenormalizeVectorForUser() {
+        VectorTransformation tx = normalizer.makeTransformation(42L, null);
+
+        MutableSparseVector vec = MutableSparseVector.create(1L, 2L, 3L);
+        vec.set(1L, -1.0);
+        vec.set(2L, -0.5);
+        vec.set(3L, 0.2);
+        assertThat(tx.unapply(vec), sameInstance(vec));
+        assertThat(vec.get(1L), closeTo(-1.0 + 3.0 + 0.5 + 0.2, 0.0001));
+        assertThat(vec.get(2L), closeTo(-0.5 + 3.0 + 0.5 - 0.1, 0.0001));
+        assertThat(vec.get(3L), closeTo(0.2 + 3.0 + 0.5, 0.0001));
+    }
+
+    @Test
+    public void testNormalizeValueForUser() {
+        VectorTransformation tx = normalizer.makeTransformation(42L, null);
+        assertThat(tx.apply(1L, 3.7), closeTo(0, 0.0001));
+        assertThat(tx.apply(3L, 3.7), closeTo(0.2, 0.0001));
+    }
+
+    @Test
+    public void testDeormalizeForUser() {
+        VectorTransformation tx = normalizer.makeTransformation(37L, null);
+        assertThat(tx.unapply(1L, 0), closeTo(3.0, 0.0001));
+        assertThat(tx.unapply(3L, 0), closeTo(2.8, 0.0001));
+    }
+
+    @Test
+    public void testForUnknownUser() {
+        VectorTransformation tx = normalizer.makeTransformation(92L, null);
+        assertThat(tx.apply(1L, 4), closeTo(0.8, 0.0001));
+        assertThat(tx.unapply(3L, 1.2), closeTo(4.2, 0.0001));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/bias/BiasItemScorerTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/BiasItemScorerTest.java
@@ -1,0 +1,179 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.lenskit.LenskitConfiguration;
+import org.lenskit.LenskitRecommender;
+import org.lenskit.api.ItemScorer;
+import org.lenskit.api.Result;
+import org.lenskit.api.ResultMap;
+import org.lenskit.baseline.GlobalMeanRatingItemScorer;
+import org.lenskit.data.dao.DataAccessObject;
+import org.lenskit.data.dao.file.StaticDataSource;
+import org.lenskit.data.entities.EntityFactory;
+import org.lenskit.data.ratings.Rating;
+import org.lenskit.data.ratings.RatingSummary;
+import org.lenskit.util.collections.LongUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Created by MichaelEkstrand on 10/8/2016.
+ */
+public class BiasItemScorerTest {
+    private static final double RATINGS_DAT_MEAN = 3.75;
+    private StaticDataSource source;
+    private DataAccessObject dao;
+    private LenskitConfiguration config;
+
+    @Before
+    public void createRatingSource() {
+        EntityFactory efac = new EntityFactory();
+        List<Rating> rs = new ArrayList<>();
+        rs.add(efac.rating(1, 5, 2));
+        rs.add(efac.rating(1, 7, 4));
+        rs.add(efac.rating(8, 4, 5));
+        rs.add(efac.rating(8, 5, 4));
+
+        source = new StaticDataSource();
+        source.addSource(rs);
+        dao = source.get();
+
+        config = new LenskitConfiguration();
+        config.bind(ItemScorer.class).to(BiasItemScorer.class);
+    }
+
+    public ItemScorer makeGlobalMean() {
+        return new GlobalMeanRatingItemScorer(RatingSummary.create(dao));
+    }
+
+    @Test
+    public void testGlobalMeanBias() {
+        config.bind(BiasModel.class).to(GlobalBiasModel.class);
+        ItemScorer pred = LenskitRecommender.build(config, dao).getItemScorer();
+        assertThat(pred, notNullValue());
+        Result score = pred.score(10L, 2L);
+        assertThat(score.getScore(), closeTo(RATINGS_DAT_MEAN, 0.00001));
+    }
+
+    @Test
+    public void testUserMeanBaseline() {
+        config.bind(BiasModel.class).to(UserBiasModel.class);
+        ItemScorer pred = LenskitRecommender.build(config, dao).getItemScorer();
+        assertThat(pred, notNullValue());
+
+        // unseen item
+        assertThat(pred.score(8, 4).getScore(), closeTo(4.5, 0.001));
+        // seen item - should be same avg
+        assertThat(pred.score(8, 10).getScore(), closeTo(4.5, 0.001));
+        // unseen user - should be global mean
+        assertThat(pred.score(10, 10).getScore(), closeTo(RATINGS_DAT_MEAN, 0.001));
+    }
+
+    @Test
+    public void testItemMeanBaseline() {
+        config.bind(BiasModel.class).to(ItemBiasModel.class);
+        ItemScorer pred = LenskitRecommender.build(config, dao).getItemScorer();
+        assertThat(pred, notNullValue());
+
+        // unseen item, should be global mean
+        assertThat(pred.score(10, 2).getScore(),
+                   closeTo(RATINGS_DAT_MEAN, 0.001));
+        // seen item - should be item average
+        assertThat(pred.score(10, 5).getScore(),
+                   closeTo(3.0, 0.001));
+    }
+
+    @Test
+    public void testUserItemMeanBaseline() {
+        config.bind(BiasModel.class).to(UserItemBiasModel.class);
+        ItemScorer pred = LenskitRecommender.build(config, dao).getItemScorer();
+        assertThat(pred, notNullValue());
+
+        // we use user 8 - their average offset is 0.5
+        // unseen item, should be global mean + user offset
+        assertThat(pred.score(8, 10).getScore(),
+                   closeTo(RATINGS_DAT_MEAN + 0.5, 0.001));
+
+        // seen item - should be item average + user offset
+        assertThat(pred.score(8, 5).getScore(),
+                   closeTo(3.5, 0.001));
+
+        // seen item, unknown user - should be item average
+        assertThat(pred.score(28, 5).getScore(),
+                   closeTo(3, 0.001));
+    }
+
+    @Test
+    public void testLiveItemMeanBaseline() {
+        config.bind(BiasModel.class).to(LiveUserItemBiasModel.class);
+        ItemScorer pred = LenskitRecommender.build(config, dao).getItemScorer();
+        assertThat(pred, notNullValue());
+
+        // we use user 8 - their average offset is 0.5
+        // unseen item, should be global mean + user offset
+        assertThat(pred.score(8, 10).getScore(),
+                   closeTo(RATINGS_DAT_MEAN + 0.5, 0.001));
+
+        // seen item - should be item average + user offset
+        assertThat(pred.score(8, 5).getScore(),
+                   closeTo(3.5, 0.001));
+
+        // seen item, unknown user - should be item average
+        assertThat(pred.score(28, 5).getScore(),
+                   closeTo(3, 0.001));
+    }
+
+    @Test
+    public void testUserItemMeanBaselineMultiRec() {
+        config.bind(BiasModel.class).to(UserItemBiasModel.class);
+        ItemScorer pred = LenskitRecommender.build(config, dao).getItemScorer();
+        assertThat(pred, notNullValue());
+
+        // we use user 8 - their average offset is 0.5
+        // unseen item, should be global mean + user offset
+        assertThat(pred.score(8, 10).getScore(),
+                   closeTo(RATINGS_DAT_MEAN + 0.5, 0.001));
+
+        // seen item - should be item average + user offset
+        assertThat(pred.score(8, 5).getScore(),
+                   closeTo(3.5, 0.001));
+
+        ResultMap results = pred.scoreWithDetails(8, LongUtils.packedSet(5, 10));
+        assertThat(results.getScore(10),
+                   closeTo(RATINGS_DAT_MEAN + 0.5, 0.001));
+        assertThat(results.getScore(5),
+                   closeTo(3.5, 0.001));
+
+        Map<Long, Double> basic = pred.score(8, LongUtils.packedSet(5, 10));
+        assertThat(basic.get(10L),
+                   closeTo(RATINGS_DAT_MEAN + 0.5, 0.001));
+        assertThat(basic.get(5L),
+                   closeTo(3.5, 0.001));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/bias/GlobalBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/GlobalBiasModelTest.java
@@ -1,0 +1,43 @@
+package org.lenskit.bias;
+
+import org.junit.Test;
+import org.lenskit.data.dao.EntityCollectionDAOBuilder;
+import org.lenskit.data.entities.EntityFactory;
+
+import javax.inject.Provider;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class GlobalBiasModelTest {
+    @Test
+    public void testZeroBias() {
+        BiasModel model = new GlobalBiasModel(0);
+        assertThat(model.getIntercept(), equalTo(0.0));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testBasicBias() {
+        BiasModel model = new GlobalBiasModel(Math.PI);
+        assertThat(model.getIntercept(), equalTo(Math.PI));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testComputeGlobalMean() {
+        EntityFactory efac = new EntityFactory();
+        EntityCollectionDAOBuilder daoBuilder = new EntityCollectionDAOBuilder();
+        daoBuilder.addEntities(efac.rating(100, 200, 3.0),
+                               efac.rating(101, 200, 4.0),
+                               efac.rating(101, 201, 2.5),
+                               efac.rating(102, 203, 4.5));
+        Provider<GlobalBiasModel> biasProvider = new GlobalAverageRatingBiasModelProvider(daoBuilder.build());
+        BiasModel model = biasProvider.get();
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-1));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/bias/GlobalBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/GlobalBiasModelTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.bias;
 
 import org.junit.Test;

--- a/lenskit-core/src/test/java/org/lenskit/bias/ItemBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/ItemBiasModelTest.java
@@ -1,3 +1,23 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.lenskit.bias;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;

--- a/lenskit-core/src/test/java/org/lenskit/bias/ItemBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/ItemBiasModelTest.java
@@ -1,0 +1,53 @@
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
+import org.junit.Test;
+import org.lenskit.LenskitConfiguration;
+import org.lenskit.LenskitRecommender;
+import org.lenskit.data.dao.EntityCollectionDAOBuilder;
+import org.lenskit.data.entities.EntityFactory;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ItemBiasModelTest {
+    @Test
+    public void testNoItems() {
+        BiasModel model = new ItemBiasModel(1.5, Long2DoubleMaps.EMPTY_MAP);
+        assertThat(model.getIntercept(), equalTo(1.5));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testWithItems() {
+        BiasModel model = new ItemBiasModel(1.5, Long2DoubleMaps.singleton(42L, 1.0));
+        assertThat(model.getIntercept(), equalTo(1.5));
+        assertThat(model.getItemBias(42L), equalTo(1.0));
+        assertThat(model.getItemBias(37L), equalTo(0.0));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testComputeMeans() {
+        EntityFactory efac = new EntityFactory();
+        EntityCollectionDAOBuilder daoBuilder = new EntityCollectionDAOBuilder();
+        daoBuilder.addEntities(efac.rating(100, 200, 3.0),
+                               efac.rating(101, 200, 4.0),
+                               efac.rating(101, 201, 2.5),
+                               efac.rating(102, 203, 4.5),
+                               efac.rating(103, 203, 3.5));
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.addRoot(BiasModel.class);
+        config.bind(BiasModel.class).toProvider(ItemAverageRatingBiasModelProvider.class);
+
+        LenskitRecommender rec = LenskitRecommender.build(config, daoBuilder.build());
+        BiasModel model = rec.get(BiasModel.class);
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-3));
+        assertThat(model.getItemBias(200), closeTo(0.0, 1.0e-3));
+        assertThat(model.getItemBias(201), closeTo(-1.0, 1.0e-3));
+        assertThat(model.getItemBias(203), closeTo(0.5, 1.0e-3));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/bias/LiveUserItemBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/LiveUserItemBiasModelTest.java
@@ -1,0 +1,71 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+import org.lenskit.LenskitConfiguration;
+import org.lenskit.LenskitRecommender;
+import org.lenskit.LenskitRecommenderEngine;
+import org.lenskit.data.dao.EntityCollectionDAO;
+import org.lenskit.data.entities.EntityFactory;
+import org.lenskit.data.ratings.Rating;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.*;
+
+/**
+ * Created by MichaelEkstrand on 10/1/2016.
+ */
+public class LiveUserItemBiasModelTest {
+    @Test
+    public void testComputeAllMeans() {
+        EntityFactory efac = new EntityFactory();
+        List<Rating> ratings = Lists.newArrayList(efac.rating(100, 200, 3.0),
+                                                  efac.rating(101, 200, 4.0),
+                                                  efac.rating(102, 201, 2.5),
+                                                  efac.rating(102, 203, 4.5),
+                                                  efac.rating(101, 203, 3.5));
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.addRoot(BiasModel.class);
+        config.bind(BiasModel.class).to(LiveUserItemBiasModel.class);
+
+        LenskitRecommenderEngine engine = LenskitRecommenderEngine.build(config, EntityCollectionDAO.create(ratings));
+
+        ratings.add(efac.rating(105, 200, 4.5));
+        ratings.add(efac.rating(105, 203, 4.8));
+
+        LenskitRecommender rec = engine.createRecommender(EntityCollectionDAO.create(ratings));
+        BiasModel model = rec.get(BiasModel.class);
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-3));
+        assertThat(model.getItemBias(200), closeTo(0.0, 1.0e-3));
+        assertThat(model.getItemBias(201), closeTo(-1.0, 1.0e-3));
+        assertThat(model.getItemBias(203), closeTo(0.5, 1.0e-3));
+        assertThat(model.getUserBias(100), closeTo(-0.5, 1.0e-3));
+        assertThat(model.getUserBias(101), closeTo(0, 1.0e-3));
+        assertThat(model.getUserBias(102), closeTo(0.25, 1.0e-3));
+
+        assertThat(model.getUserBias(105), closeTo(0.9, 1.0e-3));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/bias/UserBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/UserBiasModelTest.java
@@ -1,0 +1,73 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
+import org.junit.Test;
+import org.lenskit.LenskitConfiguration;
+import org.lenskit.LenskitRecommender;
+import org.lenskit.data.dao.EntityCollectionDAOBuilder;
+import org.lenskit.data.entities.EntityFactory;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class UserBiasModelTest {
+    @Test
+    public void testNoUsers() {
+        BiasModel model = new UserBiasModel(1.5, Long2DoubleMaps.EMPTY_MAP);
+        assertThat(model.getIntercept(), equalTo(1.5));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testWithUsers() {
+        BiasModel model = new UserBiasModel(1.5, Long2DoubleMaps.singleton(42L, 1.0));
+        assertThat(model.getIntercept(), equalTo(1.5));
+        assertThat(model.getUserBias(42L), equalTo(1.0));
+        assertThat(model.getUserBias(37L), equalTo(0.0));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testComputeMeans() {
+        EntityFactory efac = new EntityFactory();
+        EntityCollectionDAOBuilder daoBuilder = new EntityCollectionDAOBuilder();
+        daoBuilder.addEntities(efac.rating(100, 200, 3.0),
+                               efac.rating(101, 200, 4.0),
+                               efac.rating(102, 201, 2.5),
+                               efac.rating(102, 203, 4.5),
+                               efac.rating(101, 203, 3.5));
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.addRoot(BiasModel.class);
+        config.bind(BiasModel.class).to(UserBiasModel.class);
+
+        LenskitRecommender rec = LenskitRecommender.build(config, daoBuilder.build());
+        BiasModel model = rec.get(BiasModel.class);
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-3));
+        assertThat(model.getUserBias(100), closeTo(-0.5, 1.0e-3));
+        assertThat(model.getUserBias(101), closeTo(0.25, 1.0e-3));
+        assertThat(model.getUserBias(102), closeTo(0.0, 1.0e-3));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/bias/UserItemBiasModelTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/bias/UserItemBiasModelTest.java
@@ -1,0 +1,138 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2014 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.bias;
+
+import it.unimi.dsi.fastutil.longs.Long2DoubleMaps;
+import org.junit.Test;
+import org.lenskit.LenskitConfiguration;
+import org.lenskit.LenskitRecommender;
+import org.lenskit.data.dao.EntityCollectionDAOBuilder;
+import org.lenskit.data.entities.EntityFactory;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class UserItemBiasModelTest {
+    @Test
+    public void testZeroBias() {
+        BiasModel model = new UserItemBiasModel(0, Long2DoubleMaps.EMPTY_MAP, Long2DoubleMaps.EMPTY_MAP);
+        assertThat(model.getIntercept(), equalTo(0.0));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testBasicBias() {
+        BiasModel model = new UserItemBiasModel(Math.PI, Long2DoubleMaps.EMPTY_MAP, Long2DoubleMaps.EMPTY_MAP);
+        assertThat(model.getIntercept(), equalTo(Math.PI));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testWithItems() {
+        BiasModel model = new UserItemBiasModel(1.5, Long2DoubleMaps.EMPTY_MAP,
+                                                Long2DoubleMaps.singleton(42L, 1.0));
+        assertThat(model.getIntercept(), equalTo(1.5));
+        assertThat(model.getItemBias(42L), equalTo(1.0));
+        assertThat(model.getItemBias(37L), equalTo(0.0));
+        assertThat(model.getUserBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testWithUsers() {
+        BiasModel model = new UserItemBiasModel(1.5, Long2DoubleMaps.singleton(42L, 1.0), Long2DoubleMaps.EMPTY_MAP);
+        assertThat(model.getIntercept(), equalTo(1.5));
+        assertThat(model.getUserBias(42L), equalTo(1.0));
+        assertThat(model.getUserBias(37L), equalTo(0.0));
+        assertThat(model.getItemBias(42L), equalTo(0.0));
+    }
+
+    @Test
+    public void testComputeItemMeans() {
+        EntityFactory efac = new EntityFactory();
+        EntityCollectionDAOBuilder daoBuilder = new EntityCollectionDAOBuilder();
+        daoBuilder.addEntities(efac.rating(100, 200, 3.0),
+                               efac.rating(101, 200, 4.0),
+                               efac.rating(101, 201, 2.5),
+                               efac.rating(102, 203, 4.5),
+                               efac.rating(103, 203, 3.5));
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.addRoot(BiasModel.class);
+        config.bind(BiasModel.class).toProvider(ItemAverageRatingBiasModelProvider.class);
+
+        LenskitRecommender rec = LenskitRecommender.build(config, daoBuilder.build());
+        BiasModel model = rec.get(BiasModel.class);
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-3));
+        assertThat(model.getItemBias(200), closeTo(0.0, 1.0e-3));
+        assertThat(model.getItemBias(201), closeTo(-1.0, 1.0e-3));
+        assertThat(model.getItemBias(203), closeTo(0.5, 1.0e-3));
+    }
+
+    @Test
+    public void testComputeUserMeans() {
+        EntityFactory efac = new EntityFactory();
+        EntityCollectionDAOBuilder daoBuilder = new EntityCollectionDAOBuilder();
+        daoBuilder.addEntities(efac.rating(100, 200, 3.0),
+                               efac.rating(101, 200, 4.0),
+                               efac.rating(102, 201, 2.5),
+                               efac.rating(102, 203, 4.5),
+                               efac.rating(101, 203, 3.5));
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.addRoot(BiasModel.class);
+        config.bind(BiasModel.class).toProvider(UserAverageRatingBiasModelProvider.class);
+
+        LenskitRecommender rec = LenskitRecommender.build(config, daoBuilder.build());
+        BiasModel model = rec.get(BiasModel.class);
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-3));
+        assertThat(model.getUserBias(100), closeTo(-0.5, 1.0e-3));
+        assertThat(model.getUserBias(101), closeTo(0.25, 1.0e-3));
+        assertThat(model.getUserBias(102), closeTo(0.0, 1.0e-3));
+    }
+
+    @Test
+    public void testComputeAllMeans() {
+        EntityFactory efac = new EntityFactory();
+        EntityCollectionDAOBuilder daoBuilder = new EntityCollectionDAOBuilder();
+        daoBuilder.addEntities(efac.rating(100, 200, 3.0),
+                               efac.rating(101, 200, 4.0),
+                               efac.rating(102, 201, 2.5),
+                               efac.rating(102, 203, 4.5),
+                               efac.rating(101, 203, 3.5));
+        LenskitConfiguration config = new LenskitConfiguration();
+        config.addRoot(BiasModel.class);
+        config.bind(BiasModel.class).toProvider(UserItemAverageRatingBiasModelProvider.class);
+
+        LenskitRecommender rec = LenskitRecommender.build(config, daoBuilder.build());
+        BiasModel model = rec.get(BiasModel.class);
+
+        assertThat(model.getIntercept(), closeTo(3.5, 1.0e-3));
+        assertThat(model.getItemBias(200), closeTo(0.0, 1.0e-3));
+        assertThat(model.getItemBias(201), closeTo(-1.0, 1.0e-3));
+        assertThat(model.getItemBias(203), closeTo(0.5, 1.0e-3));
+        assertThat(model.getUserBias(100), closeTo(-0.5, 1.0e-3));
+        assertThat(model.getUserBias(101), closeTo(0, 1.0e-3));
+        assertThat(model.getUserBias(102), closeTo(0.25, 1.0e-3));
+    }
+}

--- a/lenskit-core/src/test/java/org/lenskit/util/keys/Long2DoubleSortedArrayMapTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/util/keys/Long2DoubleSortedArrayMapTest.java
@@ -133,6 +133,25 @@ public class Long2DoubleSortedArrayMapTest {
     }
 
     @Test
+    public void testSubMap() {
+        SortedKeyIndex idx = SortedKeyIndex.create(1, 2, 3, 4, 5);
+        double[] values = { 1.5, 2.4, -3.2, 4.3, -5.7 };
+        Long2DoubleSortedArrayMap map = new Long2DoubleSortedArrayMap(idx, values);
+        assertThat(map.size(), equalTo(5));
+
+        Long2DoubleSortedMap sub = map.subMap(LongUtils.packedSet(2L, 4L));
+        assertThat(sub.size(), equalTo(2));
+        assertThat(sub.containsKey(2L), equalTo(true));
+        assertThat(sub.containsKey(1L), equalTo(false));
+        assertThat(sub.containsKey(5L), equalTo(false));
+        assertThat(sub.containsKey(4L), equalTo(true));
+        assertThat(sub.containsKey(3L), equalTo(false));
+        assertThat(sub.keySet(), contains(2L, 4L));
+        assertThat(sub, hasEntry(2L, 2.4));
+        assertThat(sub, hasEntry(4L, 4.3));
+    }
+
+    @Test
     public void testIterStartFrom() {
         double[] values = { 1.5, 2.4, -3.2, 4.3, -5.7 };
         Long2DoubleSortedMap map = new Long2DoubleSortedArrayMap(SortedKeyIndex.create(1, 2, 3, 4, 5),

--- a/lenskit-core/src/test/java/org/lenskit/util/math/VectorsTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/util/math/VectorsTest.java
@@ -106,4 +106,34 @@ public class VectorsTest {
             }
         }
     }
+
+    @Test
+    public void testAddScalar() {
+        for (Map<Long,Double> map: someMaps(longs(), doubles(-1000, 1000))) {
+            double scalar = doubles(-250, 250).next();
+            Long2DoubleMap m = new Long2DoubleOpenHashMap(map);
+
+            Long2DoubleMap result = Vectors.addScalar(m, scalar);
+            assertThat(Vectors.sum(result), closeTo(Vectors.sum(m) + m.size() * scalar, 1.0e-6));
+
+            for (long key: result.keySet()) {
+                assertThat(result.get(key), closeTo(map.get(key) + scalar, 1.0e-6));
+            }
+        }
+    }
+
+    @Test
+    public void testAddScalarSorted() {
+        for (Map<Long,Double> map: someMaps(longs(), doubles(-1000, 1000))) {
+            double scalar = doubles(-250, 250).next();
+            Long2DoubleMap m = Long2DoubleSortedArrayMap.create(map);
+
+            Long2DoubleMap result = Vectors.addScalar(m, scalar);
+            assertThat(Vectors.sum(result), closeTo(Vectors.sum(m) + m.size() * scalar, 1.0e-6));
+
+            for (long key: result.keySet()) {
+                assertThat(result.get(key), closeTo(map.get(key) + scalar, 1.0e-6));
+            }
+        }
+    }
 }

--- a/lenskit-integration-tests/src/it/gradle/gradle.properties
+++ b/lenskit-integration-tests/src/it/gradle/gradle.properties
@@ -1,2 +1,2 @@
-lenskit.maxMemory=256m
+lenskit.maxMemory=384m
 lenskit.threadCount=3

--- a/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemAccuracyTest.groovy
@@ -21,18 +21,17 @@
 package org.lenskit.knn.item
 
 import org.grouplens.lenskit.test.CrossfoldTestSuite
-import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
+import org.grouplens.lenskit.transform.normalize.BiasUserVectorNormalizer
 import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
 import org.grouplens.lenskit.vectors.similarity.SimilarityDamping
 import org.lenskit.LenskitConfiguration
 import org.lenskit.api.ItemScorer
 import org.lenskit.baseline.BaselineScorer
-import org.lenskit.baseline.ItemMeanRatingItemScorer
-import org.lenskit.baseline.UserMeanBaseline
-import org.lenskit.baseline.UserMeanItemScorer
+import org.lenskit.bias.BiasItemScorer
+import org.lenskit.bias.BiasModel
+import org.lenskit.bias.UserItemBiasModel
 import org.lenskit.config.ConfigHelpers
 import org.lenskit.eval.traintest.SimpleEvaluator
-import org.lenskit.eval.traintest.TrainTestExperiment
 import org.lenskit.eval.traintest.recommend.RecommendEvalTask
 import org.lenskit.eval.traintest.recommend.TopNMAPMetric
 import org.lenskit.knn.NeighborhoodSize
@@ -60,9 +59,9 @@ public class ItemItemAccuracyTest extends CrossfoldTestSuite {
     protected void configureAlgorithm(LenskitConfiguration config) {
         ConfigHelpers.configure(config) {
             bind ItemScorer to ItemItemScorer
-            bind (BaselineScorer, ItemScorer) to UserMeanItemScorer
-            bind (UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
-            bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
+            bind (BaselineScorer, ItemScorer) to BiasItemScorer
+            bind BiasModel to UserItemBiasModel
+            bind UserVectorNormalizer to BiasUserVectorNormalizer
             within (ItemSimilarity) {
                 set SimilarityDamping to 100.0
             }

--- a/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemBuildSerializeTest.groovy
@@ -21,7 +21,7 @@
 package org.lenskit.knn.item
 
 import org.grouplens.lenskit.test.ML100KTestSuite
-import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
+import org.grouplens.lenskit.transform.normalize.BiasUserVectorNormalizer
 import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
 import org.junit.Test
 import org.lenskit.LenskitRecommender
@@ -30,14 +30,15 @@ import org.lenskit.ModelDisposition
 import org.lenskit.api.ItemScorer
 import org.lenskit.api.RecommenderBuildException
 import org.lenskit.baseline.BaselineScorer
-import org.lenskit.baseline.ItemMeanRatingItemScorer
-import org.lenskit.baseline.UserMeanBaseline
-import org.lenskit.baseline.UserMeanItemScorer
+import org.lenskit.bias.BiasItemScorer
+import org.lenskit.bias.BiasModel
+import org.lenskit.bias.UserItemBiasModel
 import org.lenskit.config.ConfigHelpers
 import org.lenskit.data.dao.ItemDAO
 import org.lenskit.knn.item.model.ItemItemModel
 
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.notNullValue
 import static org.junit.Assert.assertThat
 
 /**
@@ -48,9 +49,9 @@ import static org.junit.Assert.assertThat
 public class ItemItemBuildSerializeTest extends ML100KTestSuite {
     def config = ConfigHelpers.load {
         bind ItemScorer to ItemItemScorer
-        bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
-        bind(BaselineScorer, ItemScorer) to UserMeanItemScorer
-        bind(UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
+        bind (BaselineScorer, ItemScorer) to BiasItemScorer
+        bind BiasModel to UserItemBiasModel
+        bind UserVectorNormalizer to BiasUserVectorNormalizer
         root ItemDAO
     }
 

--- a/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemPopBlendAccuracyTest.groovy
+++ b/lenskit-integration-tests/src/test/groovy/org/lenskit/knn/item/ItemItemPopBlendAccuracyTest.groovy
@@ -21,17 +21,17 @@
 package org.lenskit.knn.item
 
 import org.grouplens.lenskit.test.CrossfoldTestSuite
-import org.grouplens.lenskit.transform.normalize.BaselineSubtractingUserVectorNormalizer
+import org.grouplens.lenskit.transform.normalize.BiasUserVectorNormalizer
 import org.grouplens.lenskit.transform.normalize.UserVectorNormalizer
 import org.grouplens.lenskit.vectors.similarity.SimilarityDamping
 import org.lenskit.LenskitConfiguration
 import org.lenskit.api.ItemRecommender
 import org.lenskit.api.ItemScorer
 import org.lenskit.baseline.BaselineScorer
-import org.lenskit.baseline.ItemMeanRatingItemScorer
-import org.lenskit.baseline.UserMeanBaseline
-import org.lenskit.baseline.UserMeanItemScorer
 import org.lenskit.basic.PopularityRankItemScorer
+import org.lenskit.bias.BiasItemScorer
+import org.lenskit.bias.BiasModel
+import org.lenskit.bias.UserItemBiasModel
 import org.lenskit.config.ConfigHelpers
 import org.lenskit.eval.traintest.SimpleEvaluator
 import org.lenskit.eval.traintest.recommend.ItemSelector
@@ -39,9 +39,7 @@ import org.lenskit.eval.traintest.recommend.RecommendEvalTask
 import org.lenskit.eval.traintest.recommend.TopNMAPMetric
 import org.lenskit.eval.traintest.recommend.TopNMRRMetric
 import org.lenskit.hybrid.BlendWeight
-
 import org.lenskit.hybrid.RankBlendingItemRecommender
-
 import org.lenskit.knn.NeighborhoodSize
 import org.lenskit.util.table.Table
 
@@ -59,9 +57,9 @@ public class ItemItemPopBlendAccuracyTest extends CrossfoldTestSuite {
     protected void configureAlgorithm(LenskitConfiguration config) {
         ConfigHelpers.configure(config) {
             bind ItemScorer to ItemItemScorer
-            bind (BaselineScorer, ItemScorer) to UserMeanItemScorer
-            bind (UserMeanBaseline, ItemScorer) to ItemMeanRatingItemScorer
-            bind UserVectorNormalizer to BaselineSubtractingUserVectorNormalizer
+            bind (BaselineScorer, ItemScorer) to BiasItemScorer
+            bind BiasModel to UserItemBiasModel
+            bind UserVectorNormalizer to BiasUserVectorNormalizer
             within (ItemSimilarity) {
                 set SimilarityDamping to 100.0
             }


### PR DESCRIPTION
This PR starts adding user-item bias models (#954), to be used as item scorers and normalizers. It is not ready to merge, but I want to better think about whether the design is headed in the right direction.

I do need to add a 'live' user-item model that uses precomputed item means but re-fetches the item means on the fly.