### PR TITLE
Support compound attribute types

### DIFF
--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
@@ -21,6 +21,7 @@
 package org.grouplens.lenskit.util;
 
 import com.google.common.base.Predicate;
+import com.google.common.reflect.TypeToken;
 import org.apache.commons.lang3.ClassUtils;
 
 import javax.annotation.Nullable;
@@ -130,6 +131,22 @@ public class TypeUtils {
             } catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException("Cannot load type name ", e);
             }
+        }
+    }
+
+    public static <T> String makeTypeName(TypeToken<T> type) {
+        // FIXME Handle list types
+        Class<?> raw = type.getRawType();
+        if (raw.equals(String.class)) {
+            return "string";
+        } else if (raw.equals(Double.class)) {
+            return "double";
+        } else if (raw.equals(Integer.class)) {
+            return "int";
+        } else if (raw.equals(Long.class)) {
+            return "long";
+        } else {
+            return raw.getName();
         }
     }
 }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
@@ -110,24 +110,24 @@ public class TypeUtils {
      * @param type The type name to resolve.
      * @return The type.
      */
-    public static Class<?> resolveTypeName(String type) {
+    public static TypeToken<?> resolveTypeName(String type) {
         switch (type) {
         case "string":
         case "String":
-            return String.class;
+            return TypeToken.of(String.class);
         case "int":
         case "Integer":
-            return Integer.class;
+            return TypeToken.of(Integer.class);
         case "long":
         case "Long":
-            return Long.class;
+            return TypeToken.of(Long.class);
         case "double":
         case "real":
         case "Double":
-            return Double.class;
+            return TypeToken.of(Double.class);
         default:
             try {
-                return ClassUtils.getClass(type);
+                return TypeToken.of(ClassUtils.getClass(type));
             } catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException("Cannot load type name ", e);
             }

--- a/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
+++ b/lenskit-core/src/main/java/org/grouplens/lenskit/util/TypeUtils.java
@@ -21,6 +21,7 @@
 package org.grouplens.lenskit.util;
 
 import com.google.common.base.Predicate;
+import org.apache.commons.lang3.ClassUtils;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -101,5 +102,34 @@ public class TypeUtils {
                 return parent.isAssignableFrom(input);
             }
         };
+    }
+
+    /**
+     * Resolve a type name into a type.
+     * @param type The type name to resolve.
+     * @return The type.
+     */
+    public static Class<?> resolveTypeName(String type) {
+        switch (type) {
+        case "string":
+        case "String":
+            return String.class;
+        case "int":
+        case "Integer":
+            return Integer.class;
+        case "long":
+        case "Long":
+            return Long.class;
+        case "double":
+        case "real":
+        case "Double":
+            return Double.class;
+        default:
+            try {
+                return ClassUtils.getClass(type);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException("Cannot load type name ", e);
+            }
+        }
     }
 }

--- a/lenskit-core/src/main/java/org/lenskit/data/dao/file/DelimitedColumnEntityFormat.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/dao/file/DelimitedColumnEntityFormat.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.text.StrTokenizer;
+import org.grouplens.lenskit.util.TypeUtils;
 import org.lenskit.data.entities.*;
 import org.lenskit.util.reflect.InstanceFactory;
 import org.slf4j.Logger;
