### PR TITLE
Make LenskitTask extend JavaExec

### DIFF
--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitExec.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/LenskitExec.groovy
@@ -20,6 +20,8 @@
  */
 package org.lenskit.gradle
 
+import org.gradle.api.tasks.JavaExec
+
 /**
  * Execute a LensKit command.
  */
@@ -27,7 +29,8 @@ class LenskitExec extends LenskitTask {
     def String command
     def List<String> commandArgs = []
 
-    void args(Object... args) {
+    JavaExec args(Object... args) {
         commandArgs.addAll(args.collect {it.toString()})
+        return this
     }
 }

--- a/lenskit-gradle/src/main/groovy/org/lenskit/gradle/TrainTest.groovy
+++ b/lenskit-gradle/src/main/groovy/org/lenskit/gradle/TrainTest.groovy
@@ -191,17 +191,6 @@ class TrainTest extends LenskitTask implements GradleUtils {
         evalTasks.add(task)
     }
 
-    @Override
-    @TaskAction
-    void perform() {
-        try {
-            super.perform()
-        } catch (Throwable th) {
-            logger.error('error running train-test task', th)
-            throw new RuntimeException('train-test failed', th)
-        }
-    }
-
     @Input
     def getJson() {
         def json = [output_file           : makeUrl(getOutputFile(), getSpecFile()),


### PR DESCRIPTION
This addresses #976, making all LensKit tasks extend `JavaExec`.