### PR TITLE
Add runtime data support

### DIFF
--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngine.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngine.java
@@ -67,8 +67,14 @@ public final class LenskitRecommenderEngine implements RecommenderEngine, Serial
     private final DAGNode<Component, Dependency> graph;
     private final boolean instantiable;
 
-    LenskitRecommenderEngine(@Nonnull DAGNode<Component,Dependency> graph,
-                             boolean instantiable) {
+    /**
+     * Build an engine encapsulating a dependency graph.  You generally do not want to use this - use
+     * {@link LenskitRecommenderEngineBuilder} instead.
+     * @param graph The graph.
+     * @param instantiable `true` if the recommender can be instantiated as-is, `false` otherwise.
+     */
+    public LenskitRecommenderEngine(@Nonnull DAGNode<Component,Dependency> graph,
+                                    boolean instantiable) {
         Preconditions.checkNotNull(graph, "configuration graph");
         this.graph = graph;
         this.instantiable = instantiable;
@@ -188,8 +194,6 @@ public final class LenskitRecommenderEngine implements RecommenderEngine, Serial
      * Construct a recommender with some additional configuration.  This can be used to do things
      * like add data source configuration on a per-recommender, rather than per-engine, basis.
      *
-     * This method is only used for special cases needing detailed access to the recommender.
-     *
      * @param config The configuration to adjust the recommender.
      * @return The constructed recommender.
      * @throws RecommenderConfigurationException if there is an error configuring the recommender.
@@ -211,7 +215,7 @@ public final class LenskitRecommenderEngine implements RecommenderEngine, Serial
         return createRecommender(config);
     }
 
-    public DAGNode<Component, Dependency> createRecommenderGraph(LenskitConfiguration config) throws RecommenderConfigurationException {
+    private DAGNode<Component, Dependency> createRecommenderGraph(LenskitConfiguration config) throws RecommenderConfigurationException {
         Preconditions.checkNotNull(config, "extra configuration");
         final DAGNode<Component, Dependency> toBuild;
         RecommenderGraphBuilder rgb = new RecommenderGraphBuilder();

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineBuilder.java
@@ -161,7 +161,7 @@ public class LenskitRecommenderEngineBuilder {
         for (Pair<LenskitConfiguration, ModelDisposition> cfg : configurations) {
             rgb.addConfiguration(cfg.getLeft());
         }
-        LenskitConfiguration daoConfig = null;
+        LenskitConfiguration daoConfig;
         if (dao != null) {
             daoConfig = new LenskitConfiguration();
             daoConfig.addComponent(dao);
@@ -183,7 +183,7 @@ public class LenskitRecommenderEngineBuilder {
      * @param graph The recommender graph.
      * @return The instantiated graph.
      */
-    private DAGNode<Component, Dependency> instantiateGraph(DAGNode<Component, Dependency> graph) {
+    protected DAGNode<Component, Dependency> instantiateGraph(DAGNode<Component, Dependency> graph) {
         RecommenderInstantiator inst = RecommenderInstantiator.create(graph);
 
         graph = inst.instantiate();

--- a/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/LenskitRecommenderEngineBuilder.java
@@ -41,17 +41,17 @@ import java.util.List;
 /**
  * Builds LensKit recommender engines from configurations.
  *
- * <p>
  * If multiple configurations are used, later configurations superseded previous configurations.
  * This allows you to add a configuration of defaults, followed by a custom configuration.  The
- * final build process takes the <em>union</em> of the roots of all provided configurations as
+ * final build process takes the _union_ of the roots of all provided configurations as
  * the roots of the configured object graph.
- * </p>
+ *
+ * While this class is subclassable, and exposes protected methods, users should not subclass it.
+ * Subclassing is supported only to enable the evaluator.
  *
  * @see LenskitConfiguration
  * @see LenskitRecommenderEngine
  * @since 2.1
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class LenskitRecommenderEngineBuilder {
     private static final Logger logger = LoggerFactory.getLogger(LenskitRecommenderEngineBuilder.class);
@@ -104,7 +104,7 @@ public class LenskitRecommenderEngineBuilder {
      *
      * @return The built recommender engine, with {@linkplain ModelDisposition#EXCLUDED excluded}
      *         components removed.
-     * @throws RecommenderBuildException
+     * @throws RecommenderBuildException if there is an error building the recommender.
      * @deprecated Use {@link #build(DataAccessObject)}
      */
     @Deprecated
@@ -119,10 +119,42 @@ public class LenskitRecommenderEngineBuilder {
      *            special cases.
      * @return The built recommender engine, with {@linkplain ModelDisposition#EXCLUDED excluded}
      *         components removed.
-     * @throws RecommenderBuildException
+     * @throws RecommenderBuildException if there is an error building the engine.
      */
     public LenskitRecommenderEngine build(DataAccessObject dao) throws RecommenderBuildException {
-        // Build the initial graph
+        DAGNode<Component, Dependency> graph = buildRecommenderGraph(dao);
+        graph = instantiateGraph(graph);
+        graph = rewriteExcludedComponents(graph, dao);
+
+        boolean instantiable = GraphtUtils.getPlaceholderNodes(graph).isEmpty();
+        return new LenskitRecommenderEngine(graph, instantiable);
+    }
+
+    /**
+     * Build the recommender directly, skipping an engine.  This does not separate the recommender from
+     * the DAO, it just directly builds it.
+     *
+     * @param dao The data access object to use.  Can be `null` to build without a DAO, but this is only useful in
+     *            special cases.
+     * @return The built recommender engine, with {@linkplain ModelDisposition#EXCLUDED excluded}
+     *         components removed.
+     * @throws RecommenderBuildException if there is an error building the engine.
+     */
+    public LenskitRecommender buildRecommender(DataAccessObject dao) throws RecommenderBuildException {
+        DAGNode<Component, Dependency> graph = buildRecommenderGraph(dao);
+        graph = instantiateGraph(graph);
+        return new LenskitRecommender(graph);
+    }
+
+    /**
+     * Build a recommender graph for this engine builder's configuration.
+     *
+     * Clients generally do not need to use this; it is exposed for the evaluator.
+     *
+     * @param dao The DAO, if available.
+     * @return The graph.
+     */
+    protected DAGNode<Component, Dependency> buildRecommenderGraph(DataAccessObject dao) {
         logger.debug("building graph from {} configurations", configurations.size());
         RecommenderGraphBuilder rgb = new RecommenderGraphBuilder();
         rgb.setClassLoader(classLoader);
@@ -135,23 +167,39 @@ public class LenskitRecommenderEngineBuilder {
             daoConfig.addComponent(dao);
             rgb.addConfiguration(daoConfig);
         }
-        RecommenderInstantiator inst;
+
+        DAGNode<Component, Dependency> graph;
         try {
-            inst = RecommenderInstantiator.create(rgb.buildGraph());
+            graph = rgb.buildGraph();
         } catch (ResolutionException e) {
             throw new RecommenderBuildException("Cannot resolve recommender graph", e);
         }
-        DAGNode<Component, Dependency> graph = inst.instantiate();
 
-        graph = rewriteGraph(graph, daoConfig);
-
-        boolean instantiable = GraphtUtils.getPlaceholderNodes(graph).isEmpty();
-        return new LenskitRecommenderEngine(graph, instantiable);
+        return graph;
     }
 
+    /**
+     * Instantiate the recommender graph.
+     * @param graph The recommender graph.
+     * @return The instantiated graph.
+     */
+    private DAGNode<Component, Dependency> instantiateGraph(DAGNode<Component, Dependency> graph) {
+        RecommenderInstantiator inst = RecommenderInstantiator.create(graph);
 
-    private DAGNode<Component, Dependency> rewriteGraph(DAGNode<Component, Dependency> graph,
-                                                        LenskitConfiguration daoConfig) throws RecommenderConfigurationException {
+        graph = inst.instantiate();
+        return graph;
+    }
+
+    /**
+     * Remove configuration that should be excluded from engine graphs, particularly the DAO.
+     *
+     * @param graph The input graph.
+     * @param dao The DAO.
+     * @return The rewritten graph.
+     * @throws RecommenderConfigurationException If there is a configuration error during the rewrite.
+     */
+    private DAGNode<Component, Dependency> rewriteExcludedComponents(DAGNode<Component, Dependency> graph,
+                                                                     DataAccessObject dao) throws RecommenderConfigurationException {
         RecommenderGraphBuilder rewriteBuilder = new RecommenderGraphBuilder();
         boolean rewrite = false;
         for (Pair<LenskitConfiguration,ModelDisposition> cfg: configurations) {
@@ -163,9 +211,10 @@ public class LenskitRecommenderEngineBuilder {
                 break;
             }
         }
-        if (daoConfig != null) {
-            rewriteBuilder.addBindings(daoConfig.getBindings());
-            rewriteBuilder.addRoots(daoConfig.getRoots());
+        if (dao != null) {
+            LenskitConfiguration cfg = new LenskitConfiguration();
+            cfg.addComponent(dao);
+            rewriteBuilder.addBindings(cfg.getBindings());
             rewrite = true;
         }
 

--- a/lenskit-core/src/main/java/org/lenskit/inject/AbstractConfigContext.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/AbstractConfigContext.java
@@ -38,7 +38,6 @@ import java.lang.annotation.Annotation;
 /**
  * Helper for implementing Lenskit config contexts.
  *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  * @since 1.0
  */
 public abstract class AbstractConfigContext extends AbstractContext implements LenskitConfigContext {

--- a/lenskit-core/src/main/java/org/lenskit/inject/RecommenderGraphBuilder.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/RecommenderGraphBuilder.java
@@ -37,7 +37,6 @@ import java.util.Set;
  *
  * @compat private
  * @since 2.1
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
  */
 public class RecommenderGraphBuilder {
     private static final int RESOLVE_DEPTH_LIMIT = 100;

--- a/lenskit-core/src/main/java/org/lenskit/inject/RecommenderInstantiator.java
+++ b/lenskit-core/src/main/java/org/lenskit/inject/RecommenderInstantiator.java
@@ -70,7 +70,8 @@ public final class RecommenderInstantiator {
     /**
      * Instantiate the recommender graph.  This requires the graph to have been resolved with a real
      * DAO instance, not just a class, if anything references the DAO.  Use {@link
-     * LenskitConfiguration#buildGraph()} to get such a graph.
+     * LenskitConfiguration#buildGraph()} to get such a graph.  The result of instantiating a graph
+     * is that all shareable nodes will be instantiated.
      *
      * @return A new recommender graph with all shareable nodes pre-instantiated.
      * @throws RecommenderBuildException If there is an error instantiating the graph.

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/AlgorithmInstance.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/AlgorithmInstance.java
@@ -23,15 +23,9 @@ package org.lenskit.eval.traintest;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.grouplens.grapht.Component;
-import org.grouplens.grapht.Dependency;
-import org.grouplens.grapht.ResolutionException;
-import org.grouplens.grapht.graph.DAGNode;
-import org.lenskit.*;
-import org.lenskit.api.RecommenderBuildException;
+import org.lenskit.LenskitConfiguration;
 import org.lenskit.config.ConfigurationLoader;
 import org.lenskit.config.LenskitConfigScript;
-import org.lenskit.inject.RecommenderGraphBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,50 +99,6 @@ public class AlgorithmInstance {
     @Nonnull
     public List<LenskitConfiguration> getConfigurations() {
         return configurations;
-    }
-
-    /**
-     * Build a recommender.
-     *
-     * @param defaults Additional configuration.  This configuration comes <em>before</em> the
-     *                 algorithm's configuration, so it is overridden if appropriate.  It is used
-     *                 for providing things such as DAOs.
-     * @return The instantiated recommender.
-     * @throws RecommenderBuildException
-     */
-    public LenskitRecommender buildRecommender(@Nullable LenskitConfiguration defaults) throws RecommenderBuildException {
-        LenskitRecommenderEngineBuilder builder = LenskitRecommenderEngine.newBuilder();
-        if (defaults != null) {
-            builder.addConfiguration(defaults);
-        }
-        for (LenskitConfiguration cfg: configurations) {
-            builder.addConfiguration(cfg);
-        }
-        return builder.build().createRecommender();
-    }
-
-    /**
-     * Build a recommender graph (but don't instantiate any objects).
-     *
-     * @param defaults Additional configurations.  These configurations come <em>before</em> the
-     *                 algorithm's configuration, so they are overridden if appropriate.  They are used
-     *                 for providing things such as DAOs.
-     * @return The recommender graph.
-     * @throws RecommenderConfigurationException if there is an error configuring the recommender.
-     */
-    public DAGNode<Component,Dependency> buildRecommenderGraph(@Nullable LenskitConfiguration... defaults) throws RecommenderConfigurationException {
-        RecommenderGraphBuilder rgb = new RecommenderGraphBuilder();
-        for (LenskitConfiguration dft: defaults) {
-            rgb.addConfiguration(dft);
-        }
-        for (LenskitConfiguration cfg: configurations) {
-            rgb.addConfiguration(cfg);
-        }
-        try {
-            return rgb.buildGraph();
-        } catch (ResolutionException e) {
-            throw new RecommenderConfigurationException("error configuring recommender", e);
-        }
     }
 
     /**

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSet.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSet.java
@@ -273,7 +273,7 @@ public class DataSet {
         }
 
         ImmutableList.Builder<DataSet> finalSets = ImmutableList.builder();
-        boolean isolate = json.has("isolate") && json.get("isolate").asBoolean();
+        boolean isolate = json.path("isolate").asBoolean(false);
         if (isolate) {
             for (DataSet set: sets) {
                 finalSets.add(set.copyBuilder()
@@ -303,9 +303,7 @@ public class DataSet {
 
         JsonNode etNode = json.path("entity_types");
         if (etNode.isArray()) {
-            Iterator<JsonNode> nodeList = etNode.iterator();
-            while(nodeList.hasNext()) {
-                JsonNode node = nodeList.next();
+            for (JsonNode node : etNode) {
                 entityList.add(EntityType.forName(node.asText()));
             }
         } else if (etNode.isTextual()) {
@@ -320,7 +318,9 @@ public class DataSet {
 
         dsb.setEntityTypes(entityList);
         if (part >= 0) {
-            dsb.setAttribute("Partition", part);
+            dsb.setName(String.format("%s[%d]", name, part))
+               .setAttribute("DataSet", name)
+               .setAttribute("Partition", part);
         }
         String nbase = part >= 0 ? String.format("%s[%d]", name, part) : name;
         dsb.setTrain(loadDataSource(json.get("train"), base, nbase + ".train"));

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSet.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSet.java
@@ -37,6 +37,7 @@ import org.lenskit.data.ratings.PreferenceDomain;
 import org.lenskit.util.collections.LongUtils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Provider;
 import java.io.IOException;
 import java.net.URI;
@@ -53,6 +54,8 @@ public class DataSet {
     private final String name;
     @Nonnull
     private final StaticDataSource trainData;
+    @Nullable
+    private final StaticDataSource runtimeData;
     @Nonnull
     private final StaticDataSource testData;
     @Nonnull
@@ -75,6 +78,7 @@ public class DataSet {
      */
     public DataSet(@Nonnull String name,
                    @Nonnull StaticDataSource train,
+                   @Nullable StaticDataSource rt,
                    @Nonnull StaticDataSource test,
                    @Nonnull UUID grp,
                    Map<String, Object> attrs,
@@ -83,6 +87,7 @@ public class DataSet {
         Preconditions.checkNotNull(test, "no test data");
         this.name = name;
         trainData = train;
+        runtimeData = rt;
         testData = test;
         group = grp;
         if (attrs == null) {
@@ -151,6 +156,17 @@ public class DataSet {
     @Nonnull
     public StaticDataSource getTrainingData() {
         return trainData;
+    }
+
+    /**
+     * Get the runtime data set. This is the data that should be available when the recommender is run,
+     * but not when its model is trained.
+     *
+     * @return The runtime data set.
+     */
+    @Nullable
+    public StaticDataSource getRuntimeData() {
+        return runtimeData;
     }
 
     public LongSet getAllItems() {
@@ -325,6 +341,9 @@ public class DataSet {
         String nbase = part >= 0 ? String.format("%s[%d]", name, part) : name;
         dsb.setTrain(loadDataSource(json.get("train"), base, nbase + ".train"));
         dsb.setTest(loadDataSource(json.get("test"), base, nbase + ".test"));
+        if (json.hasNonNull("runtime")) {
+            dsb.setRuntime(loadDataSource(json.get("runtime"), base, nbase + ".runtime"));
+        }
         if (json.has("group")) {
             dsb.setIsolationGroup(UUID.fromString(json.get("group").asText()));
         }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSetBuilder.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSetBuilder.java
@@ -28,7 +28,10 @@ import org.lenskit.data.entities.CommonTypes;
 import org.lenskit.data.entities.EntityType;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Builder for generic train-test data sets.
@@ -40,7 +43,6 @@ public class DataSetBuilder implements Builder<DataSet> {
     private StaticDataSource trainingData;
     private StaticDataSource testData;
     private Map<String, Object> attributes = new LinkedHashMap<>();
-    private StaticDataSource queryData;
     private UUID isoGroup = new UUID(0, 0);
     private List<EntityType> entityTypes = Lists.newArrayList(CommonTypes.RATING);
 
@@ -65,11 +67,6 @@ public class DataSetBuilder implements Builder<DataSet> {
 
     public DataSetBuilder setTrain(StaticDataSource ds) {
         trainingData = ds;
-        return this;
-    }
-
-    public DataSetBuilder setQuery(StaticDataSource query) {
-        queryData = query;
         return this;
     }
 
@@ -114,6 +111,6 @@ public class DataSetBuilder implements Builder<DataSet> {
     @Override
     public DataSet build() {
         Preconditions.checkNotNull(trainingData, "train data is Null");
-        return new DataSet(getName(), trainingData, queryData, testData, isoGroup, attributes, entityTypes);
+        return new DataSet(getName(), trainingData, testData, isoGroup, attributes, entityTypes);
     }
 }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSetBuilder.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSetBuilder.java
@@ -21,6 +21,7 @@
 package org.lenskit.eval.traintest;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.builder.Builder;
 import org.lenskit.data.dao.file.StaticDataSource;
@@ -61,7 +62,6 @@ public class DataSetBuilder implements Builder<DataSet> {
      */
     public DataSetBuilder setName(String n) {
         name = n;
-        attributes.put("DataSet", n);
         return this;
     }
 
@@ -111,6 +111,13 @@ public class DataSetBuilder implements Builder<DataSet> {
     @Override
     public DataSet build() {
         Preconditions.checkNotNull(trainingData, "train data is Null");
-        return new DataSet(getName(), trainingData, testData, isoGroup, attributes, entityTypes);
+        Map<String, Object> attrs = attributes;
+        if (!attrs.containsKey("DataSet")) {
+            attrs = ImmutableMap.<String,Object>builder()
+                                .put("DataSet", getName())
+                                .putAll(attrs)
+                                .build();
+        }
+        return new DataSet(getName(), trainingData, testData, isoGroup, attrs, entityTypes);
     }
 }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSetBuilder.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/DataSetBuilder.java
@@ -42,6 +42,7 @@ import java.util.UUID;
 public class DataSetBuilder implements Builder<DataSet> {
     private String name;
     private StaticDataSource trainingData;
+    private StaticDataSource runtimeData;
     private StaticDataSource testData;
     private Map<String, Object> attributes = new LinkedHashMap<>();
     private UUID isoGroup = new UUID(0, 0);
@@ -70,12 +71,16 @@ public class DataSetBuilder implements Builder<DataSet> {
         return this;
     }
 
+    public DataSetBuilder setRuntime(StaticDataSource ds) {
+        runtimeData = ds;
+        return this;
+    }
+
     public DataSetBuilder setTest(StaticDataSource ds) {
         testData = ds;
         return this;
     }
 
-    // TODO set entity types
     public DataSetBuilder setEntityTypes(List<EntityType> typeList) {
         entityTypes = typeList;
         return this;
@@ -118,6 +123,6 @@ public class DataSetBuilder implements Builder<DataSet> {
                                 .putAll(attrs)
                                 .build();
         }
-        return new DataSet(getName(), trainingData, testData, isoGroup, attrs, entityTypes);
+        return new DataSet(getName(), trainingData, runtimeData, testData, isoGroup, attrs, entityTypes);
     }
 }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/ExperimentJob.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/ExperimentJob.java
@@ -35,8 +35,6 @@ import org.lenskit.data.entities.CommonAttributes;
 import org.lenskit.data.entities.CommonTypes;
 import org.lenskit.data.entities.Entity;
 import org.lenskit.data.entities.EntityType;
-import org.lenskit.data.ratings.PreferenceDomain;
-import org.lenskit.data.ratings.Rating;
 import org.lenskit.inject.GraphtUtils;
 import org.lenskit.inject.NodeProcessors;
 import org.lenskit.inject.RecommenderInstantiator;
@@ -246,12 +244,9 @@ class ExperimentJob extends RecursiveAction {
 
     private LenskitRecommender buildRecommender(DataAccessObject dao) throws RecommenderBuildException {
         logger.debug("Starting recommender build");
-        LenskitConfiguration extraConfig = new LenskitConfiguration();
+        LenskitConfiguration extraConfig = dataSet.getExtraConfiguration();
+        extraConfig = new LenskitConfiguration(extraConfig);
         extraConfig.addComponent(dao);
-        PreferenceDomain dom = dataSet.getTrainingData().getPreferenceDomain();
-        if (dom != null) {
-            extraConfig.addComponent(dom);
-        }
 
         DAGNode<Component, Dependency> cfgGraph = algorithm.buildRecommenderGraph(sharedConfig, extraConfig);
         if (mergePool != null) {

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TestUsers.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TestUsers.java
@@ -20,20 +20,18 @@
  */
 package org.lenskit.eval.traintest;
 
-import org.grouplens.grapht.annotation.AllowUnqualifiedMatch;
-
 import javax.inject.Qualifier;
 import java.lang.annotation.*;
 
 /**
- * Qualifier to access query data available.
- *
- * @author <a href="http://www.grouplens.org">GroupLens Research</a>
+ * Qualifier for gaining access to the set of test users.  This can be useful for certain
+ * cases where the recommender would like to optimize for only needing to recommend for specific
+ * users; however, use of this is generally discouraged, as it makes algorithm components
+ * dependent on the evaluator.
  */
-@Documented
 @Qualifier
+@Documented
+@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.METHOD})
-@AllowUnqualifiedMatch
-public @interface QueryData {
+public @interface TestUsers {
 }

--- a/lenskit-eval/src/test/java/org/lenskit/eval/traintest/DataSetTest.java
+++ b/lenskit-eval/src/test/java/org/lenskit/eval/traintest/DataSetTest.java
@@ -51,6 +51,7 @@ public class DataSetTest {
         assertThat(ds.getName(), equalTo("ut"));
         assertThat(ds.getTrainingData().getName(), equalTo("ut.train"));
         assertThat(ds.getTestData().getName(), equalTo("ut.test"));
+        assertThat(ds.getRuntimeData(), nullValue());
         assertThat(ds.getEntityTypes(),
                    containsInAnyOrder(RATING));
     }
@@ -74,6 +75,7 @@ public class DataSetTest {
         assertThat(ds.getAttributes(), hasEntry("Partition", (Object) 1));
         assertThat(ds.getTrainingData().getName(), equalTo("ut[1].train"));
         assertThat(ds.getTestData().getName(), equalTo("ut[1].test"));
+        assertThat(ds.getRuntimeData(), nullValue());
         assertThat(ds.getEntityTypes(),
                    containsInAnyOrder(RATING));
 
@@ -83,6 +85,7 @@ public class DataSetTest {
         assertThat(ds.getAttributes(), hasEntry("Partition", (Object) 2));
         assertThat(ds.getTrainingData().getName(), equalTo("ut[2].train"));
         assertThat(ds.getTestData().getName(), equalTo("ut[2].test"));
+        assertThat(ds.getRuntimeData(), nullValue());
         assertThat(ds.getEntityTypes(),
                    containsInAnyOrder(RATING));
     }
@@ -117,5 +120,26 @@ public class DataSetTest {
         DataSet ds = dsList.get(0);
         assertThat(ds.getEntityTypes(),
                 containsInAnyOrder(ITEM));
+    }
+
+    @Test
+    public void testRuntimeData() throws IOException {
+        JsonNode node = reader.readTree("{\"name\": \"ut\",\n" +
+                                                "\"train\": {\"file\": \"train-ratings.csv\"},\n" +
+                                                "\"test\": {\"file\": \"test-ratings.csv\"},\n" +
+                                                "\"runtime\": {\"file\": \"rt-ratings.csv\"}\n" +
+                                                "}");
+        URI baseURI = Paths.get("").toUri();
+        List<DataSet> dsList = DataSet.fromJSON(node, baseURI);
+        assertThat(dsList, hasSize(1));
+
+        DataSet ds = dsList.get(0);
+        assertThat(ds.getName(), equalTo("ut"));
+        assertThat(ds.getTrainingData().getName(), equalTo("ut.train"));
+        assertThat(ds.getTestData().getName(), equalTo("ut.test"));
+        assertThat(ds.getRuntimeData(), notNullValue());
+        assertThat(ds.getRuntimeData().getName(), equalTo("ut.runtime"));
+        assertThat(ds.getEntityTypes(),
+                   containsInAnyOrder(RATING));
     }
 }

--- a/lenskit-eval/src/test/java/org/lenskit/eval/traintest/DataSetTest.java
+++ b/lenskit-eval/src/test/java/org/lenskit/eval/traintest/DataSetTest.java
@@ -30,15 +30,62 @@ import java.net.URI;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.lenskit.data.entities.CommonTypes.*;
 
-/**
- * Created by kiranthapa on 2/9/17.
- */
 public class DataSetTest {
     private ObjectReader reader = new ObjectMapper().reader();
+
+    @Test
+    public void testBasicConfig() throws IOException {
+        JsonNode node = reader.readTree("{\"name\": \"ut\",\n" +
+                                                "\"train\": {\"file\": \"train-ratings.csv\"},\n" +
+                                                "\"test\": {\"file\": \"test-ratings.csv\"}\n" +
+                                                "}");
+        URI baseURI = Paths.get("").toUri();
+        List<DataSet> dsList = DataSet.fromJSON(node, baseURI);
+        assertThat(dsList, hasSize(1));
+
+        DataSet ds = dsList.get(0);
+        assertThat(ds.getName(), equalTo("ut"));
+        assertThat(ds.getTrainingData().getName(), equalTo("ut.train"));
+        assertThat(ds.getTestData().getName(), equalTo("ut.test"));
+        assertThat(ds.getEntityTypes(),
+                   containsInAnyOrder(RATING));
+    }
+
+    @Test
+    public void testDataSetPartitions() throws IOException {
+        JsonNode node = reader.readTree("{\"name\": \"ut\",\n" +
+                                                "\"datasets\": [\n" +
+                                                "  { \"train\": {\"file\": \"train-ratings-1.csv\"},\n" +
+                                                "    \"test\": {\"file\": \"test-ratings-1.csv\"} },\n" +
+                                                "  { \"train\": {\"file\": \"train-ratings-2.csv\"},\n" +
+                                                "    \"test\": {\"file\": \"test-ratings-2.csv\"} }\n" +
+                                                "]}");
+        URI baseURI = Paths.get("").toUri();
+        List<DataSet> dsList = DataSet.fromJSON(node, baseURI);
+        assertThat(dsList, hasSize(2));
+
+        DataSet ds = dsList.get(0);
+        assertThat(ds.getName(), equalTo("ut[1]"));
+        assertThat(ds.getAttributes(), hasEntry("DataSet", (Object) "ut"));
+        assertThat(ds.getAttributes(), hasEntry("Partition", (Object) 1));
+        assertThat(ds.getTrainingData().getName(), equalTo("ut[1].train"));
+        assertThat(ds.getTestData().getName(), equalTo("ut[1].test"));
+        assertThat(ds.getEntityTypes(),
+                   containsInAnyOrder(RATING));
+
+        ds = dsList.get(1);
+        assertThat(ds.getName(), equalTo("ut[2]"));
+        assertThat(ds.getAttributes(), hasEntry("DataSet", (Object) "ut"));
+        assertThat(ds.getAttributes(), hasEntry("Partition", (Object) 2));
+        assertThat(ds.getTrainingData().getName(), equalTo("ut[2].train"));
+        assertThat(ds.getTestData().getName(), equalTo("ut[2].test"));
+        assertThat(ds.getEntityTypes(),
+                   containsInAnyOrder(RATING));
+    }
 
     @Test
     public void testEntityTypeArray() throws IOException {
@@ -71,21 +118,4 @@ public class DataSetTest {
         assertThat(ds.getEntityTypes(),
                 containsInAnyOrder(ITEM));
     }
-
-    @Test
-    public void testEntityTypeNone() throws IOException {
-        JsonNode node = reader.readTree("{\"name\": \"movie\", \n" +
-                "\"datasets\": [{\n" +
-                "\"train\": {\"file\": \"train-ratings.csv\"},\n" +
-                "\"test\": {\"file\": \"test-ratings.csv\"}\n" +
-                "}]\n" +
-                "}");
-        URI baseURI = Paths.get("").toUri();
-        List<DataSet> dsList = DataSet.fromJSON(node, baseURI);
-
-        DataSet ds = dsList.get(0);
-        assertThat(ds.getEntityTypes(),
-                containsInAnyOrder(RATING));
-    }
-
 }

--- a/lenskit-integration-tests/src/it/gradle/external-algorithms/algorithms.groovy
+++ b/lenskit-integration-tests/src/it/gradle/external-algorithms/algorithms.groovy
@@ -20,14 +20,14 @@
  */
 
 
+import org.grouplens.lenskit.eval.metrics.predict.*
 import org.lenskit.api.ItemScorer
 import org.lenskit.baseline.ItemMeanRatingItemScorer
 import org.lenskit.data.dao.DataAccessObject
-import org.lenskit.data.entities.CommonTypes
-import org.lenskit.inject.Transient
-import org.lenskit.eval.traintest.QueryData
-import org.grouplens.lenskit.eval.metrics.predict.*
+import org.lenskit.eval.traintest.TestUsers
 import org.lenskit.external.ExternalProcessItemScorerBuilder
+import org.lenskit.inject.Transient
+import it.unimi.dsi.fastutil.longs.LongSet
 
 import javax.inject.Inject
 import javax.inject.Provider
@@ -37,13 +37,13 @@ import javax.inject.Provider
  */
 class ExternalItemMeanScorerBuilder implements Provider<ItemScorer> {
     DataAccessObject trainDAO
-    DataAccessObject queryDAO
+    LongSet testUsers
 
     @Inject
     public ExternalItemMeanScorerBuilder(@Transient DataAccessObject dao,
-                                         @Transient @QueryData DataAccessObject qdata) {
+                                         @Transient @TestUsers LongSet users) {
         trainDAO = dao
-        queryDAO = qdata
+        testUsers = users
     }
 
     @Override
@@ -56,7 +56,7 @@ class ExternalItemMeanScorerBuilder implements Provider<ItemScorer> {
                       .setExecutable("python")
                       .addArgument("../item-mean.py")
                       .addArgument("--for-users")
-                      .addUserFileArgument(queryDAO.getEntityIds(CommonTypes.USER))
+                      .addUserFileArgument(testUsers)
                       .addRatingFileArgument(trainDAO)
                       .build()
     }

--- a/lenskit-integration-tests/src/it/gradle/renjin.gradle
+++ b/lenskit-integration-tests/src/it/gradle/renjin.gradle
@@ -9,10 +9,8 @@ repositories {
 dependencies {
     analyze localGroovy()
     analyze group: 'org.lenskit', name: 'lenskit-test', version: project.lenskitVersion
-    analyze group: 'org.renjin', name: 'renjin-script-engine', version: '0.8.2340'
-    analyze group: 'org.renjin.cran', name: 'assertive.files', version: '0.0-2-b9'
-    analyze group: 'org.renjin.cran', name: 'assertive.sets', version: '0.0-3-b2'
-    analyze group: 'org.renjin.cran', name: 'assertive.properties', version: '0.0-4-b2'
+    analyze group: 'org.renjin', name: 'renjin-script-engine', version: '0.8.2345'
+    analyze group: 'org.renjin.cran', name: 'assertthat', version: '0.1-b305'
 }
 
 task verifyR(type: JavaExec) {

--- a/lenskit-integration-tests/src/it/gradle/train-test-cheat-with-runtime/build.gradle
+++ b/lenskit-integration-tests/src/it/gradle/train-test-cheat-with-runtime/build.gradle
@@ -1,0 +1,71 @@
+buildscript {
+    repositories {
+        maven {
+            url project.testRepoURI
+        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.lenskit:lenskit-gradle:$project.lenskitVersion"
+        classpath 'org.yaml:snakeyaml:1.17'
+    }
+}
+import org.lenskit.gradle.*
+import org.yaml.snakeyaml.*
+
+apply plugin: 'java'
+apply plugin: 'lenskit'
+apply from: 'common.gradle'
+
+dependencies {
+    runtime 'org.hamcrest:hamcrest-library:1.3'
+    runtime "org.lenskit:lenskit-test:$project.lenskitVersion"
+    testRuntime 'com.xlson.groovycsv:groovycsv:1.0'
+}
+
+task crossfold(type: Crossfold) {
+    input textFile {
+        file ratingsFile
+        delimiter "\t"
+    }
+    outputFormat "gz"
+    partitionCount 5
+    userPartitionMethod holdout(5)
+    includeTimestamps false
+
+    doLast {
+        logger.info("creating runtime outputs")
+        def parser = new Yaml()
+        def cfFile = file("$outputDirectory/datasets.yaml")
+        def cfSpec = parser.load(cfFile.text)
+        for (int i = 0; i < 5; i++) {
+            def trainf = file("$outputDirectory/part0${i+1}.train.yaml")
+            def testf = file("$outputDirectory/part0${i+1}.test.yaml")
+            def trainY = parser.load(trainf.text)
+            def testY = parser.load(testf.text)
+            trainY << testY
+            def rtf = file("$outputDirectory/part0${i+1}.runtime.yaml")
+            rtf.text = parser.dump(trainY)
+
+            cfSpec.datasets[i].runtime = rtf.name
+        }
+        cfFile.text = parser.dump(cfSpec)
+    }
+}
+
+task trainTest(type: TrainTest) {
+    maxMemory '256m'
+    logFile "train-test.log"
+    logFileLevel 'DEBUG'
+    dataSet crossfold
+    outputFile 'results.csv'
+    algorithm 'Cheat', 'cheat.groovy'
+    predict {
+        outputFile 'predictions.csv.gz'
+        metric 'coverage'
+        metric 'rmse'
+    }
+}
+
+apply from: 'renjin.gradle'
+verifyR.dependsOn trainTest

--- a/lenskit-integration-tests/src/it/gradle/train-test-cheat-with-runtime/cheat.groovy
+++ b/lenskit-integration-tests/src/it/gradle/train-test-cheat-with-runtime/cheat.groovy
@@ -1,0 +1,10 @@
+import org.lenskit.api.ItemScorer
+import org.lenskit.api.RatingPredictor
+import org.lenskit.baseline.ItemMeanRatingItemScorer
+import org.lenskit.baseline.UserMeanBaseline
+import org.lenskit.baseline.UserMeanItemScorer
+import org.lenskit.predict.KnownRatingRatingPredictor
+import org.lenskit.predict.RatingPredictorItemScorer
+
+bind RatingPredictor to KnownRatingRatingPredictor
+bind ItemScorer to RatingPredictorItemScorer

--- a/lenskit-integration-tests/src/it/gradle/train-test-cheat-with-runtime/verify.R
+++ b/lenskit-integration-tests/src/it/gradle/train-test-cheat-with-runtime/verify.R
@@ -1,0 +1,7 @@
+library(assertthat)
+recs = read.csv(gzfile("predictions.csv.gz"))
+assert_that(are_equal(recs$Prediction, recs$Rating))
+
+count = aggregate(Item ~ User, recs, length)
+assert_that(nrow(count) > 0)
+assert_that(all(count$Item == 5))


### PR DESCRIPTION
This PR adds runtime data (#1001) to train-test, and removes the old `@QueryData` mechanism that was weird and no longer worked.