@@ -240,14 +240,14 @@ public class DelimitedColumnEntityFormat implements EntityFormat {
             for (TypedName<?> col: columns) {
                 ObjectNode colObj = cols.addObject();
                 colObj.put("name", col.getName());
-                colObj.put("type", col.getType().getName());
+                colObj.put("type", TypeUtils.makeTypeName(col.getType()));
             }
         } else if (labeledColumns != null) {
             ObjectNode cols = json.putObject("columns");
             for (Map.Entry<String,TypedName<?>> colE: labeledColumns.entrySet()) {
                 ObjectNode colNode = cols.putObject(colE.getKey());
                 colNode.put("name", colE.getValue().getName());
-                colNode.put("type", colE.getValue().getType().getName());
+                colNode.put("type", TypeUtils.makeTypeName(colE.getValue().getType()));
             }
         } else {
             throw new IllegalStateException("no labels specified");

--- a/lenskit-core/src/main/java/org/lenskit/data/dao/file/JSONEntityFormat.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/dao/file/JSONEntityFormat.java
@@ -26,15 +26,14 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.grouplens.lenskit.util.TypeUtils;
 import org.lenskit.data.entities.*;
 import org.lenskit.util.reflect.InstanceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Entity format that decodes JSON objects.
@@ -44,6 +43,7 @@ public class JSONEntityFormat implements EntityFormat {
     private EntityType entityType;
     private Class<? extends EntityBuilder> entityBuilder = BasicEntityBuilder.class;
     private InstanceFactory<EntityBuilder> builderFactory;
+    private Map<String,TypedName<?>> attributes = new LinkedHashMap<>();
 
     /**
      * Set the entity type.
@@ -97,6 +97,32 @@ public class JSONEntityFormat implements EntityFormat {
         return builderFactory.newInstance();
     }
 
+    /**
+     * Get the attributes expected.
+     * @return The expected attributes.
+     */
+    public Map<String,TypedName<?>> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    /**
+     * Add an attribute to the list of expected attributes.  It will be parsed from the JSON object field of the same
+     * name.
+     * @param attr The attribute to add.
+     */
+    public void addAttribute(TypedName<?> attr) {
+        addAttribute(attr.getName(), attr);
+    }
+
+    /**
+     * Add an attribute to the list of expected attributes, with a JSON field name.
+     * @param name The name of the field as it will appear in JSON.
+     * @param attr The attribute to add.
+     */
+    public void addAttribute(String name, TypedName<?> attr) {
+        attributes.put(name, attr);
+    }
+
     @Override
     public ObjectNode toJSON() {
         JsonNodeFactory nf = JsonNodeFactory.instance;
@@ -104,6 +130,15 @@ public class JSONEntityFormat implements EntityFormat {
         ObjectNode json = nf.objectNode();
         json.put("format", "json");
         json.put("entity_type", entityType.getName());
+
+        if (!attributes.isEmpty()) {
+            ObjectNode attrNode = json.putObject("attributes");
+            for (Map.Entry<String,TypedName<?>> attr: attributes.entrySet()) {
+                ObjectNode an = attrNode.putObject(attr.getKey());
+                an.put("name", attr.getValue().getName());
+                an.put("type", TypeUtils.makeTypeName(attr.getValue().getType()));
+            }
+        }
 
         return json;
     }
@@ -117,6 +152,26 @@ public class JSONEntityFormat implements EntityFormat {
         EntityDefaults entityDefaults = EntityDefaults.lookup(etype);
         format.setEntityType(etype);
         format.setEntityBuilder(entityDefaults != null ? entityDefaults.getDefaultBuilder() : BasicEntityBuilder.class);
+
+        JsonNode attrNode = json.path("attributes");
+        if (attrNode.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fieldIter = attrNode.fields();
+            while (fieldIter.hasNext()) {
+                Map.Entry<String, JsonNode> fieldSpec = fieldIter.next();
+                String fname = fieldSpec.getKey();
+                JsonNode fnode = fieldSpec.getValue();
+                if (fnode.isTextual()) {
+                    format.addAttribute(TypedName.create(fname, fnode.asText()));
+                } else if (fnode.isObject()) {
+                    format.addAttribute(fname, TypedName.create(fnode.get("name").asText(),
+                                                                fnode.get("type").asText()));
+                } else {
+                    throw new IllegalArgumentException("unexpected structure for field " + fname);
+                }
+            }
+        } else if (!attrNode.isMissingNode() && !attrNode.isNull()) {
+            throw new IllegalArgumentException("unexpected structure for fields configuration");
+        }
 
         Class<? extends EntityBuilder> eb = TextEntitySource.parseEntityBuilder(loader, json);
         if (eb != null) {
@@ -137,6 +192,7 @@ public class JSONEntityFormat implements EntityFormat {
     private class JSONLP extends LineEntityParser {
         private final ObjectMapper mapper;
         int lineNo = 0;
+        boolean warned = false;
 
         JSONLP() {
             mapper = new ObjectMapper();
@@ -159,7 +215,10 @@ public class JSONEntityFormat implements EntityFormat {
                 if (idNode != null) {
                     eb.setId(node.get("$id").asLong());
                 } else {
-                    logger.debug("line " + lineNo + ": using -(row number) as id");
+                    if (!warned) {
+                        logger.debug("line {}: using -(row number) as id", lineNo);
+                        warned = true;
+                    }
                     eb.setId(-lineNo);
                 }
                 Iterator<Map.Entry<String,JsonNode>> fields = node.fields();
@@ -169,16 +228,25 @@ public class JSONEntityFormat implements EntityFormat {
                     if (name.startsWith("$")) {
                         continue;
                     }
+                    TypedName<?> attr = attributes.get(name);
+                    if (attr == null && !attributes.isEmpty()) {
+                        // unknown attribute, skip it
+                        continue;
+                    }
+
                     JsonNode fn = field.getValue();
-                    if (fn.isIntegralNumber()) {
-                        eb.setAttribute(TypedName.create(name, Long.class), fn.asLong());
-                    } else if (fn.isFloatingPointNumber()) {
-                        eb.setAttribute(TypedName.create(name, Double.class), fn.asDouble());
-                    } else if (fn.isTextual()) {
-                        eb.setAttribute(TypedName.create(name, String.class), fn.asText());
-                    } else if (fn.isContainerNode()) {
-                        // FIXME Be more flexible about resulting types
-                        eb.setAttribute(TypedName.create(name, JsonNode.class), fn);
+                    if (attr != null) {
+                        eb.setAttribute(attr, mapper.convertValue(fn, attr.getJacksonType()));
+                    } else {
+                        if (fn.isIntegralNumber()) {
+                            eb.setAttribute(TypedName.create(name, Long.class), fn.asLong());
+                        } else if (fn.isFloatingPointNumber()) {
+                            eb.setAttribute(TypedName.create(name, Double.class), fn.asDouble());
+                        } else if (fn.isTextual()) {
+                            eb.setAttribute(TypedName.create(name, String.class), fn.asText());
+                        } else {
+                            eb.setAttribute(TypedName.create(name, JsonNode.class), fn);
+                        }
                     }
                 }
                 return eb.build();

--- a/lenskit-core/src/main/java/org/lenskit/data/dao/file/JSONEntityFormat.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/dao/file/JSONEntityFormat.java
@@ -198,6 +198,7 @@ public class JSONEntityFormat implements EntityFormat {
             mapper = new ObjectMapper();
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public Entity parse(String line) {
             lineNo += 1;
@@ -228,7 +229,7 @@ public class JSONEntityFormat implements EntityFormat {
                     if (name.startsWith("$")) {
                         continue;
                     }
-                    TypedName<?> attr = attributes.get(name);
+                    TypedName attr = attributes.get(name);
                     if (attr == null && !attributes.isEmpty()) {
                         // unknown attribute, skip it
                         continue;

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/AbstractEntity.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/AbstractEntity.java
@@ -64,7 +64,7 @@ public abstract class AbstractEntity implements Entity, Describable {
     @Override
     public boolean hasAttribute(TypedName<?> name) {
         Object value = maybeGet(name.getName());
-        return value != null && name.getType().isInstance(value);
+        return value != null && name.getRawType().isInstance(value);
     }
 
     /**
@@ -178,7 +178,8 @@ public abstract class AbstractEntity implements Entity, Describable {
     @Override
     public <T> T maybeGet(TypedName<T> name) {
         try {
-            return name.getType().cast(maybeGet(name.getName()));
+            // FIXME This is not fully type-safe!
+            return (T) name.getRawType().cast(maybeGet(name.getName()));
         } catch (ClassCastException e) {
             throw new IllegalArgumentException(e);
         }

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/Attribute.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/Attribute.java
@@ -21,6 +21,7 @@
 package org.lenskit.data.entities;
 
 import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -43,7 +44,7 @@ public final class Attribute<T> {
     private Attribute(@Nonnull TypedName<T> name, @Nonnull T val) {
         Preconditions.checkNotNull(name, "name");
         Preconditions.checkNotNull(val, "value");
-        Preconditions.checkArgument(name.getType().isInstance(val), "value-type mismatch");
+        Preconditions.checkArgument(name.getRawType().isInstance(val), "value-type mismatch");
         this.name = name;
         value = val;
     }
@@ -83,7 +84,7 @@ public final class Attribute<T> {
      * @return The attribute's type.
      */
     @Nonnull
-    public Class<T> getType() {
+    public TypeToken<T> getType() {
         return name.getType();
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/BareEntity.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/BareEntity.java
@@ -57,11 +57,12 @@ class BareEntity extends AbstractEntity {
         return name == CommonAttributes.ENTITY_ID;
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <T> T maybeGet(TypedName<T> name) {
         return name == CommonAttributes.ENTITY_ID
-                ? name.getType().cast(getId())
+                ? (T) name.getRawType().cast(getId())
                 : null;
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/BasicEntity.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/BasicEntity.java
@@ -71,20 +71,18 @@ class BasicEntity extends AbstractEntity {
         return attributes.containsKey(name.getName());
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <T> T maybeGet(TypedName<T> name) {
         Attribute<?> attr = attributes.get(name.getName());
         if (attr == null) {
             return null;
-        } else {
-            Class<T> type = name.getType();
+        } else if (attr.getTypedName().equals(name)) {
             Object value = attr.getValue();
-            if (type.isInstance(value)) {
-                return type.cast(value);
-            } else {
-                return null;
-            }
+            return (T) name.getRawType().cast(value);
+        } else {
+            return null;
         }
     }
 

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/BasicEntityBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/BasicEntityBuilder.java
@@ -45,7 +45,7 @@ public class BasicEntityBuilder extends EntityBuilder {
     public <T> EntityBuilder setAttribute(TypedName<T> name, T val) {
         Preconditions.checkNotNull(name, "attribute");
         Preconditions.checkNotNull(val, "value");
-        Preconditions.checkArgument(name.getType().isInstance(val),
+        Preconditions.checkArgument(name.getRawType().isInstance(val),
                                     "value %s not of type %s", val, name.getType());
         if (name == CommonAttributes.ENTITY_ID) {
             return setId(((Long) val).longValue());

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/EntityDefaults.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/EntityDefaults.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
 import org.apache.commons.lang3.ClassUtils;
 import org.grouplens.grapht.util.ClassLoaders;
 
@@ -37,6 +38,7 @@ import java.util.*;
  * Descriptor for the default characteristics of an entity type.
  */
 public class EntityDefaults {
+    private static final TypeToken<Long> LONG_TYPE = TypeToken.of(Long.class);
     private final EntityType entityType;
     private final Map<String, TypedName<?>> attributes;
     private final List<TypedName<?>> defaultColumns;
@@ -166,7 +168,7 @@ public class EntityDefaults {
         for (Map.Entry<String,String> d: bean.getDerivations().entrySet()) {
             EntityType et = EntityType.forName(d.getKey());
             TypedName<?> attr = attrs.get(d.getValue());
-            if (!attr.getType().equals(Long.class)) {
+            if (!attr.getType().equals(LONG_TYPE)) {
                 throw new RuntimeException("derived entity derives from non-Long column");
             }
             derivs.add(EntityDerivation.create(et, type, (TypedName<Long>) attr));

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/TypedName.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/TypedName.java
@@ -185,10 +185,7 @@ public final class TypedName<T> implements Serializable {
      * @throws IllegalArgumentException if `typeName` is not a valid type name.
      */
     public static TypedName<?> create(String name, String typeName) {
-        Class<?> type;
-        type = TypeUtils.resolveTypeName(typeName);
-
-        return create(name, type);
+        return create(name, TypeUtils.resolveTypeName(typeName));
     }
 
     private void readObject(ObjectInputStream in) throws IOException {

--- a/lenskit-core/src/main/java/org/lenskit/data/entities/TypedName.java
+++ b/lenskit-core/src/main/java/org/lenskit/data/entities/TypedName.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Interners;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.grouplens.grapht.util.ClassProxy;
+import org.grouplens.lenskit.util.TypeUtils;
 import org.joda.convert.StringConvert;
 import org.joda.convert.StringConverter;
 
@@ -154,35 +155,10 @@ public final class TypedName<T> implements Serializable {
      */
     public static TypedName<?> create(String name, String typeName) {
         Class<?> type;
-        switch (typeName) {
-        case "string":
-        case "String":
-            type = String.class;
-            break;
-        case "int":
-        case "Integer":
-            type = Integer.class;
-            break;
-        case "long":
-        case "Long":
-            type = Long.class;
-            break;
-        case "double":
-        case "real":
-        case "Double":
-            type = Double.class;
-            break;
-        default:
-            try {
-                type = ClassUtils.getClass(typeName);
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException("Cannot load type name ", e);
-            }
-        }
+        type = TypeUtils.resolveTypeName(typeName);
 
         return create(name, type);
     }
-
 
     private void readObject(ObjectInputStream in) throws IOException {
         throw new InvalidObjectException("typed names must use serialization proxy");

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
@@ -50,24 +50,34 @@ public class TypeUtilsTest {
 
     @Test
     public void testResolveStringType() {
-        assertThat(resolveTypeName("string"), equalTo(String.class));
-        assertThat(resolveTypeName("String"), equalTo(String.class));
+        assertThat(resolveTypeName("string"),
+                   equalTo(TypeToken.of(String.class)));
+        assertThat(resolveTypeName("String"),
+                   equalTo(TypeToken.of(String.class)));
     }
 
     @Test
     public void testResolveNumericTypes() {
-        assertThat(resolveTypeName("double"), equalTo(Double.class));
-        assertThat(resolveTypeName("Double"), equalTo(Double.class));
-        assertThat(resolveTypeName("long"), equalTo(Long.class));
-        assertThat(resolveTypeName("Long"), equalTo(Long.class));
-        assertThat(resolveTypeName("int"), equalTo(Integer.class));
-        assertThat(resolveTypeName("Integer"), equalTo(Integer.class));
-        assertThat(resolveTypeName("real"), equalTo(Double.class));
+        assertThat(resolveTypeName("double"),
+                   equalTo(TypeToken.of(Double.class)));
+        assertThat(resolveTypeName("Double"),
+                   equalTo(TypeToken.of(Double.class)));
+        assertThat(resolveTypeName("long"),
+                   equalTo(TypeToken.of(Long.class)));
+        assertThat(resolveTypeName("Long"),
+                   equalTo(TypeToken.of(Long.class)));
+        assertThat(resolveTypeName("int"),
+                   equalTo(TypeToken.of(Integer.class)));
+        assertThat(resolveTypeName("Integer"),
+                   equalTo(TypeToken.of(Integer.class)));
+        assertThat(resolveTypeName("real"),
+                   equalTo(TypeToken.of(Double.class)));
     }
 
     @Test
     public void testResolveClassType() {
-        assertThat(resolveTypeName("java.io.File"), equalTo(File.class));
+        assertThat(resolveTypeName("java.io.File"),
+                   equalTo(TypeToken.of(File.class)));
     }
 
     @Test

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
@@ -26,8 +26,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.*;
 
-import static org.grouplens.lenskit.util.TypeUtils.makeTypeName;
-import static org.grouplens.lenskit.util.TypeUtils.resolveTypeName;
+import static org.grouplens.lenskit.util.TypeUtils.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 
@@ -92,5 +91,35 @@ public class TypeUtilsTest {
                    equalTo("int"));
         assertThat(makeTypeName(TypeToken.of(Double.class)),
                    equalTo("double"));
+    }
+
+    @Test
+    public void testParseListType() {
+        TypeToken<List<String>> strList = new TypeToken<List<String>>() {};
+        assertThat(resolveTypeName("string[]"),
+                   equalTo(strList));
+        assertThat(resolveTypeName("int[]"),
+                   equalTo(new TypeToken<List<Integer>>(){}));
+        assertThat(resolveTypeName("int[][]"),
+                   equalTo(new TypeToken<List<List<Integer>>>(){}));
+    }
+
+    @Test
+    public void testStringifyListType() {
+        TypeToken<List<String>> strList = new TypeToken<List<String>>() {};
+        assertThat(makeTypeName(strList), equalTo("string[]"));
+        assertThat(makeTypeName(new TypeToken<List<List<Double>>>() {}),
+                   equalTo("double[][]"));
+    }
+
+    @Test
+    public void testExtractListElement() {
+        TypeToken<List<String>> strList = new TypeToken<List<String>>() {};
+        assertThat(listElementType(strList),
+                   equalTo(TypeToken.of(String.class)));
+
+        TypeToken<List<List<File>>> nestedList = new TypeToken<List<List<File>>>() {};
+        assertThat(listElementType(nestedList),
+                   equalTo(makeListType(TypeToken.of(File.class))));
     }
 }

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
@@ -20,11 +20,13 @@
  */
 package org.grouplens.lenskit.util;
 
+import com.google.common.reflect.TypeToken;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.*;
 
+import static org.grouplens.lenskit.util.TypeUtils.makeTypeName;
 import static org.grouplens.lenskit.util.TypeUtils.resolveTypeName;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
@@ -66,5 +68,19 @@ public class TypeUtilsTest {
     @Test
     public void testResolveClassType() {
         assertThat(resolveTypeName("java.io.File"), equalTo(File.class));
+    }
+
+    @Test
+    public void testStringifyBasicTypes() {
+        assertThat(makeTypeName(TypeToken.of(String.class)),
+                   equalTo("string"));
+        assertThat(makeTypeName(TypeToken.of(Long.class)),
+                   equalTo("long"));
+        assertThat(makeTypeName(TypeToken.of(File.class)),
+                   equalTo("java.io.File"));
+        assertThat(makeTypeName(TypeToken.of(Integer.class)),
+                   equalTo("int"));
+        assertThat(makeTypeName(TypeToken.of(Double.class)),
+                   equalTo("double"));
     }
 }

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
@@ -22,11 +22,11 @@ package org.grouplens.lenskit.util;
 
 import org.junit.Test;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
+import java.io.File;
+import java.util.*;
 
+import static org.grouplens.lenskit.util.TypeUtils.resolveTypeName;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 
 /**
@@ -44,5 +44,27 @@ public class TypeUtilsTest {
         //assertTrue(closure.contains(Object.class));
         assertFalse(closure.contains(List.class));
         assertFalse(closure.contains(null));
+    }
+
+    @Test
+    public void testResolveStringType() {
+        assertThat(resolveTypeName("string"), equalTo(String.class));
+        assertThat(resolveTypeName("String"), equalTo(String.class));
+    }
+
+    @Test
+    public void testResolveNumericTypes() {
+        assertThat(resolveTypeName("double"), equalTo(Double.class));
+        assertThat(resolveTypeName("Double"), equalTo(Double.class));
+        assertThat(resolveTypeName("long"), equalTo(Long.class));
+        assertThat(resolveTypeName("Long"), equalTo(Long.class));
+        assertThat(resolveTypeName("int"), equalTo(Integer.class));
+        assertThat(resolveTypeName("Integer"), equalTo(Integer.class));
+        assertThat(resolveTypeName("real"), equalTo(Double.class));
+    }
+
+    @Test
+    public void testResolveClassType() {
+        assertThat(resolveTypeName("java.io.File"), equalTo(File.class));
     }
 }

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
@@ -21,13 +21,19 @@
 package org.grouplens.lenskit.util;
 
 import com.google.common.reflect.TypeToken;
+import org.joda.convert.FromStringConverter;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
 
 import static org.grouplens.lenskit.util.TypeUtils.*;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
 
 /**
@@ -122,4 +128,32 @@ public class TypeUtilsTest {
         assertThat(listElementType(nestedList),
                    equalTo(makeListType(TypeToken.of(File.class))));
     }
+
+    @Test
+    public void testBasicFromString() {
+        TypeToken<Integer> intType = TypeToken.of(Integer.class);
+        FromStringConverter<Integer> cvt = TypeUtils.lookupFromStringConverter(intType);
+        assertThat(cvt, notNullValue());
+        assertThat(cvt.convertFromString((Class) intType.getRawType(), "1348"),
+                   equalTo(1348));
+    }
+
+    @Test
+    public void testStringListFromString() {
+        TypeToken<List<String>> tok = new TypeToken<List<String>>() {};
+        FromStringConverter<List<String>> cvt = TypeUtils.lookupFromStringConverter(tok);
+        assertThat(cvt, notNullValue());
+        List<String> result = cvt.convertFromString((Class) List.class, "foo,bar,\"hamster,salad\"");
+        assertThat(result, contains("foo", "bar", "hamster,salad"));
+    }
+
+    @Test
+    public void testIntListFromString() {
+        TypeToken<List<Integer>> tok = new TypeToken<List<Integer>>() {};
+        FromStringConverter<List<Integer>> cvt = TypeUtils.lookupFromStringConverter(tok);
+        assertThat(cvt, notNullValue());
+        List<Integer> result = cvt.convertFromString((Class) List.class, "39,42");
+        assertThat(result, contains(39, 42));
+    }
 }
+

--- a/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
+++ b/lenskit-core/src/test/java/org/grouplens/lenskit/util/TypeUtilsTest.java
@@ -56,33 +56,33 @@ public class TypeUtilsTest {
     @Test
     public void testResolveStringType() {
         assertThat(resolveTypeName("string"),
-                   equalTo(TypeToken.of(String.class)));
+                   equalTo((TypeToken) TypeToken.of(String.class)));
         assertThat(resolveTypeName("String"),
-                   equalTo(TypeToken.of(String.class)));
+                   equalTo((TypeToken) TypeToken.of(String.class)));
     }
 
     @Test
     public void testResolveNumericTypes() {
         assertThat(resolveTypeName("double"),
-                   equalTo(TypeToken.of(Double.class)));
+                   equalTo((TypeToken) TypeToken.of(Double.class)));
         assertThat(resolveTypeName("Double"),
-                   equalTo(TypeToken.of(Double.class)));
+                   equalTo((TypeToken) TypeToken.of(Double.class)));
         assertThat(resolveTypeName("long"),
-                   equalTo(TypeToken.of(Long.class)));
+                   equalTo((TypeToken) TypeToken.of(Long.class)));
         assertThat(resolveTypeName("Long"),
-                   equalTo(TypeToken.of(Long.class)));
+                   equalTo((TypeToken) TypeToken.of(Long.class)));
         assertThat(resolveTypeName("int"),
-                   equalTo(TypeToken.of(Integer.class)));
+                   equalTo((TypeToken) TypeToken.of(Integer.class)));
         assertThat(resolveTypeName("Integer"),
-                   equalTo(TypeToken.of(Integer.class)));
+                   equalTo((TypeToken) TypeToken.of(Integer.class)));
         assertThat(resolveTypeName("real"),
-                   equalTo(TypeToken.of(Double.class)));
+                   equalTo((TypeToken) TypeToken.of(Double.class)));
     }
 
     @Test
     public void testResolveClassType() {
         assertThat(resolveTypeName("java.io.File"),
-                   equalTo(TypeToken.of(File.class)));
+                   equalTo((TypeToken) TypeToken.of(File.class)));
     }
 
     @Test
@@ -103,11 +103,11 @@ public class TypeUtilsTest {
     public void testParseListType() {
         TypeToken<List<String>> strList = new TypeToken<List<String>>() {};
         assertThat(resolveTypeName("string[]"),
-                   equalTo(strList));
+                   equalTo((TypeToken) strList));
         assertThat(resolveTypeName("int[]"),
-                   equalTo(new TypeToken<List<Integer>>(){}));
+                   equalTo((TypeToken) new TypeToken<List<Integer>>(){}));
         assertThat(resolveTypeName("int[][]"),
-                   equalTo(new TypeToken<List<List<Integer>>>(){}));
+                   equalTo((TypeToken) new TypeToken<List<List<Integer>>>(){}));
     }
 
     @Test

--- a/lenskit-core/src/test/java/org/lenskit/data/dao/file/JSONEntityFormatTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/data/dao/file/JSONEntityFormatTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.reflect.TypeToken;
 import org.grouplens.grapht.util.ClassLoaders;
 import org.grouplens.lenskit.util.TypeUtils;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.lenskit.data.entities.*;
 import org.lenskit.data.ratings.Rating;
@@ -97,7 +98,7 @@ public class JSONEntityFormatTest {
         assertThat(res, notNullValue());
         assertThat(res.getId(), equalTo(204L));
         assertThat(res.get(CommonAttributes.NAME), equalTo("hamster"));
-        assertThat(res.get("extra"), equalTo("wumpus"));
+        assertThat(res.get("extra"), (Matcher) equalTo("wumpus"));
     }
 
     @Test
@@ -109,9 +110,9 @@ public class JSONEntityFormatTest {
         JsonNode json = reader.readTree("{\"entity_type\": \"item\", \"attributes\": {\"id\": \"long\", \"title\": {\"name\": \"name\", \"type\": \"string\"}, \"tags\": \"string[]\"}}");
         JSONEntityFormat fmt = JSONEntityFormat.fromJSON(null, ClassLoaders.inferDefault(), json);
         assertThat(fmt.getEntityType(), equalTo(CommonTypes.ITEM));
-        assertThat(fmt.getAttributes(), hasEntry("id", CommonAttributes.ENTITY_ID));
-        assertThat(fmt.getAttributes(), hasEntry("title", CommonAttributes.NAME));
-        assertThat(fmt.getAttributes(), hasEntry("tags", tlName));
+        assertThat(fmt.getAttributes(), hasEntry("id", (TypedName) CommonAttributes.ENTITY_ID));
+        assertThat(fmt.getAttributes(), hasEntry("title", (TypedName) CommonAttributes.NAME));
+        assertThat(fmt.getAttributes(), hasEntry("tags", (TypedName) tlName));
         assertThat(fmt.getAttributes().size(), equalTo(3));
 
         LineEntityParser lep = fmt.makeParser(Collections.EMPTY_LIST);

--- a/lenskit-core/src/test/java/org/lenskit/data/dao/file/JSONEntityFormatTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/data/dao/file/JSONEntityFormatTest.java
@@ -20,14 +20,19 @@
  */
 package org.lenskit.data.dao.file;
 
-import com.google.common.collect.Lists;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.grouplens.grapht.util.ClassLoaders;
 import org.junit.Test;
+import org.lenskit.data.entities.CommonAttributes;
 import org.lenskit.data.entities.CommonTypes;
 import org.lenskit.data.entities.Entities;
 import org.lenskit.data.entities.Entity;
 import org.lenskit.data.ratings.Rating;
 import org.lenskit.data.ratings.RatingBuilder;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.*;
@@ -63,5 +68,53 @@ public class JSONEntityFormatTest {
         assertThat(r.getUserId(), equalTo(42L));
         assertThat(r.getItemId(), equalTo(20L));
         assertThat(r.getValue(), equalTo(3.5));
+    }
+
+    @Test
+    public void testThingFields() {
+        JSONEntityFormat fmt = new JSONEntityFormat();
+        fmt.setEntityType(CommonTypes.ITEM);
+        fmt.addAttribute(CommonAttributes.ENTITY_ID);
+        fmt.addAttribute("title", CommonAttributes.NAME);
+
+        LineEntityParser lep = fmt.makeParser(Collections.EMPTY_LIST);
+        Entity res = lep.parse("{\"id\": 204, \"title\": \"hamster\", \"extra\": \"wumpus\"}");
+        assertThat(res, notNullValue());
+        assertThat(res.getId(), equalTo(204L));
+        assertThat(res.get(CommonAttributes.NAME), equalTo("hamster"));
+        assertThat(res.hasAttribute("extra"), equalTo(false));
+    }
+
+    @Test
+    public void testConfigureReader() throws IOException {
+        ObjectReader reader = new ObjectMapper().reader();
+        JsonNode json = reader.readTree("{\"entity_type\": \"item\"}");
+        EntityFormat fmt = JSONEntityFormat.fromJSON(null, ClassLoaders.inferDefault(), json);
+        assertThat(fmt.getEntityType(), equalTo(CommonTypes.ITEM));
+
+        LineEntityParser lep = fmt.makeParser(Collections.EMPTY_LIST);
+        Entity res = lep.parse("{\"id\": 204, \"name\": \"hamster\", \"extra\": \"wumpus\"}");
+        assertThat(res, notNullValue());
+        assertThat(res.getId(), equalTo(204L));
+        assertThat(res.get(CommonAttributes.NAME), equalTo("hamster"));
+        assertThat(res.get("extra"), equalTo("wumpus"));
+    }
+
+    @Test
+    public void testConfigureReaderFields() throws IOException {
+        ObjectReader reader = new ObjectMapper().reader();
+        JsonNode json = reader.readTree("{\"entity_type\": \"item\", \"attributes\": {\"id\": \"long\", \"title\": {\"name\": \"name\", \"type\": \"string\"}}}");
+        JSONEntityFormat fmt = JSONEntityFormat.fromJSON(null, ClassLoaders.inferDefault(), json);
+        assertThat(fmt.getEntityType(), equalTo(CommonTypes.ITEM));
+        assertThat(fmt.getAttributes(), hasEntry("id", CommonAttributes.ENTITY_ID));
+        assertThat(fmt.getAttributes(), hasEntry("title", CommonAttributes.NAME));
+        assertThat(fmt.getAttributes().size(), equalTo(2));
+
+        LineEntityParser lep = fmt.makeParser(Collections.EMPTY_LIST);
+        Entity res = lep.parse("{\"id\": 204, \"title\": \"hamster\", \"extra\": \"wumpus\"}");
+        assertThat(res, notNullValue());
+        assertThat(res.getId(), equalTo(204L));
+        assertThat(res.get(CommonAttributes.NAME), equalTo("hamster"));
+        assertThat(res.hasAttribute("extra"), equalTo(false));
     }
 }

--- a/lenskit-core/src/test/java/org/lenskit/data/entities/TypedNameTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/data/entities/TypedNameTest.java
@@ -20,6 +20,7 @@
  */
 package org.lenskit.data.entities;
 
+import com.google.common.reflect.TypeToken;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class TypedNameTest {
     public void testBasicField() {
         TypedName<String> attribute = TypedName.create("foo", String.class);
         assertThat(attribute.getName(), equalTo("foo"));
-        assertThat(attribute.getType(), equalTo(String.class));
+        assertThat(attribute.getType(), equalTo(TypeToken.of(String.class)));
         // check equality to random other object
         assertThat(attribute, not(equalTo((Object) "foo")));
 

--- a/lenskit-core/src/test/java/org/lenskit/data/entities/TypedNameTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/data/entities/TypedNameTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.List;
 
 import static org.grouplens.lenskit.util.test.ExtraMatchers.matchesPattern;
 import static org.hamcrest.Matchers.*;
@@ -92,5 +93,13 @@ public class TypedNameTest {
     public void testParseLong() {
         assertThat(TypedName.create("foo", Long.class).parseString("3209"),
                    equalTo(3209L));
+    }
+
+    @Test
+    public void testParseStringList() {
+        TypeToken<List<String>> ltt = new TypeToken<List<String>>() {};
+        TypedName<List<String>> name = TypedName.create("tags", ltt);
+        assertThat(name.parseString("foo,bar"),
+                   contains("foo", "bar"));
     }
 }


### PR DESCRIPTION
These changes will support compound attribute types, such as lists of strings, in the LensKIt data model.