### PR TITLE
Add more evaluation control

### DIFF
--- a/lenskit-core/src/test/java/org/lenskit/util/parallel/BlockersTest.java
+++ b/lenskit-core/src/test/java/org/lenskit/util/parallel/BlockersTest.java
@@ -1,0 +1,76 @@
+/*
+ * LensKit, an open source recommender systems toolkit.
+ * Copyright 2010-2016 LensKit Contributors.  See CONTRIBUTORS.md.
+ * Work on LensKit has been funded by the National Science Foundation under
+ * grants IIS 05-34939, 08-08692, 08-12148, and 10-17697.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.lenskit.util.parallel;
+
+import com.google.common.util.concurrent.Monitor;
+import org.junit.Test;
+import org.lenskit.util.UncheckedInterruptException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class BlockersTest {
+    @Test
+    public void testAcquireMonitor() {
+        Monitor monitor = new Monitor();
+        ForkJoinPool.commonPool().invoke(new RecursiveAction() {
+            AtomicInteger running = new AtomicInteger();
+
+            @Override
+            protected void compute() {
+                List<RecursiveAction> actions = new ArrayList<>();
+                for (int i = 0; i < 6; i++) {
+                    actions.add(new RecursiveAction() {
+                        @Override
+                        protected void compute() {
+                            try {
+                                Blockers.enterMonitor(monitor);
+                                try {
+                                    assertThat(monitor.isOccupiedByCurrentThread(), equalTo(true));
+                                    int n = running.incrementAndGet();
+                                    assertThat(n, equalTo(1));
+                                    Thread.sleep(100);
+                                    running.decrementAndGet();
+                                } finally {
+                                    monitor.leave();
+                                }
+                            } catch (InterruptedException e) {
+                                throw new UncheckedInterruptException(e);
+                            }
+                        }
+                    });
+                }
+                invokeAll(actions);
+                for (RecursiveAction action: actions) {
+                    action.join();
+                }
+            }
+        });
+    }
+
+}

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TrainTestExperiment.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TrainTestExperiment.java
@@ -599,6 +599,7 @@ public class TrainTestExperiment {
         if (json.has("thread_count")) {
             exp.setThreadCount(json.get("thread_count").asInt(1));
         }
+        exp.setParallelTasks(json.path("parallel_tasks").asInt(0));
         if (json.has("share_model_components")) {
             exp.setShareModelComponents(json.get("share_model_components").asBoolean());
         }

--- a/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TrainTestExperiment.java
+++ b/lenskit-eval/src/main/java/org/lenskit/eval/traintest/TrainTestExperiment.java
@@ -32,12 +32,12 @@ import org.grouplens.grapht.Component;
 import org.grouplens.grapht.Dependency;
 import org.grouplens.grapht.graph.MergePool;
 import org.grouplens.grapht.util.ClassLoaders;
-import org.lenskit.util.io.CompressionMode;
-import org.lenskit.util.io.LKFileUtils;
 import org.lenskit.LenskitConfiguration;
 import org.lenskit.config.ConfigHelpers;
 import org.lenskit.eval.traintest.predict.PredictEvalTask;
 import org.lenskit.eval.traintest.recommend.RecommendEvalTask;
+import org.lenskit.util.io.CompressionMode;
+import org.lenskit.util.io.LKFileUtils;
 import org.lenskit.util.monitor.TrackedJob;
 import org.lenskit.util.parallel.TaskGroup;
 import org.lenskit.util.table.Table;
@@ -58,6 +58,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
 
 /**
  * Sets up and runs train-test evaluations.  This class can be used directly, but it will usually be controlled from
@@ -87,7 +88,8 @@ public class TrainTestExperiment {
     private Path userOutputFile;
     private Path cacheDir;
     private boolean shareModelComponents = true;
-    private int threadCount = 1;
+    private int threadCount = 0;
+    private int parallelTasks = 0;
     private ClassLoader classLoader = ClassLoaders.inferDefault(TrainTestExperiment.class);
 
     private List<AlgorithmInstance> algorithms = new ArrayList<>();
@@ -281,6 +283,27 @@ public class TrainTestExperiment {
     }
 
     /**
+     * Get the number of evaluation tasks to permit to run in parallel.  Reducing this can be useful for reducing
+     * the memory use of LensKit.
+     *
+     * @return The number of evaluation tasks to allow to run in parallel, or 0 if there is no limit.
+     */
+    public int getParallelTasks() {
+        return parallelTasks;
+    }
+
+    /**
+     * Set the number of parallel experiment tasks to run.  If 0 (the default), then up to {@link #getThreadCount()}
+     * jobs can run in parallel.  This can be reduced to reduce memory use (by having fewer models in memory); the
+     * extra threads may still be used to speed up individual evaluations.
+     *
+     * @param pt The number of tasks to run in parallel, or 0 to have no limit.
+     */
+    public void setParallelTasks(int pt) {
+        parallelTasks = pt;
+    }
+
+    /**
      * Get the class loader for this experiment.
      * @return The class loader that will be used.
      */
@@ -471,6 +494,10 @@ public class TrainTestExperiment {
             cache = new ComponentCache(cacheDir, classLoader);
         }
         Map<UUID,TaskGroup> groups = new HashMap<>();
+        Semaphore limit = null;
+        if (parallelTasks > 0) {
+            limit = new Semaphore(parallelTasks);
+        }
 
         // set up the roots
         LenskitConfiguration config = new LenskitConfiguration();
@@ -495,7 +522,7 @@ public class TrainTestExperiment {
             }
             for (AlgorithmInstance ai: getAlgorithms()) {
                 TrackedJob j = tracker.makeChild(ExperimentJob.JOB_TYPE, "evaluate " + ai + " on " + ds);
-                ExperimentJob job = new ExperimentJob(this, ai, ds, config, cache, pool, j);
+                ExperimentJob job = new ExperimentJob(this, ai, ds, config, cache, pool, j, limit);
                 allJobs.add(job);
                 group.addTask(job);
             }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/TrainTest.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/TrainTest.groovy
@@ -60,6 +60,11 @@ class TrainTest extends LenskitTask implements GradleUtils {
     def int threadCount
 
     /**
+     * Then number of parallel tasks to allow.
+     */
+    def int parallelTasks = 0
+
+    /**
      * Configure whether the evaluator should share model components between algorithms.
      */
     def boolean shareModelComponents = true
@@ -203,6 +208,7 @@ class TrainTest extends LenskitTask implements GradleUtils {
                     user_output_file      : makeUrl(getUserOutputFile(), getSpecFile()),
                     cache_directory       : makeUrl(getCacheDirectory(), getSpecFile()),
                     thread_count          : getThreadCount(),
+                    parallel_tasks        : getParallelTasks(),
                     share_model_components: getShareModelComponents()]
         json.datasets = dataSets.collect {it.call()}
         json.algorithms = algorithms.collectEntries {k, v ->


### PR DESCRIPTION
This allows us to restrict the number of simultaneous evaluation jobs independently from the thread count.

The default is to use all threads.

**Note for reviewer:** this also changes the actual default thread count to match the documented default of all available processors.

This works on #1016.